### PR TITLE
convert the output of pre-process method to the current device

### DIFF
--- a/ts/torch_handler/vision_handler.py
+++ b/ts/torch_handler/vision_handler.py
@@ -50,7 +50,7 @@ class VisionHandler(BaseHandler, ABC):
 
             images.append(image)
 
-        return torch.stack(images)
+        return torch.stack(images).to(self.device)
 
     def get_insights(self, tensor_data, _, target=0):
         print("input shape", tensor_data.shape)

--- a/ts/torch_handler/vision_handler.py
+++ b/ts/torch_handler/vision_handler.py
@@ -55,4 +55,3 @@ class VisionHandler(BaseHandler, ABC):
     def get_insights(self, tensor_data, _, target=0):
         print("input shape", tensor_data.shape)
         return self.ig.attribute(tensor_data, target=target, n_steps=15).tolist()
-        


### PR DESCRIPTION
## Description
The PR solve the issue #888 by converting the output of pre-process method in vision_handler to the current device.

Please include a summary of the feature or issue being fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #(issue)
converting the output of pre-process method in vision_handler to the current device.

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)


## Feature/Issue validation/testing

Please describe the tests [UT/IT] that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced. 
Please also list any relevant details for your test configuration.
Run the Mnist example with captum explanation. 

- Logs

The logs for failing and working status after changes are attached along with explanation in kf-serving context.

[Failing_mnist.logs.txt](https://github.com/pytorch/serve/files/5683870/Failing_mnist.logs.txt)
[Kfserving-mnist-gpu-explain-working.logs.txt](https://github.com/pytorch/serve/files/5683871/Kfserving-mnist-gpu-explain-working.logs.txt)
[Mnist-gpu_working.logs.txt](https://github.com/pytorch/serve/files/5683874/Mnist-gpu_working.logs.txt)


## Checklist:

- [X] Have you added tests that prove your fix is effective or that this feature works?
- [ ] New and existing unit tests pass locally with these changes?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
