### PR TITLE
conda: Add initial conda building scripts

### DIFF
--- a/conda/.gitignore
+++ b/conda/.gitignore
@@ -1,0 +1,2 @@
+output/
+*.whl

--- a/conda/README.md
+++ b/conda/README.md
@@ -1,0 +1,11 @@
+# Building conda packages
+
+To build conda packages you must first produce wheels for the project, see root README.md for information.
+
+After producing wheels use the following command to build conda packages:
+
+```
+TORCHSERVE_WHEEL=/path/to/torchserve.whl TORCH_MODEL_ARCHIVER_WHEEL=/path/to/torch_model_archiver_wheel ./build_packages.sh
+```
+
+Produced conda packages are then stored in the `output` directory

--- a/conda/build_packages.sh
+++ b/conda/build_packages.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+PYTHON_VERSIONS="3.6 3.7 3.8"
+PKGS="torchserve torch_model_archiver"
+
+for pkg in ${PKGS}; do
+    for python_version in ${PYTHON_VERSIONS}; do
+        (
+            set -x
+            conda build --output-folder output/ --python="${python_version}" "${pkg}"
+        )
+    done
+done

--- a/conda/torch_model_archiver/build.sh
+++ b/conda/torch_model_archiver/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+pip install --no-deps "${TORCH_MODEL_ARCHIVER_WHEEL}"

--- a/conda/torch_model_archiver/meta.yaml
+++ b/conda/torch_model_archiver/meta.yaml
@@ -1,0 +1,23 @@
+package:
+  name: torch_model_archiver
+  version: 0.0.1b20200409
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - pillow
+    - psutil
+    - future
+
+build:
+  noarch: generic
+  script_env:
+    - TORCH_MODEL_ARCHIVER_WHEEL
+
+about:
+  home: https://github.com/pytorch/serve
+  summary: 'Model serving on PyTorch'

--- a/conda/torchserve/build.sh
+++ b/conda/torchserve/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+pip install --no-deps "${TORCHSERVE_WHEEL}"

--- a/conda/torchserve/meta.yaml
+++ b/conda/torchserve/meta.yaml
@@ -1,0 +1,23 @@
+package:
+  name: torchserve
+  version: 0.0.1b20200409
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - pillow
+    - psutil
+    - future
+
+build:
+  noarch: generic
+  script_env:
+    - TORCHSERVE_WHEEL
+
+about:
+  home: https://github.com/pytorch/serve
+  summary: 'Model serving on PyTorch'


### PR DESCRIPTION
Creates conda packages for all versions of python we intend to support

# Building conda packages

To build conda packages you must first produce wheels for the project, see root README.md for information.

After producing wheels use the following command to build conda packages:

```
TORCHSERVE_WHEEL=/path/to/torchserve.whl TORCH_MODEL_ARCHIVER_WHEEL=/path/to/torch_model_archiver_wheel ./build_packages.sh
```

Produced conda packages are then stored in the `output` directory