### PR TITLE
updated backend test case to make them compatible with latest pytest version

### DIFF
--- a/ts/tests/unit_tests/test_beckend_metric.py
+++ b/ts/tests/unit_tests/test_beckend_metric.py
@@ -6,8 +6,6 @@ from ts.metrics.dimension import Dimension
 from ts.metrics.metrics_store import MetricsStore
 from ts.service import emit_metrics
 
-logging.basicConfig(stream=sys.stdout, format="%(message)s", level=logging.INFO)
-
 
 def get_model_key(name, unit, req_id, model_name):
     dimensions = list()
@@ -30,6 +28,7 @@ def test_metrics(caplog):
     Also checks global metric service methods
     """
     # Create a batch of request ids
+    caplog.set_level(logging.INFO)
     request_ids = {0: 'abcd', 1: "xyz", 2: "qwerty", 3: "hjshfj"}
     all_req_ids = ','.join(request_ids.values())
     model_name = "dummy model"

--- a/ts/tests/unit_tests/test_worker_service.py
+++ b/ts/tests/unit_tests/test_worker_service.py
@@ -1,14 +1,11 @@
 import logging
 import os
-import sys
 
 import pytest
 
 from ts.context import Context
 from ts.service import Service
 from ts.service import emit_metrics
-
-logging.basicConfig(stream=sys.stdout, format="%(message)s", level=logging.INFO)
 
 
 # noinspection PyClassHasNoInit
@@ -50,6 +47,7 @@ class TestService:
 class TestEmitMetrics:
 
     def test_emit_metrics(self, caplog):
+        caplog.set_level(logging.INFO)
         metrics = {'test_emit_metrics': True}
         emit_metrics(metrics)
         assert "[METRICS]" in caplog.text


### PR DESCRIPTION
## Description

Updated backend test cases to make them compatible with pytest 6.0.0

Fixes #562

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Feature/Issue validation/testing

run backend pytest suite
```
pytest --cov-report html:htmlcov --cov=ts/ ts/tests/unit_tests/;
```

## Checklist:

- [x] New and existing unit tests pass locally with these changes?
