### PR TITLE
[WIP]made default batch_size and max_batch_delay configurable through config.properties

### DIFF
--- a/frontend/server/src/main/java/org/pytorch/serve/ModelServer.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/ModelServer.java
@@ -213,8 +213,8 @@ public class ModelServer {
                                 modelName,
                                 null,
                                 null,
-                                1,
-                                100,
+                                configManager.getDefaultBatchSize(),
+                                configManager.getDefaultBatchDelay(),
                                 configManager.getDefaultResponseTimeout(),
                                 defaultModelName);
                 modelManager.updateModel(

--- a/frontend/server/src/main/java/org/pytorch/serve/http/messages/RegisterModelRequest.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/http/messages/RegisterModelRequest.java
@@ -38,8 +38,14 @@ public class RegisterModelRequest {
         modelName = NettyUtils.getParameter(decoder, "model_name", null);
         runtime = NettyUtils.getParameter(decoder, "runtime", null);
         handler = NettyUtils.getParameter(decoder, "handler", null);
-        batchSize = NettyUtils.getIntParameter(decoder, "batch_size", 1);
-        maxBatchDelay = NettyUtils.getIntParameter(decoder, "max_batch_delay", 100);
+        batchSize =
+                NettyUtils.getIntParameter(
+                        decoder, "batch_size", ConfigManager.getInstance().getDefaultBatchSize());
+        maxBatchDelay =
+                NettyUtils.getIntParameter(
+                        decoder,
+                        "max_batch_delay",
+                        ConfigManager.getInstance().getDefaultBatchDelay());
         initialWorkers =
                 NettyUtils.getIntParameter(
                         decoder,
@@ -51,8 +57,8 @@ public class RegisterModelRequest {
     }
 
     public RegisterModelRequest() {
-        batchSize = 1;
-        maxBatchDelay = 100;
+        batchSize = ConfigManager.getInstance().getDefaultBatchSize();
+        maxBatchDelay = ConfigManager.getInstance().getDefaultBatchDelay();
         synchronous = true;
         initialWorkers = ConfigManager.getInstance().getConfiguredDefaultWorkersPerModel();
         responseTimeout = -1;

--- a/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
@@ -77,6 +77,8 @@ public final class ConfigManager {
     private static final String TS_MODEL_STORE = "model_store";
     private static final String TS_SNAPSHOT_STORE = "snapshot_store";
     private static final String TS_MODEL_SNAPSHOT = "model_snapshot";
+    private static final String TS_BATCH_SIZE = "batch_size";
+    private static final String TS_MAX_BATCH_DELAY = "max_batch_delay";
 
     // Configuration which are not documented or enabled through environment variables
     private static final String USE_NATIVE_IO = "use_native_io";
@@ -542,6 +544,14 @@ public final class ConfigManager {
             return def;
         }
         return Integer.parseInt(value);
+    }
+
+    public int getDefaultBatchSize() {
+        return Integer.parseInt(prop.getProperty(TS_BATCH_SIZE, "1"));
+    }
+
+    public int getDefaultBatchDelay() {
+        return Integer.parseInt(prop.getProperty(TS_MAX_BATCH_DELAY, "100"));
     }
 
     public int getDefaultResponseTimeout() {


### PR DESCRIPTION
## Description

This PR makes the default values batch_size and max_batch_delay parameters, used for batch inferencing, configurable through config.properties

Fixes #64

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Feature/Issue validation/testing

TBD

## Checklist:

- [x] New and existing unit tests pass locally with these changes?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?