### PR TITLE
NameError fixed in default image_classifier.py torch handler

### DIFF
--- a/ts/torch_handler/image_classifier.py
+++ b/ts/torch_handler/image_classifier.py
@@ -70,7 +70,7 @@ class ImageClassifier(VisionHandler):
 
                 results.append(tmp)
             else:
-                results.append({str(classes[i]):str(probs[i])})
+                results.append({str(classes[index]):str(probs[index])})
 
         return [results]
 


### PR DESCRIPTION
## Description

in image_classifier.py, when mapping of index to label is not defined, we should've done classes[index] instead of classes[i]. 'i' is not defined.

## Type of change


- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

