### PR TITLE
removing unused method - "capacity"

### DIFF
--- a/frontend/server/src/main/java/org/pytorch/serve/wlm/ModelVersionedRefs.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/wlm/ModelVersionedRefs.java
@@ -28,10 +28,6 @@ public final class ModelVersionedRefs {
         }
     }
 
-    private void checkVersionCapacity() {
-        // place holder only for now
-    }
-
     /**
      * Adds a new version of the Model to the Map if it does not exist Sets this version as the
      * default version of the model which is automatically served on the next request to this model.
@@ -50,7 +46,6 @@ public final class ModelVersionedRefs {
         }
 
         validateVersionId(versionId);
-        checkVersionCapacity();
 
         if (this.modelsVersionMap.putIfAbsent(Double.valueOf(versionId), model) != null) {
             throw new ConflictStatusException(


### PR DESCRIPTION
I created this method in the original patch (not in history here)
assuming versions would look different. Although this is a noop
just the presence of it indicates assumptions that are incorrect
in the current form of the versioning impl

Remove this.