### PR TITLE
Fixes #205 - Docker install not finding GPUs

### DIFF
--- a/PyPiDescription.rst
+++ b/PyPiDescription.rst
@@ -1,50 +1,16 @@
 Project Description
 ===================
 
-TorchServe (PyTorch mdoel server) is a flexible and easy to use tool for
+TorchServe (PyTorch model server) is a flexible and easy to use tool for
 serving deep learning models exported from `PyTorch <http://pytorch.org/>`__.
 
 Use the TorchServe CLI, or the pre-configured Docker images, to start a
 service that sets up HTTP endpoints to handle model inference requests.
 
-Prerequisites
--------------
-
-* **java 8**: Required. TorchServe use java to serve HTTP requests. You must install java 8 (or later) and make sure java is on available in $PATH environment variable *before* installing torchserve. If you have multiple java installed, you can use $JAVA_HOME environment vairable to control which java to use.
-* **PyTorch**: Required. Latest version of PyTorch will be installed as a part of TorchServe installation.
-
-For ubuntu:
-::
-
-    sudo apt-get install openjdk-8-jdk
-
-
-For centos
-::
-
-    sudo yum install java-1.8.0-openjdk
-
-
-For Mac:
-::
-
-    brew tap caskroom/versions
-    brew update
-    brew cask install java8
-
-
-Install PyTorch:
-::
-
-    pip install torch torchvision torchtext
-
-
 Installation
 ------------
 
-::
-
-    pip install torchserve
+Full installation instructions are in the project repo: https://github.com/pytorch/serve/blob/master/README.md
 
 
 Source code

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Conda instructions are provided in more detail, but you may also use `pip` and `
 To use `pip` to install TorchServe and the model archiver:
 
 ```
