### PR TITLE
Formatting and typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Note: For Conda, Python 3.8 is required to run Torchserve.
    ```
 
 #### For Windows
+
     Refer the documentation [here](docs/torchserve_on_win_native.md).
 
 
@@ -84,7 +85,8 @@ python ./ts_scripts/install_from_src.py
 ```
 
 #### For Windows
-    Refer the documentation [here].(docs/torchserve_on_win_native.md)
+
+    Refer the documentation [here](docs/torchserve_on_win_native.md)
 
 For information about the model archiver, see [detailed documentation](model-archiver/README.md).
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Note: For Conda, Python 3.8 is required to run Torchserve.
 
 #### For Windows
 
-Refer the documentation [here](docs/torchserve_on_win_native.md).
+Refer to the documentation [here](docs/torchserve_on_win_native.md).
 
 
 3. Install torchserve and torch-model-archiver
@@ -86,7 +86,7 @@ python ./ts_scripts/install_from_src.py
 
 #### For Windows
 
-Refer the documentation [here](docs/torchserve_on_win_native.md)
+Refer to the documentation [here](docs/torchserve_on_win_native.md).
 
 For information about the model archiver, see [detailed documentation](model-archiver/README.md).
 
@@ -229,7 +229,7 @@ ValueToSet = (Number of Hardware GPUs) / (Number of Unique Models)
 
 
 ## Quick Start with Docker
-Refer [torchserve docker](docker/README.md) for details.
+Refer to [torchserve docker](docker/README.md) for details.
 
 ## Learn More
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Note: For Conda, Python 3.8 is required to run Torchserve.
 
 #### For Windows
 
-    Refer the documentation [here](docs/torchserve_on_win_native.md).
+Refer the documentation [here](docs/torchserve_on_win_native.md).
 
 
 3. Install torchserve and torch-model-archiver
@@ -86,7 +86,7 @@ python ./ts_scripts/install_from_src.py
 
 #### For Windows
 
-    Refer the documentation [here](docs/torchserve_on_win_native.md)
+Refer the documentation [here](docs/torchserve_on_win_native.md)
 
 For information about the model archiver, see [detailed documentation](model-archiver/README.md).
 


### PR DESCRIPTION
## Description

Two links to the Window native documentation that don't get formatted correctly due to extra space in the beginning of lines.

Fixes #(issue)

Fixed the links and some minor typos.