### PR TITLE
added backend profiling and fixed benchmark's install dependency scripts

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -150,7 +150,7 @@ Once you have stopped recording, you should be able to analyze the data.  One us
 The benchmarks can also be used to analyze the backend performance using cProfile.  It does not require any additional packages to run the benchmark, but viewing the logs does require an additional package.  Run `pip install snakeviz` to install this.  To run the python profiling, follow these steps:
 
 1. In the file `ts/model_service_worker.py`, set the constant BENCHMARK to true at the top to enable benchmarking.
-2. Run the benchmark and TorchServe.  They can either be done automatically inside the docker container or separately with the "--ts" flag.
+2. Run the benchmark and TorchServe.  They can either be done automatically inside the docker container or separately with the "--ts" flag. If you are running `TorchServe` inside docker container make sure you map the `/tmp` directory to some local directory on your machine while starting docker.
 3. Run TorchServe directly through gradle (do not use docker).  This can be done either on your machine or on a remote machine accessible through SSH.
 4. Run the Benchmark script targeting your running TorchServe instance.  It might run something like `./benchmark.py throughput --ts https://127.0.0.1:8443`.  It can be run on either your local machine or a remote machine (if you are running remote), but we recommend running the benchmark on the same machine as the model server to avoid confounding network latencies.
 5. Run `snakeviz /tmp/tsPythonProfile.prof` to view the profiling data.  It should start up a web server on your machine and automatically open the page.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -150,8 +150,42 @@ Once you have stopped recording, you should be able to analyze the data.  One us
 The benchmarks can also be used to analyze the backend performance using cProfile.  It does not require any additional packages to run the benchmark, but viewing the logs does require an additional package.  Run `pip install snakeviz` to install this.  To run the python profiling, follow these steps:
 
 1. In the file `ts/model_service_worker.py`, set the constant BENCHMARK to true at the top to enable benchmarking.
-2. Run the benchmark and TorchServe.  They can either be done automatically inside the docker container or separately with the "--ts" flag. If you are running `TorchServe` inside docker container make sure you map the `/tmp` directory to some local directory on your machine while starting docker.
+2. Run the benchmark and TorchServe. They can either be done automatically inside the docker container or separately with the "--ts" flag. To run benchmark with backend profiling enabled inside docker, use following steps :
+
+    * create a docker image with BENCHMARK parameter set to true in model_service_worker.py
+    ```bash
+    cd docker
+    git clone https://github.com/pytorch/serve.git
+    cd serve
+    ## set BENCHMARK flag to true
+    vim ts/model_service_worker.py
+    cd ..
+    DOCKER_BUILDKIT=1 docker build --file Dockerfile_dev.cpu -t torchserve:dev .
+    ```
+    
+    * run benchmark's install_dependencies.sh
+    ```bash
+    cd ../benchmark
+    ./install_dependencies.sh
+    ```
+    
+    * start docker with /tmp directory mapped to local /tmp
+    ```bash
+    start docker with /tmp directory mapped to local /tmp
+    ```
+    
+    * start default throughput benchmark
+    ```
+    python benchmark.py throughput --ts http://127.0.0.1:8080
+    ```
+ 
 3. Run TorchServe directly through gradle (do not use docker).  This can be done either on your machine or on a remote machine accessible through SSH.
 4. Run the Benchmark script targeting your running TorchServe instance.  It might run something like `./benchmark.py throughput --ts https://127.0.0.1:8443`.  It can be run on either your local machine or a remote machine (if you are running remote), but we recommend running the benchmark on the same machine as the model server to avoid confounding network latencies.
-5. Run `snakeviz /tmp/tsPythonProfile.prof` to view the profiling data.  It should start up a web server on your machine and automatically open the page.
+5. To visualize the profiling data using `snakeviz` use following commands:
+    ```bash
+    pip install snakeviz
+    snakeviz tsPythonProfile.prof
+    ```
+   It should start up a web server on your machine and automatically open the page. Note that tha above command will fail if executed on a server where no browser is installed.
+
 6. Don't forget to set BENCHMARK = False in the model_service_worker.py file after you are finished.