+pip install torch torchtext torchvision sentencepiece
 pip install torchserve torch-model-archiver
 ```
 
@@ -32,8 +33,13 @@ _Ubuntu_
     ```
 1. Install Conda (https://docs.conda.io/projects/conda/en/latest/user-guide/install/linux.html)
 1. Create an environment and install torchserve and torch-model-archiver
+    For CPU
     ```bash
-    conda create --name torchserve torchserve torch-model-archiver -c pytorch
+    conda create --name torchserve torchserve torch-model-archiver pytorch torchtext torchvision -c pytorch -c powerai
+    ```
+    For GPU
+    ```bash
+    conda create --name torchserve torchserve torch-model-archiver pytorch torchtext torchvision cudatoolkit=10.1 -c pytorch -c powerai
     ```
 1. Activate the environment
     ```bash
@@ -51,6 +57,12 @@ _macOS_
 1. Create an environment and install torchserve and torch-model-archiver
     ```bash
     conda create --name torchserve torchserve torch-model-archiver -c pytorch
+    conda install -c pytorch -c powerai pytorch torchtext torchvision
+    ```
+    For GPU
+    ```bash
+    conda create --name torchserve torchserve torch-model-archiver -c pytorch
+    conda install -c pytorch -c powerai pytorch torchtext torchvision cudatoolkit=10.1
     ```
 1. Activate the environment
     ```bash

--- a/README.md
+++ b/README.md
@@ -53,15 +53,10 @@ _macOS_
     brew tap AdoptOpenJDK/openjdk
     brew cask install adoptopenjdk11
     ```
-1. Install Conda (https://docs.conda.io/projects/conda/en/latest/user-guide/install/linux.html)
+1. Install Conda (https://docs.conda.io/projects/conda/en/latest/user-guide/install/macos.html)
 1. Create an environment and install torchserve and torch-model-archiver
-    For CPU
     ```bash
     conda create --name torchserve torchserve torch-model-archiver pytorch torchtext torchvision -c pytorch -c powerai
-    ```
-    For GPU
-    ```bash
-    conda create --name torchserve torchserve torch-model-archiver pytorch torchtext torchvision cudatoolkit=10.1 -c pytorch -c powerai
     ```
 1. Activate the environment
     ```bash

--- a/README.md
+++ b/README.md
@@ -55,14 +55,13 @@ _macOS_
     ```
 1. Install Conda (https://docs.conda.io/projects/conda/en/latest/user-guide/install/linux.html)
 1. Create an environment and install torchserve and torch-model-archiver
+    For CPU
     ```bash
-    conda create --name torchserve torchserve torch-model-archiver -c pytorch
-    conda install -c pytorch -c powerai pytorch torchtext torchvision
+    conda create --name torchserve torchserve torch-model-archiver pytorch torchtext torchvision -c pytorch -c powerai
     ```
     For GPU
     ```bash
-    conda create --name torchserve torchserve torch-model-archiver -c pytorch
-    conda install -c pytorch -c powerai pytorch torchtext torchvision cudatoolkit=10.1
+    conda create --name torchserve torchserve torch-model-archiver pytorch torchtext torchvision cudatoolkit=10.1 -c pytorch -c powerai
     ```
 1. Activate the environment
     ```bash

--- a/README.md
+++ b/README.md
@@ -84,8 +84,17 @@ pip install -e .
 
 * To upgrade TorchServe or model archiver from source code and make changes executable, run:
 
+For CPU run the following command:
 ```bash
 pip install -U -e .
+```
+For GPU run the following command:
+```bash
+./start.sh --gpu
+```
+For GPU with specific GPU device ids run the following command:
+```bash
+./start.sh --gpu_devices 1,2,3
 ```
 
 For information about the model archiver, see [detailed documentation](model-archiver/README.md).

--- a/README.md
+++ b/README.md
@@ -88,14 +88,6 @@ For CPU run the following command:
 ```bash
 pip install -U -e .
 ```
-For GPU run the following command:
-```bash
-./start.sh --gpu
-```
-For GPU with specific GPU device ids run the following command:
-```bash
-./start.sh --gpu_devices 1,2,3
-```
 
 For information about the model archiver, see [detailed documentation](model-archiver/README.md).
 
@@ -251,6 +243,14 @@ To run your TorchServe Docker image and start TorchServe inside the container wi
 
 ```bash
 ./start.sh
+```
+For GPU run the following command:
+```bash
+./start.sh --gpu
+```
+For GPU with specific GPU device ids run the following command:
+```bash
+./start.sh --gpu_devices 1,2,3
 ```
 
 ## Learn More

--- a/build_image.sh
+++ b/build_image.sh
@@ -2,6 +2,7 @@
 
 MACHINE=cpu
 BRANCH_NAME="master"
+DOCKER_TAG="pytorch/torchserve:latest"
 
 for arg in "$@"
 do
@@ -26,6 +27,7 @@ do
           ;;
         -g|--gpu)
           MACHINE=gpu
+          DOCKER_TAG="pytorch/torchserve:latest-gpu"
           shift
           ;;
     esac
@@ -37,4 +39,4 @@ git clone https://github.com/pytorch/serve.git
 cd serve
 git checkout $BRANCH_NAME
 cd ..
-docker build --file Dockerfile.$MACHINE -t torchserve:1.0 .
+docker build --file Dockerfile.$MACHINE -t $DOCKER_TAG .

--- a/conda/.gitignore
+++ b/conda/.gitignore
@@ -1,0 +1,2 @@
+output/
+*.whl

--- a/conda/README.md
+++ b/conda/README.md
@@ -1,0 +1,11 @@
+# Building conda packages
+
+To build conda packages you must first produce wheels for the project, see root README.md for information.
+
+After producing wheels use the following command to build conda packages:
+
+```
+TORCHSERVE_WHEEL=/path/to/torchserve.whl TORCH_MODEL_ARCHIVER_WHEEL=/path/to/torch_model_archiver_wheel ./build_packages.sh
+```
+
+Produced conda packages are then stored in the `output` directory

--- a/conda/build_packages.sh
+++ b/conda/build_packages.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+PYTHON_VERSIONS="3.6 3.7 3.8"
+PKGS="torchserve torch-model-archiver"
+
+for pkg in ${PKGS}; do
+    for python_version in ${PYTHON_VERSIONS}; do
+        (
+            set -x
+            conda build --output-folder output/ --python="${python_version}" "${pkg}"
+        )
+    done
+done

