### PR TITLE
Using python tempfile to handle security and non-standard temporary files

### DIFF
--- a/model-archiver/model_archiver/model_packaging_utils.py
+++ b/model-archiver/model_archiver/model_packaging_utils.py
@@ -10,6 +10,7 @@ import re
 import zipfile
 import shutil
 import tarfile
+import tempfile
 from io import BytesIO
 from .model_archiver_error import ModelArchiverError
 
@@ -130,7 +131,7 @@ class ModelExportUtils(object):
         :param kwargs: key value pair of files to be copied in archive
         :return:
         """
-        model_path = '/tmp/{0}'.format(model_name)
+        model_path = os.path.join(tempfile.gettempdir(), model_name)
         if os.path.exists(model_path):
             shutil.rmtree(model_path)
         ModelExportUtils.make_dir(model_path)


### PR DESCRIPTION
## Description

Now model_archiver uses fixed '/tmp' file dir as temporary files location. This is not laways true. This fix uses standard and secure way of working with temp files.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Run complete tes suite and integration tests.

- UT/IT execution results

- Logs

## Checklist:

- [ ] Have you added tests that prove your fix is effective or that this feature works? 
- [x] New and existing unit tests pass locally with these changes?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