--- a/benchmarks/install_dependencies.sh
+++ b/benchmarks/install_dependencies.sh
@@ -56,10 +56,13 @@ echo "Installing JMeter through Brew"
     true
 }
 
-wget https://jmeter-plugins.org/get/ -O /home/linuxbrew/.linuxbrew/Homebrew/Cellar/jmeter/5.2.1/libexec/lib/ext/jmeter-plugins-manager-1.3.jar
-wget http://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/2.2/cmdrunner-2.2.jar -O /home/linuxbrew/.linuxbrew/Homebrew/Cellar/jmeter/5.2.1/libexec/lib/cmdrunner-2.2.jar
-java -cp /home/linuxbrew/.linuxbrew/Homebrew/Cellar/jmeter/5.2.1/libexec/lib/ext/jmeter-plugins-manager-1.3.jar org.jmeterplugins.repository.PluginManagerCMDInstaller
-/home/linuxbrew/.linuxbrew/Homebrew/Cellar/jmeter/5.2.1/libexec/bin/PluginsManagerCMD.sh install jpgc-synthesis=2.1,jpgc-filterresults=2.1,jpgc-mergeresults=2.1,jpgc-cmd=2.1,jpgc-perfmon=2.1
+CELLAR="/home/linuxbrew/.linuxbrew/Homebrew/Cellar/jmeter/"
+JMETER_HOME=`find $CELLAR ! -path $CELLAR -type d -maxdepth 1`
+
+wget https://jmeter-plugins.org/get/ -O $JMETER_HOME/libexec/lib/ext/jmeter-plugins-manager-1.3.jar
+wget http://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/2.2/cmdrunner-2.2.jar -O $JMETER_HOME/libexec/lib/cmdrunner-2.2.jar
+java -cp $JMETER_HOME/libexec/lib/ext/jmeter-plugins-manager-1.3.jar org.jmeterplugins.repository.PluginManagerCMDInstaller
+$JMETER_HOME/libexec/bin/PluginsManagerCMD.sh install jpgc-synthesis=2.1,jpgc-filterresults=2.1,jpgc-mergeresults=2.1,jpgc-cmd=2.1,jpgc-perfmon=2.1
 
 echo "Install docker"
 sudo apt-get remove docker docker-engine docker.io

--- a/benchmarks/mac_install_dependencies.sh
+++ b/benchmarks/mac_install_dependencies.sh
@@ -8,7 +8,11 @@ echo "Installing JMeter through Brew"
 brew update
 brew install jmeter
 
