### PR TITLE
Reverting failing regression test cases

### DIFF
--- a/test/postman/inference_data.json
+++ b/test/postman/inference_data.json
@@ -350,29 +350,5 @@
         "file":"../examples/text_classification/sample_text.txt",
         "content-type":"text/plain",
         "expected":"Not Accepted"
-    },
-    {
-        "url":"https://torchserve-mar-files.s3.amazonaws.com/TransformerEn2Fr.mar",
-        "model_name":"TransformerEn2Fr",
-        "worker":1,
-        "synchronous":"true",
-        "file":"../examples/nmt_transformer/model_input/sample.txt",
-        "content-type":"application/json",
-        "expected":{
-            "english_input" : "Hi James, when are you coming back home? I am waiting for you.\nPlease come as soon as possible.",
-            "french_output" : "Bonjour James, quand rentrerez-vous chez vous, je vous attends et je vous prie de venir le plus tôt possible."
-        }
-    },
-    {
-        "url":"https://torchserve-mar-files.s3.amazonaws.com/TransformerEn2De.mar",
-        "model_name":"TransformerEn2De",
-        "worker":1,
-        "synchronous":"true",
-        "file":"../examples/nmt_transformer/model_input/sample.txt",
-        "content-type":"application/json",
-        "expected":{
-            "english_input" : "Hi James, when are you coming back home? I am waiting for you.\nPlease come as soon as possible.",
-            "german_output" : "Hallo James, wann kommst du nach Hause? Ich warte auf dich. Bitte komm so bald wie möglich."
-        }
     }
 ]


### PR DESCRIPTION
## Description

Reverting failing regression test cases

Fixes Regression test failures

```
# ami-02e86b825fe559330, DLAMI 38, CUDA 10.2, Ubuntu 18.04

## Symlink appropriate CUDA version
sudo rm /usr/local/cuda && sudo ln -s /usr/local/cuda-10.2 /usr/local/cuda
ll /usr/local/cuda

## Verify EC2 updates are not running
ps ax|grep apt

## Run scripts
git clone https://github.com/pytorch/serve/
cd serve/
git checkout build_fixes
python ts_scripts/install_dependencies.py --environment dev
python torchserve_sanity.py
python test/regression_tests.py
```