### PR TITLE
Fixes failures for Regression Test Suite

### DIFF
--- a/test/regression_tests.sh
+++ b/test/regression_tests.sh
@@ -82,18 +82,15 @@ delete_model_store_snapshots() {
 
 
 run_postman_test() {
+  set -e
   # Run Postman Scripts
   mkdir $ROOT_DIR/report/
   cd $CODEBUILD_WD/test/
-  set +e
   # Run Management API Tests
   stop_torch_serve
   start_torchserve $MODEL_STORE $TS_LOG_FILE
   newman run -e postman/environment.json --bail --verbose postman/management_api_test_collection.json \
 	  -r cli,html --reporter-html-export $ROOT_DIR/report/management_report.html >>$1 2>&1
-  
-  echo "Newman Return code for Management APIs - " $?
-
 
   # Run Inference API Tests after Restart
   stop_torch_serve
@@ -109,22 +106,18 @@ run_postman_test() {
   newman run --insecure -e postman/environment.json --bail --verbose postman/https_test_collection.json \
 	  -r cli,html --reporter-html-export $ROOT_DIR/report/https_test_report.html >>$1 2>&1
 
-  set -e
   cd -
 }
 
 
-run_pytest() {
-
+run_pytest() {(
+  set -e
   mkdir -p $ROOT_DIR/report/
   cd $CODEBUILD_WD/test/pytest
   stop_torch_serve
-  set +e
   pytest . -v >>$1 2>&1
-  set -e
   cd -
-
-}
+)}
 
 sudo rm -rf $ROOT_DIR && sudo mkdir $ROOT_DIR
 sudo chown -R $USER:$USER $ROOT_DIR

--- a/test/regression_tests.sh
+++ b/test/regression_tests.sh
@@ -91,6 +91,8 @@ run_postman_test() {
   start_torchserve $MODEL_STORE $TS_LOG_FILE
   newman run -e postman/environment.json --bail --verbose postman/management_api_test_collection.json \
 	  -r cli,html --reporter-html-export $ROOT_DIR/report/management_report.html >>$1 2>&1
+  
+  echo "Newman Return code for Management APIs - " $?
 
 
   # Run Inference API Tests after Restart


### PR DESCRIPTION
Halt newman / pytest and fail early to ensure that CodeBuild job fails.

Testing : Confirmed that the latest Job fails.

<img width="965" alt="Screen Shot 2020-07-14 at 12 42 49 AM" src="https://user-images.githubusercontent.com/60679183/87398678-1902ae00-c56b-11ea-8de9-f962c8e1219d.png">

Logs : 

```

+ mkdir /workspace//report/
--
958 | + cd /codebuild/output/src600067126/src/github.com/pytorch/serve/test/
959 | + stop_torch_serve
960 | + torchserve --stop
961 | TorchServe is not currently running.
962 | + start_torchserve /workspace//model_store /tmp/ts.log
963 | + torchserve --start --model-store /workspace//model_store --models /workspace//model_store/densenet161_v1.mar
964 | + sleep 10
965 | + curl http://127.0.0.1:8081/models
966 | % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
967 | Dload  Upload   Total   Spent    Left  Speed
968 |  
969 | 0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
970 | 100   134  100   134    0     0   2851      0 --:--:-- --:--:-- --:--:--  2851
971 | {
972 | "models": [
973 | {
974 | "modelName": "densenet161_v1",
975 | "modelUrl": "/workspace//model_store/densenet161_v1.mar"
976 | }
977 | ]
978 | }
979 | + newman run -e postman/environment.json --bail --verbose postman/management_api_test_collection.json -r cli,html --reporter-html-export /workspace//report/management_report.html
980 |  
981 | [Container] 2020/07/14 07:34:50 Command did not exit successfully ./test/regression_tests.sh $NIGHTLY_BUILD_BRANCH exit status 1
982 | [Container] 2020/07/14 07:34:50 Phase complete: BUILD State: FAILED
983 | [Container] 2020/07/14 07:34:50 Phase context status code: COMMAND_EXECUTION_ERROR Message: Error while executing command: ./test/regression_tests.sh $NIGHTLY_BUILD_BRANCH. Reason: exit status 1


```