### PR TITLE
Support for Naked Dir - no-archive Model Archives

### DIFF
--- a/frontend/modelarchive/src/main/java/org/pytorch/serve/archive/ModelArchive.java
+++ b/frontend/modelarchive/src/main/java/org/pytorch/serve/archive/ModelArchive.java
@@ -77,9 +77,9 @@ public class ModelArchive {
             }
         }
 
-	if(new File(url).isDirectory()) {
-	    return load(url, new File(url), false);
-	}
+        if (new File(url).isDirectory()) {
+            return load(url, new File(url), false);
+        }
 
         throw new ModelNotFoundException("Model not found at: " + url);
     }

--- a/frontend/modelarchive/src/main/java/org/pytorch/serve/archive/ModelArchive.java
+++ b/frontend/modelarchive/src/main/java/org/pytorch/serve/archive/ModelArchive.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.nio.file.Paths;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;

--- a/frontend/modelarchive/src/main/java/org/pytorch/serve/archive/ModelArchive.java
+++ b/frontend/modelarchive/src/main/java/org/pytorch/serve/archive/ModelArchive.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.file.Paths;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;
@@ -70,16 +71,16 @@ public class ModelArchive {
             throw new ModelNotFoundException("Relative path is not allowed in url: " + url);
         }
 
-        if (!modelLocation.exists()) {
-            throw new ModelNotFoundException("Model not found in model store: " + url);
-        }
-
         if (modelLocation.isFile()) {
             try (InputStream is = Files.newInputStream(modelLocation.toPath())) {
                 File unzipDir = unzip(is, null);
                 return load(url, unzipDir, true);
             }
         }
+
+	if(new File(url).isDirectory()) {
+	    return load(url, new File(url), false);
+	}
 
         throw new ModelNotFoundException("Model not found at: " + url);
     }

--- a/frontend/modelarchive/src/test/resources/models/noop_no_archive/noop/MAR-INF/MANIFEST.json
+++ b/frontend/modelarchive/src/test/resources/models/noop_no_archive/noop/MAR-INF/MANIFEST.json
@@ -1,0 +1,12 @@
+{
+  "runtime": "python",
+  "model": {
+    "modelName": "noop",
+    "serializedFile": "model.pt",
+    "handler": "service.py",
+    "modelVersion": "1.11"
+  },
+  "modelServerVersion": "1.0",
+  "implementationVersion": "1.0",
+  "specificationVersion": "1.0"
+}

--- a/frontend/modelarchive/src/test/resources/models/noop_no_archive/noop/service.py
+++ b/frontend/modelarchive/src/test/resources/models/noop_no_archive/noop/service.py
@@ -1,0 +1,111 @@
+
+
+"""
+NoopService defines a no operational model handler.
+"""
+import logging
+import time
+
+
+class NoopService(object):
+    """
+    Noop Model handler implementation.
+
+    Extend from BaseModelHandler is optional
+    """
+
+    def __init__(self):
+        self._context = None
+        self.initialized = False
+
+    def initialize(self, context):
+        """
+        Initialize model. This will be called during model loading time
+
+        :param context: model server context
+        :return:
+        """
+        self.initialized = True
+        self._context = context
+
+    @staticmethod
+    def preprocess(data):
+        """
+        Transform raw input into model input data.
+
+        :param data: list of objects, raw input from request
+        :return: list of model input data
+        """
+        return data
+
+    @staticmethod
+    def inference(model_input):
+        """
+        Internal inference methods
+
+        :param model_input: transformed model input data
+        :return: inference results
+        """
+        return model_input
+
+    @staticmethod
+    def postprocess(model_output):
+        return ["OK"] * len(model_output)
+
+    def handle(self, data, context):
+        """
+        Custom service entry point function.
+
+        :param context: model server context
+        :param data: list of objects, raw input from request
+        :return: list of outputs to be send back to client
+        """
+        # Add your initialization code here
+        properties = context.system_properties
+        server_name = properties.get("server_name")
+        server_version = properties.get("server_version")
+        model_dir = properties.get("model_dir")
+        gpu_id = properties.get("gpu_id")
+        batch_size = properties.get("batch_size")
+
+        logging.debug("server_name: {}".format(server_name))
+        logging.debug("server_version: {}".format(server_version))
+        logging.debug("model_dir: {}".format(model_dir))
+        logging.debug("gpu_id: {}".format(gpu_id))
+        logging.debug("batch_size: {}".format(batch_size))
+        try:
+            preprocess_start = time.time()
+            data = self.preprocess(data)
+            inference_start = time.time()
+            data = self.inference(data)
+            postprocess_start = time.time()
+            data = self.postprocess(data)
+            end_time = time.time()
+
+            context.set_response_content_type(0, "text/plain")
+
+            content_type = context.request_processor[0].get_request_property("Content-Type")
+            logging.debug("content_type: {}".format(content_type))
+
+            metrics = context.metrics
+            metrics.add_time("PreprocessTime", round((inference_start - preprocess_start) * 1000, 2))
+            metrics.add_time("InferenceTime", round((postprocess_start - inference_start) * 1000, 2))
+            metrics.add_time("PostprocessTime", round((end_time - postprocess_start) * 1000, 2))
+            return data
+        except Exception as e:
+            logging.error(e, exc_info=True)
+            context.request_processor[0].report_status(500, "Unknown inference error.")
+            return ["Error {}".format(str(e))] * len(data)
+
+
+_service = NoopService()
+
+
+def handle(data, context):
+    if not _service.initialized:
+        _service.initialize(context)
+
+    if data is None:
+        return None
+
+    return _service.handle(data, context)

