### PR TITLE
Run benchmarking with Apache Bench against a running TS instance

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -191,7 +191,11 @@ TS error rate: 0.000000%
 CSV : cpu, vgg11, 1, 10, 20, 269.49, 369.21, 370.55, 12.57, 702, 907, 907, 1012, 795.813, 0.000000
 ```
 
+To run benchmarks against an already running TorchServe instance, execute the benchmark script with the `--ts` argument as follows
 
+```
+./benchmark-ab.sh --model  vgg11 --url https://torchserve-mar-files.s3.amazonaws.com/vgg11.mar --ts http://localhost --bsize 1 --bdelay 50 --worker 4 --input ../examples/image_classifier/kitten.jpg --requests 20 --concurrency 10
+```
 
 # Profiling
 


### PR DESCRIPTION
## Description

Add a `--ts` CLI option to benchmark-ab.sh to run Apache Bench benchmarking against an already running TS instance.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## Feature/Issue validation/testing

Start an existing TS docker instance:
```bash
docker run --rm -it -p 8080:8080 -p 8081:8081 pytorch/torchserve:latest 2>&1 | tee /tmp/benchmark/logs/model_metrics.log
```

Run Apache Bench benchmarking against the running instance with:
```bash
./benchmark-ab.sh --model vgg11 --url https://torchserve-mar-files.s3.amazonaws.com/vgg11.mar --ts http://localhost --bsize 1 --bdelay 50 --worker 4 --input ../examples/image_classifier/kitten.jpg --requests 20 --concurrency 10
```

- UT/IT execution results

- Logs

## Checklist:

- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [x] New and existing unit tests pass locally with these changes?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?
