### PR TITLE
Update model_zoo.html to with new URLs

### DIFF
--- a/model_zoo.html
+++ b/model_zoo.html
@@ -280,7 +280,7 @@ To propose a model for inclusion, please submit a <a class="reference external" 
 <td>Image Classification</td>
 <td>ImageNet</td>
 <td>216 MB</td>
-<td><a href="https://torchserve.s3.amazonaws.com/mar_files/alexnet.mar">.mar</a></td>
+<td><a href="https://torchserve.pytorch.org/mar_files/alexnet.mar">.mar</a></td>
 <td><a href="https://github.com/pytorch/serve/blob/master/examples/image_classifier/kitten.jpg">kitten.jpg</a></td>
 <td>Eager</td>
 </tr>
@@ -289,7 +289,7 @@ To propose a model for inclusion, please submit a <a class="reference external" 
 <td>Image Classification</td>
 <td>ImageNet</td>
 <td>106 MB</td>
-<td><a href="https://torchserve.s3.amazonaws.com/mar_files/densenet161.mar">.mar</a></td>
+<td><a href="https://torchserve.pytorch.org/mar_files/densenet161.mar">.mar</a></td>
 <td><a href="https://github.com/pytorch/serve/blob/master/examples/image_classifier/kitten.jpg">kitten.jpg</a></td>
 <td>Eager</td>
 </tr>
@@ -298,7 +298,7 @@ To propose a model for inclusion, please submit a <a class="reference external" 
 <td>Image Classification</td>
 <td>ImageNet</td>
 <td>41 MB</td>
-<td><a href="https://torchserve.s3.amazonaws.com/mar_files/resnet-18.mar">.mar</a></td>
+<td><a href="https://torchserve.pytorch.org/mar_files/resnet-18.mar">.mar</a></td>
 <td><a href="https://github.com/pytorch/serve/blob/master/examples/image_classifier/kitten.jpg">kitten.jpg</a></td>
 <td>Eager</td>
 </tr>
@@ -307,7 +307,7 @@ To propose a model for inclusion, please submit a <a class="reference external" 
 <td>Image Classification</td>
 <td>ImageNet</td>
 <td>471 MB</td>
-<td><a href="https://torchserve.s3.amazonaws.com/mar_files/vgg11_v2.mar">.mar</a></td>
+<td><a href="https://torchserve.pytorch.org/mar_files/vgg11_v2.mar">.mar</a></td>
 <td><a href="https://github.com/pytorch/serve/blob/master/examples/image_classifier/kitten.jpg">kitten.jpg</a></td>
 <td>Eager</td>
 </tr>
@@ -316,7 +316,7 @@ To propose a model for inclusion, please submit a <a class="reference external" 
 <td>Image Classification</td>
 <td>ImageNet</td>
 <td>4.4 MB</td>
-<td><a href="https://torchserve.s3.amazonaws.com/mar_files/squeezenet1_1.mar">.mar</a></td>
+<td><a href="https://torchserve.pytorch.org/mar_files/squeezenet1_1.mar">.mar</a></td>
 <td><a href="https://github.com/pytorch/serve/blob/master/examples/image_classifier/kitten.jpg">kitten.jpg</a></td>
 <td>Eager</td>
 </tr>
@@ -325,7 +325,7 @@ To propose a model for inclusion, please submit a <a class="reference external" 
 <td>Image Classification</td>
 <td>MNIST</td>
 <td>4.3 MB</td>
-<td><a href="https://torchserve.s3.amazonaws.com/mar_files/mnist_v2.mar">.mar</a></td>
+<td><a href="https://torchserve.pytorch.org/mar_files/mnist_v2.mar">.mar</a></td>
 <td><a href="https://github.com/pytorch/serve/blob/master/examples/image_classifier/mnist/test_data/0.png">0.png</a></td>
 <td>Eager</td>
 </tr>
@@ -334,7 +334,7 @@ To propose a model for inclusion, please submit a <a class="reference external" 
 <td>Image Classification</td>
 <td>ImageNet</td>
 <td>214 MB</td>
-<td><a href="https://torchserve.s3.amazonaws.com/mar_files/resnet-152-batch_v2.mar">.mar</a></td>
+<td><a href="https://torchserve.pytorch.org/mar_files/resnet-152-batch_v2.mar">.mar</a></td>
 <td><a href="https://github.com/pytorch/serve/blob/master/examples/image_classifier/kitten.jpg">kitten.jpg</a></td>
 <td>Eager</td>
 </tr>
