### PR TITLE
Fixed type on --model-store location parameter on model serving instr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ For more information about the model archiver, see [Torch Model archiver for Tor
 After you archive and store the model, use the `torchserve` command to serve the model.
 
 ```bash
-torchserve --start --model-store model_store --models ~/model_store/densenet161=densenet161.mar
+torchserve --start --model-store ~/model_store --models ~/model_store/densenet161=densenet161.mar
 ```
 
 After you execute the `torchserve` command above, TorchServe runs on your host, listening for inference requests.


### PR DESCRIPTION
## Description

There is a small bug on the "serve a model" section of the README -- the --model-store parameter has an incorrect setting. The --model-store should point to a user-relative directory to be consistent with instructions from earlier in the same README documentation.
