### PR TITLE
added numpy in developer requirement file

### DIFF
--- a/requirements/developer.txt
+++ b/requirements/developer.txt
@@ -5,3 +5,4 @@ pylint
 pytest-mock
 pytest-cov
 nvgpu
+numpy

--- a/test/regression_tests.sh
+++ b/test/regression_tests.sh
@@ -57,7 +57,7 @@ install_torchserve_from_source() {
   cd serve
   echo "Installing torchserve torch-model-archiver from source"
   ./scripts/install_from_src
-  pip install -r requirements/developer.txt
+  pip install -U -r requirements/developer.txt
   pip install transformers
   echo "TS Branch : " "$(git rev-parse --abbrev-ref HEAD)" >> $3
   echo "TS Branch Commit Id : " "$(git rev-parse HEAD)" >> $3


### PR DESCRIPTION
## Description

Pytest cases in regression suite fail on DLAMI due to incompatible pytest and numpy versions. Added numpy as dependecy package in `developer.txt` requirement file.

Fixes #606 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Feature/Issue validation/testing

Regression suite execution log on DLAMI 30 :
[test_exec.log](https://github.com/pytorch/serve/files/5054876/test_exec.log)


## Checklist:

- [x] New and existing unit tests pass locally with these changes?