@@ -343,7 +343,7 @@ To propose a model for inclusion, please submit a <a class="reference external" 
 <td>Object Detection</td>
 <td>COCO</td>
 <td>148 MB</td>
-<td><a href="https://torchserve.s3.amazonaws.com/mar_files/fastrcnn.mar">.mar</a></td>
+<td><a href="https://torchserve.pytorch.org/mar_files/fastrcnn.mar">.mar</a></td>
 <td><a href="https://github.com/pytorch/serve/blob/master/examples/object_detector/persons.jpg">persons.jpg</a></td>
 <td>Eager</td>
 </tr>
@@ -352,7 +352,7 @@ To propose a model for inclusion, please submit a <a class="reference external" 
 <td>Object Detection</td>
 <td>COCO</td>
 <td>158 MB</td>
-<td><a href="https://torchserve.s3.amazonaws.com/mar_files/maskrcnn.mar">.mar</a></td>
+<td><a href="https://torchserve.pytorch.org/mar_files/maskrcnn.mar">.mar</a></td>
 <td><a href="https://github.com/pytorch/serve/blob/master/examples/object_detector/persons.jpg">persons.jpg</a></td>
 <td>Eager</td>
 </tr>
@@ -361,7 +361,7 @@ To propose a model for inclusion, please submit a <a class="reference external" 
 <td>Text Classification</td>
 <td>AG_NEWS</td>
 <td>169 MB</td>
-<td><a href="https://torchserve.s3.amazonaws.com/mar_files/my_text_classifier_v2.mar">.mar</a></td>
+<td><a href="https://torchserve.pytorch.org/mar_files/my_text_classifier_v2.mar">.mar</a></td>
 <td><a href="https://github.com/pytorch/serve/blob/master/examples/text_classification/sample_text.txt">sample_text.txt</a></td>
 <td>Eager</td>
 </tr>
@@ -370,7 +370,7 @@ To propose a model for inclusion, please submit a <a class="reference external" 
 <td>Image Segmentation</td>
 <td>COCO</td>
 <td>193 MB</td>
-<td><a href="https://torchserve.s3.amazonaws.com/mar_files/fcn_resnet_101.mar">.mar</a></td>
+<td><a href="https://torchserve.pytorch.org/mar_files/fcn_resnet_101.mar">.mar</a></td>
 <td><a href="https://github.com/pytorch/serve/blob/master/examples/image_segmenter/fcn/persons.jpg">persons.jpg</a></td>
 <td>Eager</td>
 </tr>
@@ -379,7 +379,7 @@ To propose a model for inclusion, please submit a <a class="reference external" 
 <td>Image Classification</td>
 <td>ImageNet</td>
 <td>216 MB</td>
-<td><a href="https://torchserve.s3.amazonaws.com/mar_files/alexnet_scripted.mar">.mar</a></td>
+<td><a href="https://torchserve.pytorch.org/mar_files/alexnet_scripted.mar">.mar</a></td>
 <td><a href="https://github.com/pytorch/serve/blob/master/examples/image_classifier/kitten.jpg">kitten.jpg</a></td>
 <td>Torchscripted</td>
 </tr>
@@ -388,7 +388,7 @@ To propose a model for inclusion, please submit a <a class="reference external" 
 <td>Image Classification</td>
 <td>ImageNet</td>
 <td>105 MB</td>
-<td><a href="https://torchserve.s3.amazonaws.com/mar_files/densenet161_scripted.mar">.mar</a></td>
+<td><a href="https://torchserve.pytorch.org/mar_files/densenet161_scripted.mar">.mar</a></td>
 <td><a href="https://github.com/pytorch/serve/blob/master/examples/image_classifier/kitten.jpg">kitten.jpg</a></td>
 <td>Torchscripted</td>
 </tr>
@@ -397,7 +397,7 @@ To propose a model for inclusion, please submit a <a class="reference external" 
 <td>Image Classification</td>
 <td>ImageNet</td>
 <td>42 MB</td>
-<td><a href="https://torchserve.s3.amazonaws.com/mar_files/resnet-18_scripted.mar">.mar</a></td>
+<td><a href="https://torchserve.pytorch.org/mar_files/resnet-18_scripted.mar">.mar</a></td>
 <td><a href="https://github.com/pytorch/serve/blob/master/examples/image_classifier/kitten.jpg">kitten.jpg</a></td>
 <td>Torchscripted</td>
 </tr>