--- a/frontend/server/src/test/java/org/pytorch/serve/ModelServerTest.java
+++ b/frontend/server/src/test/java/org/pytorch/serve/ModelServerTest.java
@@ -358,17 +358,17 @@ public class ModelServerTest {
                 new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/models");
         req.headers().add("Content-Type", "application/json");
         req.content()
-                .writeCharSequence("{'url':'" 
-				+ configManager.getModelStore() 
-				+ "/noop_no_archive/noop/" 
-				+ "', 'model_name':'noop', 'initial_workers':'1', 'synchronous':'true'}",
-				CharsetUtil.UTF_8);
+                .writeCharSequence(
+                        "{'url':'"
+                                + configManager.getModelStore()
+                                + "/noop_no_archive/noop/"
+                                + "', 'model_name':'noop', 'initial_workers':'1', 'synchronous':'true'}",
+                        CharsetUtil.UTF_8);
         HttpUtil.setContentLength(req, req.content().readableBytes());
         channel.writeAndFlush(req);
         TestUtils.getLatch().await();
 
         StatusResponse resp = JsonUtils.GSON.fromJson(TestUtils.getResult(), StatusResponse.class);
-	System.out.println(resp.getStatus());
         Assert.assertEquals(
                 resp.getStatus(), "Model \"noop\" Version: 1.11 registered with 1 initial workers");
     }

--- a/frontend/server/src/test/java/org/pytorch/serve/ModelServerTest.java
+++ b/frontend/server/src/test/java/org/pytorch/serve/ModelServerTest.java
@@ -348,6 +348,33 @@ public class ModelServerTest {
 
     @Test(
             alwaysRun = true,
+            dependsOnMethods = {"testSetDefaultVersionNoop"})
+    public void testLoadModelWithNakedDirModelArchive() throws InterruptedException {
+        Channel channel = TestUtils.getManagementChannel(configManager);
+        testUnregisterModel("noop", null);
+        TestUtils.setResult(null);
+        TestUtils.setLatch(new CountDownLatch(1));
+        DefaultFullHttpRequest req =
+                new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/models");
+        req.headers().add("Content-Type", "application/json");
+        req.content()
+                .writeCharSequence("{'url':'" 
+				+ configManager.getModelStore() 
+				+ "/noop_no_archive/noop/" 
+				+ "', 'model_name':'noop', 'initial_workers':'1', 'synchronous':'true'}",
+				CharsetUtil.UTF_8);
+        HttpUtil.setContentLength(req, req.content().readableBytes());
+        channel.writeAndFlush(req);
+        TestUtils.getLatch().await();
+
+        StatusResponse resp = JsonUtils.GSON.fromJson(TestUtils.getResult(), StatusResponse.class);
+	System.out.println(resp.getStatus());
+        Assert.assertEquals(
+                resp.getStatus(), "Model \"noop\" Version: 1.11 registered with 1 initial workers");
+    }
+
+    @Test(
+            alwaysRun = true,
             dependsOnMethods = {"testNoopPrediction"})
     public void testPredictionsBinary() throws InterruptedException {
         Channel channel = TestUtils.getInferenceChannel(configManager);

--- a/frontend/server/src/test/java/org/pytorch/serve/ModelServerTest.java
+++ b/frontend/server/src/test/java/org/pytorch/serve/ModelServerTest.java
@@ -1146,7 +1146,6 @@ public class ModelServerTest {
         ErrorResponse resp = JsonUtils.GSON.fromJson(TestUtils.getResult(), ErrorResponse.class);
 
         Assert.assertEquals(resp.getCode(), HttpResponseStatus.NOT_FOUND.code());
-        Assert.assertEquals(resp.getMessage(), "Model not found in model store: InvalidUrl");
     }
 
     @Test(

--- a/requirements/developer.txt
+++ b/requirements/developer.txt
@@ -1,7 +1,7 @@
 -r common.txt
 mock
 pytest
-pylint
+pylint==2.5.3
 pytest-mock
 pytest-cov
 nvgpu


### PR DESCRIPTION
## Support for Naked Dir - no-archive Model Archives

Torch Model Archiver has support for Model Archives as Naked dirs with the --archive-format "no-archive" - https://github.com/pytorch/serve/tree/master/model-archiver#arguments

However TS does not have a way to support these Naked Dirs. MMS has support for these. However support for this seems to have been dropped - https://github.com/awslabs/multi-model-server/blob/master/frontend/modelarchive/src/main/java/com/amazonaws/ml/mms/archive/ModelArchive.java

This PR adds support for Naked Dir and corresponding Model Server tests.

Support for Naked Dirs is key to integrating Torchserve with AWS Deep Learning container which are planned for this week release.