### PR TITLE
Document the docker settings for running in production mode

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -184,7 +184,7 @@ You may want to consider the following aspects / docker options when deploying t
 * Exposing specific ports / volumes between the host & docker env.
 
     *  ```-p8080:p8080 -p8081:8081``` TorchServe uses default ports 8080 / 8081 for inference & management APIs. You may want to expose these ports to the host for HTTP Requests between Docker & Host.
-    * The model store is passed to torchserve with the --model-store option. You may want want to consider using a shared volume if you prefer pre populating models in model-store directory.
+    * The model store is passed to torchserve with the --model-store option. You may want to consider using a shared volume if you prefer pre populating models in model-store directory.
 
 For example,
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -178,7 +178,7 @@ You may want to consider about the following aspects / docker options when deplo
     * ```--ulimit memlock=-1``` : Maximum locked-in-memory address space. 
     * ```--ulimit stack``` : Linux stack size 
 
-    The current ulimit values can be viewed by executing ```ulimit -a```. A more exhaustive set of options for resource constraining can be found in the Docker Documentation [here](https://docs.docker.com/config/containers/resource_constraints/) [here](https://docs.docker.com/engine/reference/commandline/run/#set-ulimits-in-container---ulimit) and [here](https://docs.docker.com/engine/reference/run/#runtime-constraints-on-resources)
+    The current ulimit values can be viewed by executing ```ulimit -a```. A more exhaustive set of options for resource constraining can be found in the Docker Documentation [here](https://docs.docker.com/config/containers/resource_constraints/), [here](https://docs.docker.com/engine/reference/commandline/run/#set-ulimits-in-container---ulimit) and [here](https://docs.docker.com/engine/reference/run/#runtime-constraints-on-resources)
 
 
 * Exposing specific ports / volumes between the host & docker env.

--- a/docker/README.md
+++ b/docker/README.md
@@ -168,17 +168,17 @@ Refer [torch-model-archiver](../model-archiver/README.md) for details.
 You may want to consider about the following aspects / docker options when deploying torchserve in Production with Docker.
 
 
-* Shared Memory Size - 
+* Shared Memory Size 
 
     * ```shm-size``` - The shm-size parameter allows you to specify the shared memory that a container can use. It enables memory-intensive containers to run faster by giving more access to allocated memory.
 
 
-* User Limits for System Resources - [ulimit](https://docs.docker.com/engine/reference/commandline/run/#set-ulimits-in-container---ulimit)
+* User Limits for System Resources
     
     * ```--ulimit memlock=-1``` : Maximum locked-in-memory address space. 
     * ```--ulimit stack``` : Linux stack size 
 
-    The current ulimit values can be viewed by executing ```ulimit -a```. A more exhaustive set of options for resource constraining can be found in the Docker Documentation [here](https://docs.docker.com/config/containers/resource_constraints/) and [here](https://docs.docker.com/engine/reference/run/#runtime-constraints-on-resources)
+    The current ulimit values can be viewed by executing ```ulimit -a```. A more exhaustive set of options for resource constraining can be found in the Docker Documentation [here](https://docs.docker.com/config/containers/resource_constraints/) [here](https://docs.docker.com/engine/reference/commandline/run/#set-ulimits-in-container---ulimit) and [here](https://docs.docker.com/engine/reference/run/#runtime-constraints-on-resources)
 
 
 * Exposing specific ports / volumes between the host & docker env.

--- a/docker/README.md
+++ b/docker/README.md
@@ -165,7 +165,7 @@ Refer [torch-model-archiver](../model-archiver/README.md) for details.
 
 # Running TorchServe in a Production Docker Environment.
 
-You may want to consider about the following aspects / docker options when deploying torchserve in Production with Docker.
+You may want to consider the following aspects / docker options when deploying torchserve in Production with Docker.
 
 
 * Shared Memory Size 

--- a/docker/README.md
+++ b/docker/README.md
@@ -183,7 +183,7 @@ You may want to consider the following aspects / docker options when deploying t
 
 * Exposing specific ports / volumes between the host & docker env.
 
-    *  ```-p8080:p8080 -p8081:8081``` TorchServe uses 8080 / 8081 for inference & management APIs. You may want to expose these ports to the host for HTTP Requests between Docker & Host.
+    *  ```-p8080:p8080 -p8081:8081``` TorchServe uses default ports 8080 / 8081 for inference & management APIs. You may want to expose these ports to the host for HTTP Requests between Docker & Host.
     * The model store is passed to torchserve with the --model-store option. You may want want to consider using a shared volume if you prefer pre populating models in model-store directory.
 
 For example,


### PR DESCRIPTION
### Document the docker settings for running in production mode #234.

Adds documentation for TS in Production env for Docker -  Shared Memory Size / User Limits for System Resources / Exposing specific ports / volumes between the host & docker env.

