### PR TITLE
fix default netty thread in docs as 0 and minor markdown syntax issue

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -198,16 +198,15 @@ By default, TorchServe uses all available GPUs for inference. Use `number_of_gpu
 
 ### Enable metrics api
 * `enable_metrics_api` : Enable or disable metric apis i.e. it can be either `true` or `false`. Default: true (Enabled)
-* `metrics_format` : Use this to specify metric report format . At present, the only supported and default value for this is `prometheus'
-		     This is used in conjunction with `enable_meterics_api` option above.
+* `metrics_format` : Use this to specify metric report format. At present, the only supported and default value for this is `prometheus`. This is used in conjunction with `enable_meterics_api` option above.
 
 ### Other properties
 
 Most of the following properties are designed for performance tuning. Adjusting these numbers will impact scalability and throughput.
 
 * `enable_envvars_config`: Enable configuring TorchServe through environment variables. When this option is set to "true", all the static configurations of TorchServe can come through environment variables as well. Default: false
-* `number_of_netty_threads`: Number frontend netty thread. This specifies the numer of threads in the child [EventLoopGroup](https://livebook.manning.com/book/netty-in-action/chapter-8) of the frontend netty server. This group provides EventLoops for processing Netty Channel events (namely inference and management requests) from accepted connections. Default: number of logical processors available to the JVM.
-* `netty_client_threads`: Number of backend netty thread. This specifies the number of threads in the WorkerThread [EventLoopGroup](https://livebook.manning.com/book/netty-in-action/chapter-8) which writes inference responses to the frontend. Default: number of logical processors available to the JVM.
+* `number_of_netty_threads`: Number of frontend netty thread. This specifies the numer of threads in the child [EventLoopGroup](https://livebook.manning.com/book/netty-in-action/chapter-8) of the frontend netty server. This group provides EventLoops for processing Netty Channel events (namely inference and management requests) from accepted connections. Default: 0.
+* `netty_client_threads`: Number of backend netty thread. This specifies the number of threads in the WorkerThread [EventLoopGroup](https://livebook.manning.com/book/netty-in-action/chapter-8) which writes inference responses to the frontend. Default: 0.
 * `default_workers_per_model`: Number of workers to create for each model that loaded at startup time. Default: available GPUs in system or number of logical processors available to the JVM.
 * `job_queue_size`: Number inference jobs that frontend will queue before backend can serve. Default: 100.
 * `async_logging`: Enable asynchronous logging for higher throughput, log output may be delayed if this is enabled. Default: false.


### PR DESCRIPTION
## Description
- In the docs [configuration.md](https://github.com/pytorch/serve/blob/master/docs/configuration.md), it is mentioned that default netty thread number is the number of available logical processors
- According to [ConfigManager.java](https://github.com/pytorch/serve/blob/bacdf0a626fc24d89f332c413a2039f7c0cf9953/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java#L316), the Netty threads set are 0, and nowhere else they are set as ```Runtime.getRuntime().availableProcessors();```.
- Only the default number of workers are set as the number of logical processors.

Fixes https://github.com/pytorch/serve/issues/782

## Type of change

Please delete options that are not relevant.

- [ ] This change requires a documentation update

## Feature/Issue validation/testing

- 

## Checklist:

- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] New and existing unit tests pass locally with these changes?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
