### PR TITLE
embed dependencies in setup.py and fix version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ class BuildPlugins(Command):
 if __name__ == '__main__':
     version = detect_model_server_version()
 
-    requirements = ['Pillow', 'psutil', 'future']
+    requirements = ['Pillow', 'psutil', 'future', 'torch', 'torchvision', 'torchtext']
 
     setup(
         name='torchserve',

--- a/ts/version.py
+++ b/ts/version.py
@@ -3,4 +3,4 @@
 This is the current version of TorchServe
 """
 
-__version__ = '0.0.1'
+__version__ = '0.1.0'


### PR DESCRIPTION
## Description

It would be nice if you could just:
`pip install torchserve`
without having to first do a bunch of other installations....
Also, I found that if we put in torchtext we get sentencepiece so why call it out separately?

Seems like this would help simplify the installation docs - at least for pip.

I also fix the version number. 
Addresses part of #319.

How to test:
I tested this on DLAMI Ubuntu w/ Python 3.6 in a conda environment from the branch root:
```
conda create -n ts_pip_req
conda activate ts_pip_req
pip install .
```
It serves densenet and infers and prints the proper version now.

```
(ts_pip_req) ubuntu@ip-172-31-44-208:~/serve-1$ python
Python 3.6.6 |Anaconda, Inc.| (default, Oct  9 2018, 12:34:16) 
[GCC 7.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import ts
>>> ts.__version__
'0.1.0'
```

Fixes #(issue)
n/a
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

