### PR TITLE
Doc fix for Issue 860, warn about OOME when building Docker image

### DIFF
--- a/kubernetes/kfserving/README.md
+++ b/kubernetes/kfserving/README.md
@@ -15,6 +15,8 @@ For BERT and Text Classifier models, to generate a .mar file refer to the ".mar 
 DOCKER_BUILDKIT=1 docker build --no-cache --file Dockerfile_kf.dev -t <docker image name> .
 ```
 
+***Note:** To avoid out-of-memory errors building the Docker image and running inference, it is recommended to allocate at least 4GB of memory to your Docker container. Your memory needs may vary depending on the size of your model(s) and data.*
+
 The KFServing wrapper will be started along with Torchserve inside the image. Refer [KFServing Wrapper](https://github.com/pytorch/serve/blob/master/kubernetes/kfserving/kfserving_wrapper/README.md) to understand how it works.
 
 * Step - 3 : Push the docker image to the docker registry that you can access from. 


### PR DESCRIPTION
## Description

When creating a Docker image that builds TorchServe from source, one needs at least 4GB of RAM allocated to the container. If too little RAM is allocated, OOMEs cause installation (specifically pip's installation of PyTorch, the package for which is >700MB) to fail with an uninformative error message ("Killed").

This PR adds a note to the documentation for setting up the KFServing Docker image recommending a 4GB minimum RAM allocation.

Fixes #860 

## Type of change

This change is a documentation update

## Feature/Issue validation/testing

The instructions to build the Docker image fail (on my Mac running macOS 10.15.7) if too little RAM is allocated, but succeed consistently when there's sufficient memory. This has been tested multiple times.

## Checklist:

- n/a Have you added tests that prove your fix is effective or that this feature works?
- n/a New and existing unit tests pass locally with these changes?
- n/a Has code been commented, particularly in hard-to-understand areas?
- [√] Have you made corresponding changes to the documentation?
