### PR TITLE
Fix some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ pip install -U grpcio protobuf grpcio-tools
  - Generate inference client using proto files
 
 ```bash
-python -m grpc_tools.protoc --proto_path=frontend/server/src/main/resources/proto/ --python_out=script --grpc_python_out=script frontend/server/src/main/resources/proto/inference.proto frontend/server/src/main/resources/proto/managment.proto 
+python -m grpc_tools.protoc --proto_path=frontend/server/src/main/resources/proto/ --python_out=script --grpc_python_out=script frontend/server/src/main/resources/proto/inference.proto frontend/server/src/main/resources/proto/management.proto
 ```
 
  - Run inference using a sample client [gRPC python client](scripts/torchserve_grpc_client.py)

--- a/docs/grpc_api.md
+++ b/docs/grpc_api.md
@@ -48,7 +48,7 @@ torchserve --start
  - Generate python gRPC client stub using the proto files
  
 ```bash
-python -m grpc_tools.protoc --proto_path=frontend/server/src/main/resources/proto/ --python_out=script --grpc_python_out=script frontend/server/src/main/resources/proto/inference.proto frontend/server/src/main/resources/proto/managment.proto
+python -m grpc_tools.protoc --proto_path=frontend/server/src/main/resources/proto/ --python_out=script --grpc_python_out=script frontend/server/src/main/resources/proto/inference.proto frontend/server/src/main/resources/proto/management.proto
 ```
 
  - Register densenet161 model

--- a/test/pytest/test_gRPC_inference_api.py
+++ b/test/pytest/test_gRPC_inference_api.py
@@ -46,8 +46,8 @@ def test_inference_apis():
         test_data = json.loads(f.read())
 
     for item in test_data:
-        managment_stub = test_gRPC_utils.get_management_stub()
-        response = managment_stub.RegisterModel(management_pb2.RegisterModelRequest(
+        management_stub = test_gRPC_utils.get_management_stub()
+        response = management_stub.RegisterModel(management_pb2.RegisterModelRequest(
             url=item['url'],
             initial_workers=item['worker'],
             synchronous=bool(item['synchronous']),
@@ -78,7 +78,7 @@ def test_inference_apis():
             else:
                 assert str(prediction) == str(item['expected'])
 
-        response = managment_stub.UnregisterModel(management_pb2.UnregisterModelRequest(
+        response = management_stub.UnregisterModel(management_pb2.UnregisterModelRequest(
             model_name=item['model_name'],
         ))
 

--- a/test/pytest/test_gRPC_utils.py
+++ b/test/pytest/test_gRPC_utils.py
@@ -17,30 +17,30 @@ def get_management_stub():
 
 
 def register_model(**kwargs):
-    managment_stub = get_management_stub()
-    return managment_stub.RegisterModel(management_pb2.RegisterModelRequest(**kwargs))
+    management_stub = get_management_stub()
+    return management_stub.RegisterModel(management_pb2.RegisterModelRequest(**kwargs))
 
 
 def unregister_model(**kwargs):
-    managment_stub = get_management_stub()
-    return managment_stub.UnregisterModel(management_pb2.UnregisterModelRequest(**kwargs))
+    management_stub = get_management_stub()
+    return management_stub.UnregisterModel(management_pb2.UnregisterModelRequest(**kwargs))
 
 
 def scale_model(**kwargs):
-    managment_stub = get_management_stub()
-    return managment_stub.ScaleWorker(management_pb2.ScaleWorkerRequest(**kwargs))
+    management_stub = get_management_stub()
+    return management_stub.ScaleWorker(management_pb2.ScaleWorkerRequest(**kwargs))
 
 
 def set_default_model(**kwargs):
-    managment_stub = get_management_stub()
-    return managment_stub.SetDefault(management_pb2.SetDefaultRequest(**kwargs))
+    management_stub = get_management_stub()
+    return management_stub.SetDefault(management_pb2.SetDefaultRequest(**kwargs))
 
 
 def list_model(**kwargs):
-    managment_stub = get_management_stub()
-    return managment_stub.ListModels(management_pb2.ListModelsRequest(**kwargs))
+    management_stub = get_management_stub()
+    return management_stub.ListModels(management_pb2.ListModelsRequest(**kwargs))
 
 
 def describe_model(**kwargs):
-    managment_stub = get_management_stub()
-    return managment_stub.DescribeModel(management_pb2.DescribeModelRequest(**kwargs))
+    management_stub = get_management_stub()
+    return management_stub.DescribeModel(management_pb2.DescribeModelRequest(**kwargs))


### PR DESCRIPTION
## Description

I noticed a typo in the README which seems to have propagated elsewhere too. Note that this is based on https://github.com/pytorch/serve/issues/656 (not master).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

This is only a bug in the sense that copy-pasting a command from the README doesn't work