### PR TITLE
Fixed issue Snapshot not emitted after unregistering model with 0 workers 

### DIFF
--- a/frontend/server/src/main/java/org/pytorch/serve/wlm/WorkLoadManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/wlm/WorkLoadManager.java
@@ -95,6 +95,9 @@ public class WorkLoadManager {
                 threads = workers.remove(model.getModelVersionName());
                 if (threads == null) {
                     future.complete(HttpResponseStatus.OK);
+                    if (!isStartup) {
+                        SnapshotManager.getInstance().saveSnapshot();
+                    }
                     return future;
                 }
             } else {

--- a/frontend/server/src/test/java/org/pytorch/serve/SnapshotTest.java
+++ b/frontend/server/src/test/java/org/pytorch/serve/SnapshotTest.java
@@ -230,6 +230,20 @@ public class SnapshotTest {
     @Test(
             alwaysRun = true,
             dependsOnMethods = {"testAsyncScaleModelSnapshot"})
+    private void testUnregisterModelWithZeroWorkerSnapshot() throws InterruptedException {
+        Channel managementChannel = TestUtils.getManagementChannel(configManager);
+        TestUtils.setResult(null);
+        TestUtils.setLatch(new CountDownLatch(1));
+        TestUtils.registerModel(managementChannel, "noop.mar", "noop_zero", false, false);
+        waitForSnapshot(2000);
+        TestUtils.unregisterModel(managementChannel, "noop_zero", null, true);
+        validateSnapshot("snapshot9.cfg");
+        waitForSnapshot();
+    }
+
+    @Test(
+            alwaysRun = true,
+            dependsOnMethods = {"testUnregisterModelWithZeroWorkerSnapshot"})
     public void testStopTorchServeSnapshot() {
         server.stop();
         validateSnapshot("snapshot9.cfg");


### PR DESCRIPTION
Duplicate of https://github.com/pytorch/serve/pull/315 changed the base to master.

## Description

Snapshot not emitted after unregistering model with 0 workers

Fixes #200 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Feature/Issue validation/testing

 -[x] Test 1: No snapshot is created on list model request
	(tsenv) admins@BRL07887:~TorchServe/TSSource$ curl "http://localhost:8081/models"
		{
		  "models": []
		}
	
	(tsenv) admins@BRL07887:~$ ls logs/config/20200508164* -l
		-rw-rw-r-- 1 admins admins 313 May  8 16:48 logs/config/20200508164820357-startup.cfg

 -[x] Test 2: Snapshot is created when model is loaded with zero initial_workers
	(tsenv) admins@BRL07887:~TorchServe/TSSource$  curl -X POST "http://localhost:8081/models?url=resnet-18.mar&initial_workers=0&synchronous=true"
		{
		  "status": "Model \"resnet-18\" registered"
		}
	
	(tsenv) admins@BRL07887:~$ ls logs/config/20200508164* -l
		-rw-rw-r-- 1 admins admins 313 May  8 16:48 logs/config/20200508164820357-startup.cfg
		-rw-rw-r-- 1 admins admins 589 May  8 16:49 logs/config/20200508164922000-snapshot.cfg

 -[x] Test 3: Snapshot is created when model is registered with some initial_workers
	(tsenv) admins@BRL07887:~$ curl -X POST "http://localhost:8081/models?url=densenet161.mar&initial_workers=3&synchronous=true"
		{
		  "status": "Workers scaled"
		}

	(tsenv) admins@BRL07887:~$ ls logs/config/20200508* -l
		-rw-rw-r-- 1 admins admins 313 May  8 16:48 logs/config/20200508164820357-startup.cfg
		-rw-rw-r-- 1 admins admins 589 May  8 16:49 logs/config/20200508164922000-snapshot.cfg
		-rw-rw-r-- 1 admins admins 865 May  8 16:51 logs/config/20200508165112917-snapshot.cfg

 -[x] Test 4: Snapshot file is created when model deleted with zero initial_workers 
	(tsenv) admins@BRL07887:~$ curl -X DELETE "http://localhost:8081/models/resnet-18"
		{
		  "status": "Model \"resnet-18\" unregistered"
		}

	(tsenv) admins@BRL07887:~$ ls logs/config/20200508* -l
		-rw-rw-r-- 1 admins admins 313 May  8 16:48 logs/config/20200508164820357-startup.cfg
		-rw-rw-r-- 1 admins admins 589 May  8 16:49 logs/config/20200508164922000-snapshot.cfg
		-rw-rw-r-- 1 admins admins 865 May  8 16:51 logs/config/20200508165112917-snapshot.cfg
		-rw-rw-r-- 1 admins admins 593 May  8 16:53 logs/config/20200508165309631-snapshot.cfg

 -[x] Test 5: snapshot file is created when model is deleted with some initial_workers 
	(tsenv) admins@BRL07887:~$ curl -X DELETE "http://localhost:8081/models/densenet161"
		{
		  "status": "Model \"densenet161\" unregistered"
		}

	(tsenv) admins@BRL07887:~$ ls -l logs/config/
	total 20
		-rw-rw-r-- 1 admins admins 313 May  8 16:48 20200508164820357-startup.cfg
		-rw-rw-r-- 1 admins admins 589 May  8 16:49 20200508164922000-snapshot.cfg
		-rw-rw-r-- 1 admins admins 865 May  8 16:51 20200508165112917-snapshot.cfg
		-rw-rw-r-- 1 admins admins 593 May  8 16:53 20200508165309631-snapshot.cfg
		-rw-rw-r-- 1 admins admins 314 May  8 16:54 20200508165438447-snapshot.cfg

 -[x] Test 6: Snapshot file is created when server is stopped 
	(tsenv) admins@BRL07887:~$ torchserve --stop
		TorchServe has stopped.

	(tsenv) admins@BRL07887:~$ ls -l logs/config/
		total 24
		-rw-rw-r-- 1 admins admins 313 May  8 16:48 20200508164820357-startup.cfg
		-rw-rw-r-- 1 admins admins 589 May  8 16:49 20200508164922000-snapshot.cfg
		-rw-rw-r-- 1 admins admins 865 May  8 16:51 20200508165112917-snapshot.cfg
		-rw-rw-r-- 1 admins admins 593 May  8 16:53 20200508165309631-snapshot.cfg
		-rw-rw-r-- 1 admins admins 314 May  8 16:54 20200508165438447-snapshot.cfg
		-rw-rw-r-- 1 admins admins 314 May  8 16:55 20200508165522332-shutdown.cfg

- Logs
[torchserve_sanity.log](https://github.com/pytorch/serve/files/4598998/torchserve_sanity.log)
## Checklist:

- [x] Have you added tests that prove your fix is effective or that this feature works?
- [x] New and existing unit tests pass locally with these changes?

