### PR TITLE
Fix typo in benchmark-ab.sh

### DIFF
--- a/benchmarks/benchmark-ab.sh
+++ b/benchmarks/benchmark-ab.sh
@@ -132,7 +132,7 @@ metric_log="/tmp/benchmark/logs/model_metrics.log"
 
 echo "Registering model ..."
 
-RURL="?model_name=${MODEL}&url=${URL}&batch_size=${BATCH_SIZE}&max_batch_delay=${BATCH_DELAY}&initial_workers=${WORKERS}&synchronous=true"
+RURL="?model_name=${MODEL}&url=${URL}&batch_size=${BATCH_SIZE}&max_batch_delay=${BATCH_DELAY}&initial_workers=${WORKER}&synchronous=true"
 curl -X POST "http://localhost:8081/models${RURL}"
 
 echo "Executing Apache Bench tests ..."


### PR DESCRIPTION
## Description

Fix typo ${WORKERS} -> ${WORKER} in the benchmark script to be able to set the number of initial workers correctly

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)