-wget https://jmeter-plugins.org/get/ -O /usr/local/Cellar/jmeter/5.2.1/libexec/lib/ext/jmeter-plugins-manager-1.3.jar
-wget http://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/2.2/cmdrunner-2.2.jar -O /usr/local/Cellar/jmeter/5.2.1/libexec/lib/cmdrunner-2.2.jar
-java -cp /usr/local/Cellar/jmeter/5.2.1/libexec/lib/ext/jmeter-plugins-manager-1.3.jar org.jmeterplugins.repository.PluginManagerCMDInstaller
-/usr/local/Cellar/jmeter/5.2.1/libexec/bin/PluginsManagerCMD.sh install jpgc-synthesis=2.1,jpgc-filterresults=2.1,jpgc-mergeresults=2.1,jpgc-cmd=2.1,jpgc-perfmon=2.1
+
+CELLAR="/usr/local/Cellar/jmeter"
+JMETER_HOME=`find $CELLAR ! -path $CELLAR -type d -maxdepth 1`
+
+wget https://jmeter-plugins.org/get/ -O $JMETER_HOME/libexec/lib/ext/jmeter-plugins-manager-1.3.jar
+wget http://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/2.2/cmdrunner-2.2.jar -O $JMETER_HOME/libexec/lib/cmdrunner-2.2.jar
+java -cp $JMETER_HOME/libexec/lib/ext/jmeter-plugins-manager-1.3.jar org.jmeterplugins.repository.PluginManagerCMDInstaller
+$JMETER_HOME/libexec/bin/PluginsManagerCMD.sh install jpgc-synthesis=2.1,jpgc-filterresults=2.1,jpgc-mergeresults=2.1,jpgc-cmd=2.1,jpgc-perfmon=2.1

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,6 +4,7 @@
 * [Create TorchServe docker image](#docker_image_production)
 * [Create TorchServe docker image from source](#docker_image_source)
 * [Create torch-model-archiver from container](#docker_torch_model_archiver)
+* [Running TorchServe docker image in production](#docker_image_production)
 
 # Prerequisites
 
@@ -161,3 +162,37 @@ torch-model-archiver --model-name densenet161 --version 1.0 --model-file /home/m
 Refer [torch-model-archiver](../model-archiver/README.md) for details.
 
 4. desnet161.mar file should be present at /home/model-server/model-store
+
+# Running TorchServe in a Production Docker Environment.
+
+You may want to consider the following aspects / docker options when deploying torchserve in Production with Docker.
+
+
+* Shared Memory Size 
+
+    * ```shm-size``` - The shm-size parameter allows you to specify the shared memory that a container can use. It enables memory-intensive containers to run faster by giving more access to allocated memory.
+
+
+* User Limits for System Resources
+    
+    * ```--ulimit memlock=-1``` : Maximum locked-in-memory address space. 
+    * ```--ulimit stack``` : Linux stack size 
+
+    The current ulimit values can be viewed by executing ```ulimit -a```. A more exhaustive set of options for resource constraining can be found in the Docker Documentation [here](https://docs.docker.com/config/containers/resource_constraints/), [here](https://docs.docker.com/engine/reference/commandline/run/#set-ulimits-in-container---ulimit) and [here](https://docs.docker.com/engine/reference/run/#runtime-constraints-on-resources)
+
+
+* Exposing specific ports / volumes between the host & docker env.
+
+    *  ```-p8080:p8080 -p8081:8081``` TorchServe uses default ports 8080 / 8081 for inference & management APIs. You may want to expose these ports to the host for HTTP Requests between Docker & Host.
+    * The model store is passed to torchserve with the --model-store option. You may want to consider using a shared volume if you prefer pre populating models in model-store directory.
+
+For example,
+
+```
+docker run --rm --shm-size=1g \
+        --ulimit memlock=-1 \
+        --ulimit stack=67108864 \
+        -p8080:8080 \
+        -p8081:8081 \
+        --mount type=bind,source=/path/to/model/store,target=/tmp/models <container> torchserve --model-store=/tmp/models 
+```


### PR DESCRIPTION
## Description
 This PR addresses following :

 - added code changes to enable backend profiling
 - makes benchmark install dependency scripts independent of jmeter version.

Fixes #400

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

 - create a docker image with BENCHMARK parameter set to true in model_service_worker.py

```
git clone https://github.com/pytorch/serve.git
cd serve
git checkout issue_400
cd docker
git clone https://github.com/pytorch/serve.git
cd serve
git checkout issue_400
## set BENCHMARK flag to true
vim ts/model_service_worker.py
cd ..
DOCKER_BUILDKIT=1 docker build --file Dockerfile_dev.cpu -t torchserve:dev .
```
 - run benchmark's install_dependencies.sh

```
cd benchmark
./install_dependencies.sh
```

 - start docker with /tmp directory mapped to local /tmp

```
docker run --rm -it -p 8080:8080 -p 8081:8081 -v /tmp:/tmp torchserve:dev
```

 - start default throughput benchmark

```
cd benchmark
python benchmark.py throughput --ts http://127.0.0.1:8080
```

**Profiling **
Attached generated report for 10 loops in zip format :

[profile.zip](https://github.com/pytorch/serve/files/4681242/profile.zip)

To access report on browser run following
```
unzip profile.zip
pip install snakeviz
snakeviz tsPythonProfile.prof
```

Profiling report generated on Mac : 
[profile_mac.zip](https://github.com/pytorch/serve/files/4681877/profile_mac.zip)


## Checklist:

- [x] Have you made corresponding changes to the documentation?