--- a/conda/torch-model-archiver/build.sh
+++ b/conda/torch-model-archiver/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+pip install --no-deps "${TORCH_MODEL_ARCHIVER_WHEEL}"

--- a/conda/torch-model-archiver/meta.yaml
+++ b/conda/torch-model-archiver/meta.yaml
@@ -1,0 +1,23 @@
+package:
+  name: torch-model-archiver
+  version: 0.0.1b20200409
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - pillow
+    - psutil
+    - future
+
+build:
+  noarch: generic
+  script_env:
+    - TORCH_MODEL_ARCHIVER_WHEEL
+
+about:
+  home: https://github.com/pytorch/serve
+  summary: 'Model serving on PyTorch'

--- a/conda/torchserve/build.sh
+++ b/conda/torchserve/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+pip install --no-deps "${TORCHSERVE_WHEEL}"

--- a/conda/torchserve/meta.yaml
+++ b/conda/torchserve/meta.yaml
@@ -1,0 +1,23 @@
+package:
+  name: torchserve
+  version: 0.0.1b20200409
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - pillow
+    - psutil
+    - future
+
+build:
+  noarch: generic
+  script_env:
+    - TORCHSERVE_WHEEL
+
+about:
+  home: https://github.com/pytorch/serve
+  summary: 'Model serving on PyTorch'

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -9,7 +9,7 @@ RUN apt-get update && \
     dpkg-dev \
     g++ \
     python3-dev \
