### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ Complete the following steps:
 The following code completes all three steps:
 
 ```bash
-curl -O https://s3.amazonaws.com/model-server/inputs/kitten.jpg
-curl http://127.0.0.1:8080/predictions/densenet161 -T kitten.jpg
+curl -O https://raw.githubusercontent.com/pytorch/serve/master/docs/images/kitten_small.jpg
+curl http://127.0.0.1:8080/predictions/densenet161 -T kitten_small.jpg
 ```
 
 The predict endpoint returns a prediction response in JSON. It will look something like the following result:

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -27,7 +27,7 @@ OUT_DIR = os.path.join(BENCHMARK_DIR, 'out/')
 RESOURCE_DIR = os.path.join(BENCHMARK_DIR, 'resource/')
 
 RESOURCE_MAP = {
-    'kitten.jpg': 'https://s3.amazonaws.com/model-server/inputs/kitten.jpg'
+    'kitten.jpg': 'https://raw.githubusercontent.com/pytorch/serve/master/docs/images/kitten_small.jpg'
 }
 
 # Listing out all the JMX files

--- a/cloudformation/README.md
+++ b/cloudformation/README.md
@@ -42,9 +42,9 @@ aws cloudformation create-stack \
      ]
 }
 
-> curl -O https://s3.amazonaws.com/model-server/inputs/kitten.jpg
+> curl -O https://raw.githubusercontent.com/pytorch/serve/master/docs/images/kitten_small.jpg
 
-> curl --insecure "<TorchServeInferenceURL>/predictions/squeezenet1_1" -T kitten.jpg
+> curl --insecure "<TorchServeInferenceURL>/predictions/squeezenet1_1" -T kitten_small.jpg
 [
     {
         "tabby": 0.2752002477645874
@@ -115,9 +115,9 @@ aws cloudformation create-stack \
   ]
 }
 
-> curl -O https://s3.amazonaws.com/model-server/inputs/kitten.jpg
+> curl -O https://raw.githubusercontent.com/pytorch/serve/master/docs/images/kitten_small.jpg
 
-> curl "<TorchServeInferenceURL>/predictions/squeezenet1_1" -T kitten.jpg
+> curl "<TorchServeInferenceURL>/predictions/squeezenet1_1" -T kitten_small.jpg
 [
     {
         "tabby": 0.2752002477645874

--- a/docs/inference_api.md
+++ b/docs/inference_api.md
@@ -45,13 +45,13 @@ To get predictions from the default version of each loaded model, make a REST ca
 ### curl Example
 
 ```bash
-curl -O https://s3.amazonaws.com/model-server/inputs/kitten.jpg
+curl -O https://raw.githubusercontent.com/pytorch/serve/master/docs/images/kitten_small.jpg
 
-curl http://localhost:8080/predictions/resnet-18 -T kitten.jpg
+curl http://localhost:8080/predictions/resnet-18 -T kitten_small.jpg
 
 or:
 
-curl http://localhost:8080/predictions/resnet-18 -F "data=@kitten.jpg"
+curl http://localhost:8080/predictions/resnet-18 -F "data=@kitten_small.jpg"
 ```
 
 To get predictions from a specific version of each loaded model, make a REST call to `/predictions/{model_name}/{version}`:
@@ -61,13 +61,13 @@ To get predictions from a specific version of each loaded model, make a REST cal
 ## curl Example
 
 ```bash
-curl -O https://s3.amazonaws.com/model-server/inputs/kitten.jpg
+curl -O https://raw.githubusercontent.com/pytorch/serve/master/docs/images/kitten_small.jpg
 
-curl http://localhost:8080/predictions/resnet-18/2.0 -T kitten.jpg
+curl http://localhost:8080/predictions/resnet-18/2.0 -T kitten_small.jpg
 
 or:
 
-curl http://localhost:8080/predictions/resnet-18/2.0 -F "data=@kitten.jpg"
+curl http://localhost:8080/predictions/resnet-18/2.0 -F "data=@kitten_small.jpg"
 ```
 
 The result is JSON that tells you that the image is most likely a tabby cat. The highest prediction was:


### PR DESCRIPTION
## Description

The kitten.jpg link previously hosted on S3 no longer works. Changing to pull directly from the torchserve GitHub repo.

Fixes #(issue) - No issue created

## Type of change

Please delete options that are not relevant.
- [x] This change requires a documentation update

## Feature/Issue validation/testing

Fetch the cat image and call the prediction endpoint. Verify it works.

- Logs
```
ubuntu@ip-172-31-22-19:~$ curl -O https://raw.githubusercontent.com/pytorch/serve/master/docs/images/kitten_small.jpg
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  7341  100  7341    0     0   159k      0 --:--:-- --:--:-- --:--:--  159k
ubuntu@ip-172-31-22-19:~$ curl http://127.0.0.1:8080/predictions/densenet161 -T kitten_small.jpg 
{
  "tabby": 0.5078840851783752,
  "lynx": 0.18985284864902496,
  "tiger_cat": 0.16152925789356232,
  "tiger": 0.05462226644158363,
  "Egyptian_cat": 0.04894305393099785
```

## Checklist:

- [x] Have you made corresponding changes to the documentation?
