### PR TITLE
remove minus y in pip install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ If you plan to develop with TorchServe and change some of the source code, you m
 1. Install dependencies
 
     ```bash
-    pip install psutil future -y
+    pip install psutil future
     ```
 
 1. Clone the repo
@@ -304,6 +304,6 @@ To run your TorchServe Docker image and start TorchServe inside the container wi
 
 We welcome all contributions!
 
-To learn more about how to contribute, see the contributor guide [here](https://github.com/pytorch/serve/blob/master/CONTRIBUTING.md). 
+To learn more about how to contribute, see the contributor guide [here](https://github.com/pytorch/serve/blob/master/CONTRIBUTING.md).
 
 To file a bug or request a feature, please file a GitHub issue. For filing pull requests, please use the template [here](https://github.com/pytorch/serve/blob/master/pull_request_template.md). Cheers!


### PR DESCRIPTION
## Description
Minor fix that removes a flag that doesn't work with pip.

However, I don't see why this is different from the regular installation steps that include many more dependencies. This fixes the current problem, but I still think this line should be reviewed.

Might be better to sync with:

```
pip install psutil future pytorch torchtext torchvision
```

Fixes #(issue)
Fixes #310 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the tests [UT/IT] that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced. 
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- UT/IT execution results

- Logs

## Checklist:

- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] New and existing unit tests pass locally with these changes?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
