### PR TITLE
Porting memory fix changes to TorchServe

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -163,6 +163,13 @@ cors_allowed_methods=GET, POST, PUT, OPTIONS
 cors_allowed_headers=X-Custom-Header
 ```
 
+### Prefer direct buffer
+Configuration parameter prefer_direct_buffer controls if the model server will be using direct memory specified by -XX:MaxDirectMemorySize. This parameter is for model server only and  doesn't affect other packages' usage of direct memory buffer. Default: false
+
+```properties
+prefer_direct_buffer=true
+```
+
 ### Restrict backend worker to access environment variables
 
 Environment variables might contain sensitive information, like AWS credentials. Backend workers execute an arbitrary model's custom code,

--- a/frontend/server/src/main/java/org/pytorch/serve/ModelServer.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/ModelServer.java
@@ -5,6 +5,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.FixedRecvByteBufAllocator;
 import io.netty.channel.ServerChannel;
 import io.netty.handler.ssl.SslContext;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -52,6 +53,7 @@ public class ModelServer {
     private List<ChannelFuture> futures = new ArrayList<>(2);
     private AtomicBoolean stopped = new AtomicBoolean(false);
     private ConfigManager configManager;
+    public static final int MAX_RCVBUF_SIZE = 4096;
 
     /** Creates a new {@code ModelServer} instance. */
     public ModelServer(ConfigManager configManager) {
@@ -240,7 +242,10 @@ public class ModelServer {
                 .channel(channelClass)
                 .childOption(ChannelOption.SO_LINGER, 0)
                 .childOption(ChannelOption.SO_REUSEADDR, true)
-                .childOption(ChannelOption.SO_KEEPALIVE, true);
+                .childOption(ChannelOption.SO_KEEPALIVE, true)
+                .childOption(
+                        ChannelOption.RCVBUF_ALLOCATOR,
+                        new FixedRecvByteBufAllocator(MAX_RCVBUF_SIZE));
         b.group(serverGroup, workerGroup);
 
         SslContext sslCtx = null;

--- a/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
@@ -76,6 +76,7 @@ public final class ConfigManager {
     private static final String TS_MODEL_SERVER_HOME = "model_server_home";
     private static final String TS_MODEL_STORE = "model_store";
     private static final String TS_SNAPSHOT_STORE = "snapshot_store";
+    private static final String TS_PREFER_DIRECT_BUFFER = "prefer_direct_buffer";
 
     // Configuration which are not documented or enabled through environment variables
     private static final String USE_NATIVE_IO = "use_native_io";
@@ -262,6 +263,10 @@ public final class ConfigManager {
             binding = prop.getProperty(TS_INFERENCE_ADDRESS, "http://127.0.0.1:8080");
         }
         return Connector.parse(binding, management);
+    }
+
+    public boolean getPreferDirectBuffer() {
+        return Boolean.parseBoolean(getProperty(TS_PREFER_DIRECT_BUFFER, "false"));
     }
 
     public int getNettyThreads() {
@@ -524,7 +529,9 @@ public final class ConfigManager {
                 + "\nMaximum Response Size: "
                 + prop.getProperty(TS_MAX_RESPONSE_SIZE, "6553500")
                 + "\nMaximum Request Size: "
-                + prop.getProperty(TS_MAX_REQUEST_SIZE, "6553500");
+                + prop.getProperty(TS_MAX_REQUEST_SIZE, "6553500")
+                + "\nPrefer direct buffer: "
+                + prop.getProperty(TS_PREFER_DIRECT_BUFFER, "false");
     }
 
     public boolean useNativeIo() {

--- a/frontend/server/src/main/java/org/pytorch/serve/util/codec/ModelRequestEncoder.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/codec/ModelRequestEncoder.java
@@ -14,6 +14,9 @@ import org.pytorch.serve.util.messages.RequestInput;
 
 @ChannelHandler.Sharable
 public class ModelRequestEncoder extends MessageToByteEncoder<BaseModelRequest> {
+    public ModelRequestEncoder(boolean preferDirect) {
+        super(preferDirect);
+    }
 
     @Override
     protected void encode(ChannelHandlerContext ctx, BaseModelRequest msg, ByteBuf out) {

--- a/frontend/server/src/main/java/org/pytorch/serve/wlm/WorkerThread.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/wlm/WorkerThread.java
@@ -46,7 +46,8 @@ public class WorkerThread implements Runnable {
     };
 
     private static final long WORKER_TIMEOUT = 2L;
-    private static final ModelRequestEncoder ENCODER = new ModelRequestEncoder();
+    private static final ModelRequestEncoder ENCODER =
+            new ModelRequestEncoder(ConfigManager.getInstance().getPreferDirectBuffer());
 
     private ConfigManager configManager;
     private EventLoopGroup backendEventGroup;
@@ -180,6 +181,7 @@ public class WorkerThread implements Runnable {
             // WorkerThread is running in thread pool, the thread will be assigned to next
             // Runnable once this worker is finished. If currentThread keep holding the reference
             // of the thread, currentThread.interrupt() might kill next worker.
+            backendChannel.disconnect();
             currentThread.set(null);
             Integer exitValue = lifeCycle.getExitValue();
 
@@ -314,6 +316,7 @@ public class WorkerThread implements Runnable {
         if (backendChannel != null) {
             backendChannel.close();
         }
+        lifeCycle.terminateIOStreams();
         Thread thread = currentThread.getAndSet(null);
         if (thread != null) {
             thread.interrupt();

--- a/ts/model_server.py
+++ b/ts/model_server.py
@@ -87,6 +87,7 @@ def start():
             props = load_properties(ts_conf_file)
             vm_args = props.get("vmargs")
             if vm_args:
+                print("Warning: TorchServe is using non-default JVM parameters: {}".format(vm_args))
                 arg_list = vm_args.split()
                 if args.log_config:
                     for word in arg_list[:]:

--- a/ts/model_service_worker.py
+++ b/ts/model_service_worker.py
@@ -180,7 +180,7 @@ if __name__ == "__main__":
     except socket.timeout:
         logging.error("Backend worker did not receive connection in: %d", SOCKET_ACCEPT_TIMEOUT)
     except Exception:  # pylint: disable=broad-except
-        logging.error("Backend worker process die.", exc_info=True)
+        logging.error("Backend worker process died.", exc_info=True)
     finally:
         if sock_type == 'unix' and os.path.exists(socket_name):
             os.remove(socket_name)


### PR DESCRIPTION
## Description

Adds an option to use [DirectBuffer](https://github.com/mrniko/netty-socketio/blob/bed2a3b05d68a5ac84eba32c59d410c0f88dc0d7/src/main/java/com/corundumstudio/socketio/Configuration.java#L347) for netty which is suitable for I/O instead of HeapBuffer

Closes #415

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Feature/Issue validation/testing

Verified UT/IT/ST. Stress tested with DirectBuffer

```
inference_address=http://0.0.0.0:8080
management_address=http://0.0.0.0:8081
number_of_netty_threads=32
job_queue_size=1000
model_store=/home/model-server/model-store
vmargs=-Xmx4g -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/home/log
prefer_direct_buffer=true
```
```
nohup ab -q -c 50 -n 1000000 -k -p sample_text.txt -T application/txt http://127.0.0.1:8082/predictions/BERT_SeqClassification > /tmp/buff.out 2>&1 &
```


## Checklist:

- [X] New and existing unit tests pass locally with these changes?
- [X] Has code been commented, particularly in hard-to-understand areas?
- [X] Have you made corresponding changes to the documentation?
