### PR TITLE
fix for issue 842

### DIFF
--- a/ts_scripts/install_dependencies.py
+++ b/ts_scripts/install_dependencies.py
@@ -79,6 +79,10 @@ class Darwin(Common):
     def install_nodejs(self):
         os.system("brew install node")
 
+    def install_node_packages(self):
+        os.system(f"{self.sudo_cmd} ./ts_scripts/mac_npm_deps")
+
+
     def install_torch_packages(self, cuda_version=''):
         os.system(f"pip install -U -r requirements/torch.txt -f {self.torch_stable_url}")
 

--- a/ts_scripts/mac_npm_deps
+++ b/ts_scripts/mac_npm_deps
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# check whether node in path, if not, add local
+if ! command -v node &> /dev/null
+then
+    PATH=$PATH:/usr/local/bin
+fi
+
+# if node still not in path, there's a problem
+if ! command -v node &> /dev/null
+then
+    echo Error: node not installed
+    exit -1
+fi
+
+npm install -g newman newman-reporter-html markdown-link-check


### PR DESCRIPTION
## Description

This fixes issue #842 regarding failure to install dependencies on Mac for source install

Fixes #842 

## Type of change

Bug fix (non-breaking change which fixes an issue)

The issue was that `node` was not installed in a path where `root` could see it, so calling `sudo npm install...` would fail. Trying without `sudo` failed because the `node_modules` folder was owned by `root`. This fix:

* Updates `ts_scripts/install_dependencies.py` to call `sudo ts_scripts/mac_npm_deps` instead of calling `sudo npm install...` directly
* Adds `ts_scripts/mac_npm_deps`, which does the following:
 * Checks whether `node` is in the `PATH`
 * If not, adjusts the path to include `/usr/local/bin`
 * Checks for `node` again
 * If `node` not available, exit with message
 * Otherwise, perform `npm install...`

## Feature/Issue validation/testing

Tested Mac dependency install on two Macs running macOS 10.15.7 and 10.15.6, with success.

## Checklist:

- n/a Have you added tests that prove your fix is effective or that this feature works?
- n/a New and existing unit tests pass locally with these changes?
- √ Has code been commented, particularly in hard-to-understand areas?
- n/a Have you made corresponding changes to the documentation?
