### PR TITLE
Add build date / branch to nightly build

### DIFF
--- a/test/regression_tests.sh
+++ b/test/regression_tests.sh
@@ -28,6 +28,8 @@ install_torchserve_from_source() {
   cd serve
   echo "Installing torchserve torch-model-archiver from source"
   ./scripts/install_from_src_ubuntu
+  echo "TS Branch : " $(git rev-parse --abbrev-ref HEAD) >> $3
+  echo "Build date : " $(date) >> $3
   echo "Torchserve Succesfully installed"
 }
 
@@ -127,7 +129,7 @@ cd $ROOT_DIR
 
 echo "** Execuing TorchServe Regression Test Suite executon for " $TS_REPO " **"
 
-install_torchserve_from_source $TS_REPO $BRANCH
+install_torchserve_from_source $TS_REPO $BRANCH $TEST_EXECUTION_LOG_FILE
 generate_densenet_test_model_archive $MODEL_STORE
 run_postman_test $TEST_EXECUTION_LOG_FILE
 run_pytest $TEST_EXECUTION_LOG_FILE

--- a/test/regression_tests.sh
+++ b/test/regression_tests.sh
@@ -29,6 +29,7 @@ install_torchserve_from_source() {
   echo "Installing torchserve torch-model-archiver from source"
   ./scripts/install_from_src_ubuntu
   echo "TS Branch : " $(git rev-parse --abbrev-ref HEAD) >> $3
+  echo "TS Branch Commit Id : " $(git rev-parse HEAD) >> $3
   echo "Build date : " $(date) >> $3
   echo "Torchserve Succesfully installed"
 }


### PR DESCRIPTION
Verified this on **nightly_code_build_branch_date_info** branch this info is added to the top of the log.

```
TS Branch :  nightly_code_build_branch_date_info
TS Branch Commit Id : 4ae2e8a5967eacf4212494c0e6964b9131bddb10
Build date :  Tue Jun 9 01:40:29 UTC 2020
newman

torchserve_regression_management

→ Register Model
  POST http://localhost:8081/models?url=https://torchserve.s3.amazonaws.com/mar_files/squeezenet1_1.mar&model_name=squeezenet1_1 [200 OK, 409B, 903ms]

  prepare   wait   dns-lookup   tcp-handshake   transfer-start   download   process   total 
  22ms      6ms    170µs        846µs           886ms            8ms        540µs     924ms 

  ✓  Successful POST request

→ Get Valid Model
  GET http://localhost:8081/models/squeezenet1_1 [200 OK, 584B, 8ms]
...
```