### PR TITLE
Fixes #205 - Docker install not finding GPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,17 @@ To create image for GPU device with specific branch use following command :
 
 **Running docker image and starting TorchServe inside container with pre-registered resnet-18 image classification model**
 
+For CPU run the following command:
 ```bash
 ./start.sh
+```
+For GPU run the following command:
+```bash
+./start.sh --gpu
+```
+For GPU with specific GPU device ids run the following command:
+```bash
+./start.sh --gpu_devices 1,2,3
 ```
 
 **For pre-trained and pre-packaged models-archives refer [TorchServe model zoo](docs/model_zoo.md)**

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -9,7 +9,7 @@ RUN apt-get update && \
     dpkg-dev \
     g++ \
     python3-dev \
-    openjdk-8-jdk-headless \
+    openjdk-11-jdk-headless \
     curl \
     vim \
     && rm -rf /var/lib/apt/lists/* \

--- a/start.sh
+++ b/start.sh
@@ -1,9 +1,34 @@
 #!/bin/bash
 IMAGE_NAME="torchserve:1.0"
 
+for arg in "$@"
+do
+    case $arg in
+        -h|--help)
+          echo "options:"
+          echo "-h, --help  show brief help"
+          echo "-g, --gpu specify to use gpu"
+          echo "-d, --gpu_devices to use specific gpu device ids"
+          exit 0
+          ;;
+        -g|--gpu)
+          DOCKER_RUNTIME="--runtime=nvidia"
+          shift
+          ;;
+	-d|--gpu_devices)
+          if test $
+          then
+	    GPU_DEVICES="-e NVIDIA_VISIBLE_DEVICES=$2"
+            shift
+          fi
+          shift
+          ;;
+    esac
+done
 echo "Starting torchserve:1.0 docker image"
 
-docker run -d --rm -it -p 8080:8080 -p 8081:8081 torchserve:1.0 > /dev/null 2>&1
+docker run $DOCKER_RUNTIME $GPU_DEVICES -d --rm -it -p 8080:8080 -p 8081:8081 torchserve:1.0 > /dev/null 2>&1
+
 container_id=$(docker ps --filter="ancestor=$IMAGE_NAME" -q | xargs)
 
 sleep 30


### PR DESCRIPTION
Fixes #205 - Docker install not finding GPUs

* Invokes docker with  --runtime=nvidia for GPU
* Added the option to specify the GPU / specific GPU ids in start.sh
* Fixed the documentation for start.sh script
* Fixed the JDK version in Dockerfile.gpu

Tests : 

Testing : This was tested on a DL AMI 27, Ubuntu 18 / p3.8xlarge (which has 4 CUDA-compatible GPUs). I built the Docker image with the --gpu directive.

Terminal Output for all 3 cases :


```
ubuntu@ip-172-31-32-255:~/serve$ ./start.sh
Starting torchserve:1.0 docker image
Successfully started torchserve in docker
Registering resnet-18 model
.....
ubuntu@ip-172-31-32-255:~/serve$ docker exec -it 4a162a13f695 head logs/ts_log.log
....
Temp directory: /home/model-server/tmp
Number of GPUs: 0
Number of CPUs: 32

ubuntu@ip-172-31-32-255:~/serve$ ./start.sh -g
Starting torchserve:1.0 docker image
Successfully started torchserve in docker
Registering resnet-18 model
....
ubuntu@ip-172-31-32-255:~/serve$ docker exec -it 281fc5744248 head logs/ts_log.log
....
Temp directory: /home/model-server/tmp
Number of GPUs: 4
Number of CPUs: 32

ubuntu@ip-172-31-32-255:~/serve$ ./start.sh --gpu --gpu_devices 1,2,3
Registering resnet-18 model
successfully registered resnet-18 model with torchserve
...

ubuntu@ip-172-31-32-255:~/serve$ docker exec -it e05ff19681f9 head logs/ts_log.log
...
Number of GPUs: 3
Number of CPUs: 32
...
```