### PR TITLE
make sanity script robust

### DIFF
--- a/torchserve_sanity.sh
+++ b/torchserve_sanity.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euxo pipefail
 
 cleanup()
 {


### PR DESCRIPTION
The CI workflow depends on torchserve_sanity script
to catch all issues in CI env. We add more
instance types and runtime env to CI so we must add
more reliability to it. It's a simple bash script that
does the job for now, but it is a *simple* bash script
without any safeguards to handle exceptions etc.

add set -euxo pipefail to the front of this script

What I Tested:
-----------
run the script on EC2 instance.
pushing this will trigger it in CI env which is the true test.

Fixes and avoids any potential script issues.