-    openjdk-8-jdk-headless \
+    openjdk-11-jdk-headless \
     curl \
     vim \
     && rm -rf /var/lib/apt/lists/* \

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,4 +1,4 @@
-#### Create TorchServe docker image
+# Create TorchServe docker image
 
 ```bash
 cd serve/docker
@@ -15,20 +15,29 @@ For creating GPU based image :
 docker build --file Dockerfile.gpu -t torchserve:1.0 .
 ```
 
-#### Start container with TorchServe image
+## Start a container with a TorchServe image
 
-For CPU based image :
+### Start CPU container
 
+For specific versions you can pass in the specific tag to use (ex: 0.1-cpu):
 ```bash
-docker run --rm -it -p 8080:8080 -p 8081:8081 torchserve:1.0
-```
-For GPU based image :
-
-```bash
-docker run --rm -it --gpus --gpus '"device=1,2"' -p 8080:8080 -p 8081:8081 torchserve:1.0
+docker run --rm -it -p 8080:8080 -p 8081:8081 pytorch/torchserve:0.1-cpu
 ```
 
-The above command will start the container with 8080/81 port exposed to outer-world/localhost
+For the latest version, you can use the `latest` tag:
+docker run --rm -it -p 8080:8080 -p 8081:8081 pytorch/torchserve:latest
+
+#### Start GPU container
+
+For specific versions you can pass in the specific tag to use (ex: 0.1-cpu):
+```bash
+docker run --rm -it --gpus all -p 8080:8080 -p 8081:8081 pytorch/torchserve:0.1-cuda10.1-cudnn7-runtime
+```
+
+For the latest version, you can use the `gpu-latest` tag:
+```bash
+docker run --rm -it --gpus all -p 8080:8080 -p 8081:8081 pytorch/torchserve:latest-gpu
+```
 
 #### Accessing TorchServe APIs inside container
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,12 +7,12 @@ git clone https://github.com/pytorch/serve.git
 
 For creating CPU based image :
 ```bash
-docker build --file Dockerfile.cpu -t torchserve:1.0 .
+docker build --file Dockerfile.cpu -t torchserve:latest .
 ```
 
 For creating GPU based image :
 ```bash
-docker build --file Dockerfile.gpu -t torchserve:1.0 .
+docker build --file Dockerfile.gpu -t torchserve:latest .
 ```
 
 ## Start a container with a TorchServe image

--- a/docker/README.md
+++ b/docker/README.md
@@ -17,8 +17,15 @@ docker build --file Dockerfile.gpu -t torchserve:1.0 .
 
 #### Start container with TorchServe image
 
+For CPU based image :
+
 ```bash
 docker run --rm -it -p 8080:8080 -p 8081:8081 torchserve:1.0
+```
+For GPU based image :
+
+```bash
+docker run --rm -it --gpus --gpus '"device=1,2"' -p 8080:8080 -p 8081:8081 torchserve:1.0
 ```
 
 The above command will start the container with 8080/81 port exposed to outer-world/localhost

--- a/model-archiver/PyPiDescription.rst
+++ b/model-archiver/PyPiDescription.rst
@@ -19,23 +19,6 @@ Installation
 
     pip install torch-model-archiver
 
-Development
------------
-
-We welcome new contributors of all experience levels. For information on
-how to install MMS for development, refer to the `TS
-docs <https://github.com/pytorch/serve/blob/master/docs/install.md>`__.
-
-Important links
----------------
-
--  `Official source code
-   repo <https://github.com/pytorch/serve>`__
--  `Download
-   releases <https://pypi.org/project/torchserve/#files>`__
--  `Issue
-   tracker <https://github.com/pytorch/serve/issues>`__
-
 Source code
 -----------
 
@@ -45,23 +28,9 @@ You can check the latest source code as follows:
 
     git clone https://github.com/pytorch/serve.git
 
-Testing
--------
-
-After installation, try out the MMS Quickstart for `Create a
-model archive <https://github.com/pytorch/serve/blob/serve/README.md#model-archive>`__
-and `Serving a
-Model <https://github.com/pytorch/serve/blob/serve/model-archiver/README.md#serve-a-model>`__.
-
-
-Help and Support
-----------------
-
--  `Documentation <https://github.com/pytorch/serve/blob/serve/docs/README.md>`__
--  `Forum <https://discuss.mxnet.io/latest>`__
 
 Citation
 --------
 
-If you use MMS in a publication or project, please cite MMS:
-https://github.com/awslabs/mxnet-model-server
+If you use torchserve in a publication or project, please cite torchserve:
+https://github.com/pytorch/serve

--- a/model-archiver/PyPiDescription.rst
+++ b/model-archiver/PyPiDescription.rst
@@ -6,7 +6,7 @@ Torch Model Archiver is a tool used for creating archives of trained neural net 
 Use the Torch Model Archiver CLI to start create a ``.mar`` file.
 
 Torch Model Archiver is part of `TS <https://pypi.org/project/torchserve/>`__.
-However,you can install Torch Model Archiver stand alone.
+However, you can install Torch Model Archiver stand alone.
 
 Detailed documentation and examples are provided in the `README
 <https://github.com/pytorch/serve/model-archiver/README.md>`__.

--- a/start.sh
+++ b/start.sh
@@ -19,6 +19,8 @@ do
 	-d|--gpu_devices)
           if test $
           then
+	    DOCKER_RUNTIME="--runtime=nvidia"
+            IMAGE_NAME="pytorch/torchserve:latest-gpu"
 	    GPU_DEVICES="-e NVIDIA_VISIBLE_DEVICES=$2"
             shift
           fi

--- a/start.sh
+++ b/start.sh
@@ -19,15 +19,16 @@ do
 	-d|--gpu_devices)
           if test $
           then
-            DOCKER_RUNTIME="--runtime=nvidia"
+	    DOCKER_RUNTIME="--runtime=nvidia"
             IMAGE_NAME="pytorch/torchserve:latest-gpu"
-            GPU_DEVICES="-e NVIDIA_VISIBLE_DEVICES=$2"
+	    GPU_DEVICES="-e NVIDIA_VISIBLE_DEVICES=$2"
             shift
           fi
           shift
           ;;
     esac
 done
+
 echo "Starting $IMAGE_NAME docker image"
 
 docker run $DOCKER_RUNTIME $GPU_DEVICES -d --rm -it -p 8080:8080 -p 8081:8081 $IMAGE_NAME > /dev/null 2>&1

--- a/start.sh
+++ b/start.sh
@@ -19,9 +19,9 @@ do
 	-d|--gpu_devices)
           if test $
           then
-	    DOCKER_RUNTIME="--runtime=nvidia"
+            DOCKER_RUNTIME="--runtime=nvidia"
             IMAGE_NAME="pytorch/torchserve:latest-gpu"
-	    GPU_DEVICES="-e NVIDIA_VISIBLE_DEVICES=$2"
+            GPU_DEVICES="-e NVIDIA_VISIBLE_DEVICES=$2"
             shift
           fi
           shift

--- a/start.sh
+++ b/start.sh
@@ -1,9 +1,35 @@
 #!/bin/bash
-IMAGE_NAME="torchserve:1.0"
+IMAGE_NAME="pytorch/torchserve:latest"
 
-echo "Starting torchserve:1.0 docker image"
+for arg in "$@"
+do
+    case $arg in
+        -h|--help)
+          echo "options:"
+          echo "-h, --help  show brief help"
+          echo "-g, --gpu specify to use gpu"
+          echo "-d, --gpu_devices to use specific gpu device ids"
+          exit 0
+          ;;
+        -g|--gpu)
+          DOCKER_RUNTIME="--runtime=nvidia"
+          IMAGE_NAME="pytorch/torchserve:latest-gpu"
+          shift
+          ;;
+	-d|--gpu_devices)
+          if test $
+          then
+	    GPU_DEVICES="-e NVIDIA_VISIBLE_DEVICES=$2"
+            shift
+          fi
+          shift
+          ;;
+    esac
+done
+echo "Starting $IMAGE_NAME docker image"
 
-docker run -d --rm -it -p 8080:8080 -p 8081:8081 torchserve:1.0 > /dev/null 2>&1
+docker run $DOCKER_RUNTIME $GPU_DEVICES -d --rm -it -p 8080:8080 -p 8081:8081 $IMAGE_NAME > /dev/null 2>&1
+
 container_id=$(docker ps --filter="ancestor=$IMAGE_NAME" -q | xargs)
 
 sleep 30


### PR DESCRIPTION
Fixes #205 - Docker install not finding GPUs

* Invokes docker with  --runtime=nvidia for GPU
* Added the option to specify the GPU / specific GPU ids in start.sh
* Fixed the documentation for start.sh script
* Fixed the JDK version in Dockerfile.gpu

Tests : 

Testing : This was tested on a DL AMI 27, Ubuntu 18 / p3.8xlarge (which has 4 CUDA-compatible GPUs). I built the Docker image with the --gpu directive.

Terminal Output for all 3 cases :


```
ubuntu@ip-172-31-32-255:~/serve$ ./start.sh
Starting pytorch/torchserve:latest-gpu docker image
Successfully started torchserve in docker
Registering resnet-18 model
.....
ubuntu@ip-172-31-32-255:~/serve$ docker exec -it 4a162a13f695 head logs/ts_log.log
....
Temp directory: /home/model-server/tmp
Number of GPUs: 0
Number of CPUs: 32

ubuntu@ip-172-31-32-255:~/serve$ ./start.sh -g
Starting pytorch/torchserve:latest-gpu docker image
Successfully started torchserve in docker
Registering resnet-18 model
....
ubuntu@ip-172-31-32-255:~/serve$ docker exec -it 281fc5744248 head logs/ts_log.log
....
Temp directory: /home/model-server/tmp
Number of GPUs: 4
Number of CPUs: 32

ubuntu@ip-172-31-32-255:~/serve$ ./start.sh --gpu --gpu_devices 1,2,3
Starting pytorch/torchserve:latest-gpu docker image
Successfully started torchserve in docker
Registering resnet-18 model
successfully registered resnet-18 model with torchserve
...

ubuntu@ip-172-31-32-255:~/serve$ docker exec -it e05ff19681f9 head logs/ts_log.log
...
Number of GPUs: 3
Number of CPUs: 32
...
```