### PR TITLE
fixed command for install from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ If you plan to develop with TorchServe and change some of the source code, you m
     cd serve
     ```
 
-1. Make your changes executable
+1. Install from source
 
     ```bash
     pip install .
@@ -152,7 +152,7 @@ cd serve/model-archiver
 pip install .
 ```
 
-* To upgrade TorchServe or model archiver from source code and make changes executable, run:
+* To upgrade TorchServe or model archiver from source code, run:
 
 ```bash
 pip install -U .

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ Conda instructions are provided in more detail, but you may also use `pip` and `
     For CPU
 
     ```bash
-    conda create --name torchserve torchserve torch-model-archiver psutil future pytorch torchtext torchvision -c pytorch -c powerai
+    conda create --name torchserve torchserve torch-model-archiver psutil future pytorch torchtext torchvision -c pytorch
     ```
 
     For GPU
 
     ```bash
-    conda create --name torchserve torchserve torch-model-archiver psutil future pytorch torchtext torchvision cudatoolkit=10.1 -c pytorch -c powerai
+    conda create --name torchserve torchserve torch-model-archiver psutil future pytorch torchtext torchvision cudatoolkit=10.1 -c pytorch
     ```
 
 1. Activate the environment
@@ -80,7 +80,7 @@ Conda instructions are provided in more detail, but you may also use `pip` and `
 1. Create an environment and install torchserve and torch-model-archiver
 
     ```bash
-    conda create --name torchserve torchserve torch-model-archiver psutil future pytorch torchtext torchvision -c pytorch -c powerai
+    conda create --name torchserve torchserve torch-model-archiver psutil future pytorch torchtext torchvision -c pytorch
     ```
 
 1. Activate the environment

--- a/README.md
+++ b/README.md
@@ -108,8 +108,23 @@ If you plan to develop with TorchServe and change some of the source code, you m
 
 1. Install dependencies
 
+* To install in Python virtual environment
+
     ```bash
-    pip install psutil future
+    pip install torch torchtext torchvision sentencepiece psutil future
+    ```
+
+* To install in Conda virtual environment
+    For CPU
+
+    ```bash
+    conda install psutil future pytorch torchtext torchvision -c pytorch -c powerai
+    ```
+
+    For GPU
+
+    ```bash
+    conda install psutil future pytorch torchtext torchvision cudatoolkit=10.1 -c pytorch -c powerai
     ```
 
 1. Clone the repo

--- a/README.md
+++ b/README.md
@@ -118,13 +118,18 @@ If you plan to develop with TorchServe and change some of the source code, you m
     For CPU
 
     ```bash
-    conda install psutil future pytorch torchtext torchvision -c pytorch -c powerai
+    conda install psutil future pytorch torchtext torchvision -c pytorch
     ```
 
     For GPU
 
     ```bash
-    conda install psutil future pytorch torchtext torchvision cudatoolkit=10.1 -c pytorch -c powerai
+    conda install psutil future pytorch torchtext torchvision cudatoolkit=10.1 -c pytorch
+    ```
+
+    Optional if using torchtext models
+    ```bash
+    pip install sentencepiece
     ```
 
 1. Clone the repo

--- a/README.md
+++ b/README.md
@@ -122,20 +122,20 @@ If you plan to develop with TorchServe and change some of the source code, you m
 1. Make your changes executable
 
     ```bash
-    pip install -e .
+    pip install .
     ```
 
 * To develop with torch-model-archiver:
 
 ```bash
 cd serve/model-archiver
-pip install -e .
+pip install .
 ```
 
 * To upgrade TorchServe or model archiver from source code and make changes executable, run:
 
 ```bash
-pip install -U -e .
+pip install -U .
 ```
 
 For information about the model archiver, see [detailed documentation](model-archiver/README.md).


### PR DESCRIPTION
## Description

This PR fixes the command for installing from source in README.

Fixes #312

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Feature/Issue validation/testing

Clone serve repo and run following command

`pip install .`

Upgrade using following command 

`pip install -U .`


Logs for successful installation and upgrade on p3.2xlarge instance using DL AMI
[build_from_source.log](https://github.com/pytorch/serve/files/4599788/build_from_source.log)

Logs for upgrading TorchServe multiple time from source
[upgrade_torchserve_from_source.log](https://github.com/pytorch/serve/files/4599790/upgrade_torchserve_from_source.log)


## Checklist:

- [x] Have you made corresponding changes to the documentation?
