### PR TITLE
made model server port tests independent

### DIFF
--- a/frontend/server/src/test/java/org/pytorch/serve/ModelServerTest.java
+++ b/frontend/server/src/test/java/org/pytorch/serve/ModelServerTest.java
@@ -95,13 +95,8 @@ public class ModelServerTest {
 
     @Test
     public void testPing() throws InterruptedException {
-        Channel channel = TestUtils.getInferenceChannel(configManager);
-        TestUtils.setResult(null);
-        TestUtils.setLatch(new CountDownLatch(1));
-        HttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/ping");
-        channel.writeAndFlush(req);
+        TestUtils.ping(configManager);
         TestUtils.getLatch().await();
-
         StatusResponse resp = JsonUtils.GSON.fromJson(TestUtils.getResult(), StatusResponse.class);
         Assert.assertEquals(resp.getStatus(), "Healthy");
         Assert.assertTrue(TestUtils.getHeaders().contains("x-request-id"));
@@ -1372,20 +1367,21 @@ public class ModelServerTest {
     @Test(
             alwaysRun = true,
             dependsOnMethods = {"testUnregisterModelFailure"})
-    private void testTSValidPort()
+    public void testTSValidPort()
             throws InterruptedException, InvalidSnapshotException, GeneralSecurityException,
                     IOException {
         //  test case for verifying port range refer https://github.com/pytorch/serve/issues/291
-        server.stop();
+        ConfigManager.init(new ConfigManager.Arguments());
+        ConfigManager configManagerValidPort = ConfigManager.getInstance();
         FileUtils.deleteQuietly(new File(System.getProperty("LOG_LOCATION"), "config"));
-        configManager.setProperty("inference_address", "https://127.0.0.1:42523");
-        server = new ModelServer(configManager);
-        server.start();
+        configManagerValidPort.setProperty("inference_address", "https://127.0.0.1:42523");
+        ModelServer serverValidPort = new ModelServer(configManagerValidPort);
+        serverValidPort.start();
 
         Channel channel = null;
         Channel managementChannel = null;
         for (int i = 0; i < 5; ++i) {
-            channel = TestUtils.connect(false, configManager);
+            channel = TestUtils.connect(false, configManagerValidPort);
             if (channel != null) {
                 break;
             }
@@ -1393,7 +1389,7 @@ public class ModelServerTest {
         }
 
         for (int i = 0; i < 5; ++i) {
-            managementChannel = TestUtils.connect(true, configManager);
+            managementChannel = TestUtils.connect(true, configManagerValidPort);
             if (managementChannel != null) {
                 break;
             }
@@ -1403,21 +1399,26 @@ public class ModelServerTest {
         Assert.assertNotNull(channel, "Failed to connect to inference port.");
         Assert.assertNotNull(managementChannel, "Failed to connect to management port.");
 
-        testPing();
+        TestUtils.ping(configManagerValidPort);
+
+        serverValidPort.stop();
     }
 
     @Test(
             alwaysRun = true,
             dependsOnMethods = {"testTSValidPort"})
-    private void testTSInvalidPort() {
+    public void testTSInvalidPort()
+            throws IOException, InterruptedException, GeneralSecurityException,
+                    InvalidSnapshotException {
         //  test case for verifying port range refer https://github.com/pytorch/serve/issues/291
         //  invalid port test
-        server.stop();
+        ConfigManager.init(new ConfigManager.Arguments());
+        ConfigManager configManagerInvalidPort = ConfigManager.getInstance();
         FileUtils.deleteQuietly(new File(System.getProperty("LOG_LOCATION"), "config"));
-        configManager.setProperty("inference_address", "https://127.0.0.1:65536");
-        server = new ModelServer(configManager);
+        configManagerInvalidPort.setProperty("inference_address", "https://127.0.0.1:65536");
+        ModelServer serverInvalidPort = new ModelServer(configManagerInvalidPort);
         try {
-            server.start();
+            serverInvalidPort.start();
         } catch (Exception e) {
             Assert.assertEquals(e.getClass(), IllegalArgumentException.class);
             Assert.assertEquals(e.getMessage(), "Invalid port number: https://127.0.0.1:65536");

--- a/frontend/server/src/test/java/org/pytorch/serve/TestUtils.java
+++ b/frontend/server/src/test/java/org/pytorch/serve/TestUtils.java
@@ -204,6 +204,14 @@ public final class TestUtils {
         channel.writeAndFlush(req);
     }
 
+    public static void ping(ConfigManager configManager) throws InterruptedException {
+        Channel channel = TestUtils.getInferenceChannel(configManager);
+        TestUtils.setResult(null);
+        TestUtils.setLatch(new CountDownLatch(1));
+        HttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/ping");
+        channel.writeAndFlush(req);
+    }
+
     public static Channel connect(boolean management, ConfigManager configManager) {
         return connect(management, configManager, 120);
     }


### PR DESCRIPTION
## Description

Made model server port tests independent of other test cases in ModelServerTest.java.

Fixes #391 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

- Logs
[install_from_source_391.txt](https://github.com/pytorch/serve/files/4676837/install_from_source_391.txt)

## Checklist:

- [x] Have you added tests that prove your fix is effective or that this feature works?
- [x] New and existing unit tests pass locally with these changes?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
