### PR TITLE
removed bert scripted models from sanity script

### DIFF
--- a/torchserve_sanity.sh
+++ b/torchserve_sanity.sh
@@ -38,12 +38,11 @@ mkdir -p model_store
 start_torchserve
 
 models=("fastrcnn" "fcn_resnet_101" "my_text_classifier" "resnet-18" "my_text_classifier_scripted" "alexnet_scripted" "fcn_resnet_101_scripted"
-          "roberta_qa_torchscript" "roberta_qa_no_torchscript" "bert_token_classification_torchscript" "bert_token_classification_no_torchscript"
-          "bert_seqc_with_torchscript" "bert_seqc_without_torchscript")
+           "roberta_qa_no_torchscript" "bert_token_classification_no_torchscript" "bert_seqc_without_torchscript")
 model_inputs=("examples/object_detector/persons.jpg,docs/images/blank_image.jpg" "examples/image_segmenter/fcn/persons.jpg" "examples/text_classification/sample_text.txt" "examples/image_classifier/kitten.jpg"
- "examples/text_classification/sample_text.txt" "examples/image_classifier/kitten.jpg" "examples/image_segmenter/fcn/persons.jpg" "examples/Huggingface_Transformers/sample_text.txt" "examples/Huggingface_Transformers/sample_text.txt"
- "examples/Huggingface_Transformers/sample_text.txt" "examples/Huggingface_Transformers/sample_text.txt" "examples/Huggingface_Transformers/sample_text.txt" "examples/Huggingface_Transformers/sample_text.txt")
-handlers=("object_detector" "image_segmenter" "text_classification" "image_classifier" "text_classification" "image_classifier" "image_segmenter" "custom" "custom" "custom" "custom" "custom" "custom")
+ "examples/text_classification/sample_text.txt" "examples/image_classifier/kitten.jpg" "examples/image_segmenter/fcn/persons.jpg" "examples/Huggingface_Transformers/QA_artifacts/sample_text.txt"
+ "examples/Huggingface_Transformers/Token_classification_artifacts/sample_text.txt" "examples/Huggingface_Transformers/Seq_classification_artifacts/sample_text.txt")
+handlers=("object_detector" "image_segmenter" "text_classification" "image_classifier" "text_classification" "image_classifier" "image_segmenter" "custom" "custom" "custom")
 
 
 for i in ${!models[@]};


### PR DESCRIPTION
## Description

Reverted bert scripted models from sanity suite, which are currently broken on GPU (#479) . The sanity suite is currently passing on code build CI on GPU due to #564 

Hence reverting back the changes, these models should be added back in sanity suite as part of fix for #479 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Feature/Issue validation/testing

Sanity suites executed successfully on CI build.

## Checklist:

- [x] New and existing unit tests pass locally with these changes?

