### PR TITLE
Fixed minor error regarding the Docker port option

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -195,7 +195,7 @@ You may want to consider the following aspects / docker options when deploying t
 
 * Exposing specific ports / volumes between the host & docker env.
 
-    *  ```-p8080:p8080 -p8081:8081``` TorchServe uses default ports 8080 / 8081 for inference & management APIs. You may want to expose these ports to the host for HTTP Requests between Docker & Host.
+    *  ```-p8080:8080 -p8081:8081``` TorchServe uses default ports 8080 / 8081 for inference & management APIs. You may want to expose these ports to the host for HTTP Requests between Docker & Host.
     * The model store is passed to torchserve with the --model-store option. You may want to consider using a shared volume if you prefer pre populating models in model-store directory.
 
 For example,


### PR DESCRIPTION
## Description

Fix minor error in [docker/README.md](https://github.com/pytorch/serve/tree/master/docker#running-torchserve-in-a-production-docker-environment) as the '_Exposing specific ports / volumes between the host & docker env._' section specifies the option `-p8080:p8080 -p8081:8081` and it is not valid as there is an extra 'p' in `-p8080:p8080`, which may be confusing.

So the only fix has been `-p8080:p8080` to `-p8080:8080`.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