@@ -406,7 +406,7 @@ To propose a model for inclusion, please submit a <a class="reference external" 
 <td>Image Classification</td>
 <td>ImageNet</td>
 <td>471 MB</td>
-<td><a href="https://torchserve.s3.amazonaws.com/mar_files/vgg11_scripted.mar">.mar</a></td>
+<td><a href="https://torchserve.pytorch.org/mar_files/vgg11_scripted.mar">.mar</a></td>
 <td><a href="https://github.com/pytorch/serve/blob/master/examples/image_classifier/kitten.jpg">kitten.jpg</a></td>
 <td>Torchscripted</td>
 </tr>
@@ -415,7 +415,7 @@ To propose a model for inclusion, please submit a <a class="reference external" 
 <td>Image Classification</td>
 <td>ImageNet</td>
 <td>4.4 MB</td>
-<td><a href="https://torchserve.s3.amazonaws.com/mar_files/squeezenet1_1_scripted.mar">.mar</a></td>
+<td><a href="https://torchserve.pytorch.org/mar_files/squeezenet1_1_scripted.mar">.mar</a></td>
 <td><a href="https://github.com/pytorch/serve/blob/master/examples/image_classifier/kitten.jpg">kitten.jpg</a></td>
 <td>Torchscripted</td>
 </tr>
@@ -424,7 +424,7 @@ To propose a model for inclusion, please submit a <a class="reference external" 
 <td>Image Classification</td>
 <td>MNIST</td>
 <td>4.3 MB</td>
-<td><a href="https://torchserve.s3.amazonaws.com/mar_files/mnist_scripted_v2.mar">.mar</a></td>
+<td><a href="https://torchserve.pytorch.org/mar_files/mnist_scripted_v2.mar">.mar</a></td>
 <td><a href="https://github.com/pytorch/serve/blob/master/examples/image_classifier/mnist/test_data/0.png">0.png</a></td>
 <td>Torchscripted</td>
 </tr>
@@ -433,7 +433,7 @@ To propose a model for inclusion, please submit a <a class="reference external" 
 <td>Image Classification</td>
 <td>ImageNet</td>
 <td>215 MB</td>
-<td><a href="https://torchserve.s3.amazonaws.com/mar_files/resnet-152-scripted_v2.mar">.mar</a></td>
+<td><a href="https://torchserve.pytorch.org/mar_files/resnet-152-scripted_v2.mar">.mar</a></td>
 <td><a href="https://github.com/pytorch/serve/blob/master/examples/image_classifier/kitten.jpg">kitten.jpg</a></td>
 <td>Torchscripted</td>
 </tr>
@@ -442,7 +442,7 @@ To propose a model for inclusion, please submit a <a class="reference external" 
 <td>Text Classification</td>
 <td>AG_NEWS</td>
 <td>169 MB</td>
-<td><a href="https://torchserve.s3.amazonaws.com/mar_files/my_text_classifier_scripted_v2.mar">.mar</a></td>
+<td><a href="https://torchserve.pytorch.org/mar_files/my_text_classifier_scripted_v2.mar">.mar</a></td>
 <td><a href="https://github.com/pytorch/serve/blob/master/examples/text_classification/sample_text.txt">sample_text.txt</a></td>
 <td>Torchscripted</td>
 </tr>
@@ -451,7 +451,7 @@ To propose a model for inclusion, please submit a <a class="reference external" 
 <td>Image Segmentation</td>
 <td>COCO</td>
 <td>193 MB</td>
-<td><a href="https://torchserve.s3.amazonaws.com/mar_files/fcn_resnet_101_scripted.mar">.mar</a></td>
+<td><a href="https://torchserve.pytorch.org/mar_files/fcn_resnet_101_scripted.mar">.mar</a></td>
 <td><a href="https://github.com/pytorch/serve/blob/master/examples/image_segmenter/fcn/persons.jpg">persons.jpg</a></td>
 <td>Torchscripted</td>
 </tr>


### PR DESCRIPTION
## Description

I've enabled the models in the existing S3 bucket to be served on the torchserve.pytorch.org domain. It still points to the existing S3 bucket (torchserve.s3.amazonaws.com).

Fixes #(issue) - Not an existing issue

## Type of change

Please delete options that are not relevant.
- [x] This change requires a documentation update

## Feature/Issue validation/testing
Use the new links for the models and verify that you are able to download them.

- UT/IT execution results
I was able to download the models from the new URL.

## Checklist:
- [x] Have you made corresponding changes to the documentation?
