### PR TITLE
fixed frontend python layer to use model store from config file if not provied in command-line args

### DIFF
--- a/ts/model_server.py
+++ b/ts/model_server.py
@@ -98,6 +98,9 @@ def start():
             if plugins:
                 class_path += ":" + plugins + "/*" if "*" not in plugins else ":" + plugins
 
+            if not args.model_store and props.get('model_store'):
+                args.model_store = props.get('model_store')
+
         cmd.append("-cp")
         cmd.append(class_path)
 


### PR DESCRIPTION
Added fix for #63 

if `--models` param was provided in args and `--model-store` parameter was skipped in the the args the torchserve python layer which invoked the Java frontend of model-server did not entertain the model-store parameter provided in 'ts_config_file' 