### PR TITLE
fixed resnet152 custom handler to work with GPU

### DIFF
--- a/examples/image_classifier/resnet_152_batch/resnet152_handler.py
+++ b/examples/image_classifier/resnet_152_batch/resnet152_handler.py
@@ -46,11 +46,11 @@ class BatchImageClassifier(object):
             if not os.path.isfile(model_def_path):
                 raise RuntimeError("Missing the model.py file")
 
-            state_dict = torch.load(model_pt_path, map_location=self.device)
+            state_dict = torch.load(model_pt_path)
             from model import ResNet152ImageClassifier
             self.model = ResNet152ImageClassifier()
             self.model.load_state_dict(state_dict)
-
+        self.model.to(self.device)
         self.model.eval()
         logger.debug('Model file {0} loaded successfully'.format(model_pt_path))
 
@@ -87,7 +87,7 @@ class BatchImageClassifier(object):
             ])
             input_image = Image.open(io.BytesIO(image))
             input_image = my_preprocess(input_image).unsqueeze(0)
-
+            input_image = Variable(input_image).to(self.device)
             if input_image.shape is not None:
                 if image_tensor is None:
                     image_tensor = input_image


### PR DESCRIPTION
## Description

The custom handler did not load the model on GPU. Even though the device is properly initialized with the gpu id, the model will always be loaded in the default device i.e., CPU.

Fixes #(153)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Feature/Issue validation/testing

nvidia-smi output after registering the resnet152 model with 3 workers.

(torchserve38) ubuntu@ip-172-31-64-54:~$ nvidia-smi
Thu Apr 23 15:00:19 2020       
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 440.82       Driver Version: 440.82       CUDA Version: 10.2     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|===============================+======================+======================|
|   0  Tesla V100-SXM2...  Off  | 00000000:00:1B.0 Off |                    0 |
| N/A   43C    P0    38W / 300W |     11MiB / 16160MiB |      0%      Default |
+-------------------------------+----------------------+----------------------+
|   1  Tesla V100-SXM2...  Off  | 00000000:00:1C.0 Off |                    0 |
| N/A   46C    P0    54W / 300W |   1194MiB / 16160MiB |      0%      Default |
+-------------------------------+----------------------+----------------------+
|   2  Tesla V100-SXM2...  Off  | 00000000:00:1D.0 Off |                    0 |
| N/A   43C    P0    56W / 300W |   1194MiB / 16160MiB |      0%      Default |
+-------------------------------+----------------------+----------------------+
|   3  Tesla V100-SXM2...  Off  | 00000000:00:1E.0 Off |                    0 |
| N/A   44C    P0    62W / 300W |   1194MiB / 16160MiB |      0%      Default |
+-------------------------------+----------------------+----------------------+
                                                                               
+-----------------------------------------------------------------------------+
| Processes:                                                       GPU Memory |
|  GPU       PID   Type   Process name                             Usage      |
|=============================================================================|
|    1      2808      C   .../anaconda3/envs/torchserve38/bin/python  1183MiB |
|    2      2807      C   .../anaconda3/envs/torchserve38/bin/python  1183MiB |
|    3      2809      C   .../anaconda3/envs/torchserve38/bin/python  1183MiB |
+-----------------------------------------------------------------------------+

## Checklist:

- [x] Test the updated example on both CPU and GPU
