### PR TITLE
removed pytest version from sanity script

### DIFF
--- a/torchserve_sanity.sh
+++ b/torchserve_sanity.sh
@@ -68,7 +68,7 @@ cleanup()
 }
 
 
-pip install mock pytest==3.6 pylint pytest-mock pytest-cov
+pip install mock pytest pylint pytest-mock pytest-cov
 
 cd frontend
 


### PR DESCRIPTION
## Description

Recent builds started failing for even doc related changes. On closer observation it was observed that the `torchserve_sanity.sh` script used in CI build was downgrading the pytest version to 3.6. Because of this the recently released version of pytest-mock [3.1.0] started throwing error due  incompatibility.

On removing the version dependency for pytest from `torchserve_sanity.sh` script the build suite is working correctly now.


[torchserve_sanity_logs.log](https://github.com/pytorch/serve/files/4503787/torchserve_sanity_logs.log)
