### PR TITLE
added python3-distutils in dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -58,6 +58,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     python3 \
+    python3-distutils \
     openjdk-11-jre-headless \
     && rm -rf /var/lib/apt/lists/* \
     && cd /tmp


### PR DESCRIPTION
## Description

pip command requires `python3-distutils` package installed on linux. This package was missing in the Dockerfile.

Fixes #628


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Feature/Issue validation/testing

Logs on docker image created using Dockerfile from latest master :

```
(base) ubuntu@ip-172-31-54-27:~$ docker ps
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                              NAMES
e205f508e0bc        torchserve:latest   "/usr/local/bin/dock…"   38 seconds ago      Up 36 seconds       0.0.0.0:8080-8081->8080-8081/tcp   stoic_lumiere
(base) ubuntu@ip-172-31-54-27:~$ docker exec -it stoic_lumiere /bin/bash
model-server@e205f508e0bc:~$ pip show torchserve
Traceback (most recent call last):
  File "/home/venv/bin/pip", line 7, in <module>
    from pip import main
  File "/home/venv/lib/python3.6/site-packages/pip/__init__.py", line 29, in <module>
    from pip.utils import get_installed_distributions, get_prog
  File "/home/venv/lib/python3.6/site-packages/pip/utils/__init__.py", line 23, in <module>
    from pip.locations import (
  File "/home/venv/lib/python3.6/site-packages/pip/locations.py", line 9, in <module>
    from distutils import sysconfig
ImportError: cannot import name 'sysconfig'
```


Logs on docker image created with fix
```
(base) ubuntu@ip-172-31-54-27:~$ docker ps
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                              NAMES
8bf310d74337        torchserve:latest   "/usr/local/bin/dock…"   5 seconds ago       Up 4 seconds        0.0.0.0:8080-8081->8080-8081/tcp   cranky_visvesvaraya
(base) ubuntu@ip-172-31-54-27:~$ docker exec -it cranky_visvesvaraya /bin/bash
model-server@8bf310d74337:~$ pip show torchserve
Name: torchserve
Version: 0.2.0
Summary: TorchServe is a tool for serving neural net models for inference
Home-page: https://github.com/pytorch/serve.git
Author: PyTorch Serving team
Author-email: noreply@noreply.com
License: Apache License Version 2.0
Location: /home/venv/lib/python3.6/site-packages
Requires: future, Pillow, psutil, packaging
```

