### PR TITLE
Fix benchmarks/README typo and JMeter versioning issue

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -7,8 +7,8 @@ The benchmarks measure the performance of TorchServe on various models and bench
 ### Ubuntu
 
 The script is mainly intended to run on a Ubuntu EC2 instance.  For this reason, we have provided an `install_dependencies.sh` script to install everything needed to execute the benchmark on this environment.  All you need to do is run this file and clone the TorchServe repo.
-On CPU based instance, use `install_depdendencies.sh`.
-On GPU based instance, use `install_depdendencies.sh True`. 
+On CPU based instance, use `./install_dependencies.sh`.
+On GPU based instance, use `./install_dependencies.sh True`.
 
 ### MacOS
 

--- a/benchmarks/install_dependencies.sh
+++ b/benchmarks/install_dependencies.sh
@@ -56,13 +56,20 @@ echo "Installing JMeter through Brew"
     true
 }
 
-wget https://jmeter-plugins.org/get/ -O /home/linuxbrew/.linuxbrew/Homebrew/Cellar/jmeter/5.2.1/libexec/lib/ext/jmeter-plugins-manager-1.3.jar
-wget http://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/2.2/cmdrunner-2.2.jar -O /home/linuxbrew/.linuxbrew/Homebrew/Cellar/jmeter/5.2.1/libexec/lib/cmdrunner-2.2.jar
-java -cp /home/linuxbrew/.linuxbrew/Homebrew/Cellar/jmeter/5.2.1/libexec/lib/ext/jmeter-plugins-manager-1.3.jar org.jmeterplugins.repository.PluginManagerCMDInstaller
-/home/linuxbrew/.linuxbrew/Homebrew/Cellar/jmeter/5.2.1/libexec/bin/PluginsManagerCMD.sh install jpgc-synthesis=2.1,jpgc-filterresults=2.1,jpgc-mergeresults=2.1,jpgc-cmd=2.1,jpgc-perfmon=2.1
+if [ $(ls -1d /home/linuxbrew/.linuxbrew/Homebrew/Cellar/jmeter/* | wc -l) -gt 1 ];then
+  echo "Multiple versions of JMeter installed. Exiting..."
+  exit 1
+fi
+
+export JMETER_HOME=$(ls -1d /home/linuxbrew/.linuxbrew/Homebrew/Cellar/jmeter/* | head -n 1)
+
+wget https://jmeter-plugins.org/get/ -O $JMETER_HOME/libexec/lib/ext/jmeter-plugins-manager-1.3.jar
+wget http://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/2.2/cmdrunner-2.2.jar -O $JMETER_HOME/libexec/lib/cmdrunner-2.2.jar
+java -cp $JMETER_HOME/libexec/lib/ext/jmeter-plugins-manager-1.3.jar org.jmeterplugins.repository.PluginManagerCMDInstaller
+$JMETER_HOME/libexec/bin/PluginsManagerCMD.sh install jpgc-synthesis=2.1,jpgc-filterresults=2.1,jpgc-mergeresults=2.1,jpgc-cmd=2.1,jpgc-perfmon=2.1
 
 echo "Install docker"
-sudo apt-get remove docker docker-engine docker.io
+sudo apt-get remove -y docker docker-engine docker.io
 sudo apt-get install -y \
      apt-transport-https \
      ca-certificates \
@@ -116,5 +123,5 @@ then
     sudo pkill -SIGHUP dockerd
 
     # Test nvidia-smi with the latest official CUDA image
-    docker run --runtime=nvidia --rm nvidia/cuda nvidia-smi
+    docker run --gpus all --rm nvidia/cuda nvidia-smi
 fi

--- a/benchmarks/mac_install_dependencies.sh
+++ b/benchmarks/mac_install_dependencies.sh
@@ -8,7 +8,14 @@ echo "Installing JMeter through Brew"
 brew update
 brew install jmeter
 
-wget https://jmeter-plugins.org/get/ -O /usr/local/Cellar/jmeter/5.2.1/libexec/lib/ext/jmeter-plugins-manager-1.3.jar
-wget http://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/2.2/cmdrunner-2.2.jar -O /usr/local/Cellar/jmeter/5.2.1/libexec/lib/cmdrunner-2.2.jar
-java -cp /usr/local/Cellar/jmeter/5.2.1/libexec/lib/ext/jmeter-plugins-manager-1.3.jar org.jmeterplugins.repository.PluginManagerCMDInstaller
-/usr/local/Cellar/jmeter/5.2.1/libexec/bin/PluginsManagerCMD.sh install jpgc-synthesis=2.1,jpgc-filterresults=2.1,jpgc-mergeresults=2.1,jpgc-cmd=2.1,jpgc-perfmon=2.1
+if [ $(ls -1d /usr/local/Cellar/jmeter/* | wc -l) -gt 1 ];then
+  echo "Multiple versions of JMeter installed. Exiting..."
+  exit 1
+fi
+
+export JMETER_HOME=$(ls -1d /usr/local/Cellar/jmeter/* | head -n 1)
+
+wget https://jmeter-plugins.org/get/ -O $JMETER_HOME/libexec/lib/ext/jmeter-plugins-manager-1.3.jar
+wget http://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/2.2/cmdrunner-2.2.jar -O $JMETER_HOME/libexec/lib/cmdrunner-2.2.jar
+java -cp $JMETER_HOME/libexec/lib/ext/jmeter-plugins-manager-1.3.jar org.jmeterplugins.repository.PluginManagerCMDInstaller
+$JMETER_HOME/libexec/bin/PluginsManagerCMD.sh install jpgc-synthesis=2.1,jpgc-filterresults=2.1,jpgc-mergeresults=2.1,jpgc-cmd=2.1,jpgc-perfmon=2.1


### PR DESCRIPTION
## Description
* Fixes script failure on newer versions of JMeter (5.3)
* Fix typo in README in the name of dependency script

Related: Issue #98 and PR #126

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## Feature/Issue validation/testing
Ran
* `./benchmarks/mac_install_dependencies.sh` on Mac
* `./benchmarks/install_dependencies.sh`
* `./benchmarks/install_dependencies.sh True`
* `python benchmark.py throughput --ts http://127.0.0.1:8080`

---
- Logs
[mac.log](https://github.com/pytorch/serve/files/4692811/build.log)
[gpu_build.log](https://github.com/pytorch/serve/files/4692816/gpu_build.log)

## Checklist:

- [X] Have you added tests that prove your fix is effective or that this feature works?
- [X] New and existing unit tests pass locally with these changes?
