### PR TITLE
Fixes #772: unit test attribute error - 'bytes' object has no attribute 'metrics'

### DIFF
--- a/ts/torch_handler/unit_tests/test_image_classifier.py
+++ b/ts/torch_handler/unit_tests/test_image_classifier.py
@@ -14,7 +14,7 @@ sys.path.append('ts/torch_handler/unit_tests/models/tmp')
 
 @pytest.fixture()
 def model_setup():
-    context = MockContext()
+    context = MockContext(model_name = "mnist")
     with open('ts/torch_handler/unit_tests/models/tmp/images/kitten.jpg', 'rb') as fin:
         image_bytes = fin.read()
     return (context, image_bytes)
@@ -28,9 +28,9 @@ def test_initialize(model_setup):
     return handler
 
 def test_handle(model_setup):
-    _, image_bytes = model_setup
+    context, image_bytes = model_setup
     handler = test_initialize(model_setup)
     test_data = [{'data': image_bytes}] * 2
-    results = handler.handle(test_data, image_bytes)
+    results = handler.handle(test_data, context)
     assert(len(results) == 2)
     assert('tiger_cat' in results[0])

--- a/ts/torch_handler/unit_tests/test_image_segmenter.py
+++ b/ts/torch_handler/unit_tests/test_image_segmenter.py
@@ -14,7 +14,7 @@ sys.path.append('ts/torch_handler/unit_tests/models/tmp')
 
 @pytest.fixture()
 def model_setup():
-    context = MockContext()
+    context = MockContext(model_name = "image_segmenter")
     with open('ts/torch_handler/unit_tests/models/tmp/persons.jpg', 'rb') as fin:
         image_bytes = fin.read()
     return (context, image_bytes)
@@ -28,9 +28,9 @@ def test_initialize(model_setup):
     return handler
 
 def test_handle(model_setup):
-    _, image_bytes = model_setup
+    context, image_bytes = model_setup
     handler = test_initialize(model_setup)
     test_data = [{'data': image_bytes}] * 2
-    results = handler.handle(test_data, image_bytes)
+    results = handler.handle(test_data, context)
     assert(len(results) == 2)
     assert(len(results[0]) == 224)

--- a/ts/torch_handler/unit_tests/test_object_detector.py
+++ b/ts/torch_handler/unit_tests/test_object_detector.py
@@ -14,7 +14,7 @@ sys.path.append('ts/torch_handler/unit_tests/models/tmp')
 
 @pytest.fixture()
 def model_setup():
-    context = MockContext()
+    context = MockContext(model_name = "object_detector")
     with open('ts/torch_handler/unit_tests/models/tmp/persons.jpg', 'rb') as fin:
         image_bytes = fin.read()
     return (context, image_bytes)
@@ -28,9 +28,9 @@ def test_initialize(model_setup):
     return handler
 
 def test_handle(model_setup):
-    _, image_bytes = model_setup
+    context, image_bytes = model_setup
     handler = test_initialize(model_setup)
     test_data = [{'data': image_bytes}] * 2
-    results = handler.handle(test_data, image_bytes)
+    results = handler.handle(test_data, context)
     assert(len(results) == 2)
     assert('bench' in results[0])

--- a/ts/torch_handler/unit_tests/test_utils/mock_context.py
+++ b/ts/torch_handler/unit_tests/test_utils/mock_context.py
@@ -2,7 +2,9 @@
 Mocks for adding model context without loading all of Torchserve
 """
 
+import uuid
 import torch
+from ts.metrics.metrics_store import MetricsStore
 
 class MockContext():
     """
@@ -12,7 +14,8 @@ class MockContext():
                  model_pt_file='model.pt',
                  model_dir='ts/torch_handler/unit_tests/models/tmp',
                  model_file='model.py',
-                 gpu_id='0'):
+                 gpu_id='0',
+                 model_name = "mnist"):
         self.manifest = {
             'model': {
                 'serializedFile': model_pt_file,
@@ -28,3 +31,5 @@ class MockContext():
 
         if torch.cuda.is_available() and gpu_id:
             self.system_properties['gpu_id'] = gpu_id
+
+        self.metrics = MetricsStore(uuid.uuid4(), model_name)


### PR DESCRIPTION
## Description

Fixed Torch handler unit test attribute error - 'bytes' object has no attribute 'metrics'
Fixes #772 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Feature/Issue validation/testing

Ran the run_script.sh from the ts/torch_handler/unit_test folder.

- Logs
[issue_772_run_scripts_logs.log](https://github.com/pytorch/serve/files/5488233/issue_772_run_scripts_logs.log)

## Checklist:

- [x] Have you added tests that prove your fix is effective or that this feature works?

