### PR TITLE
Text_classifier handler fix for expalantion on GPU 

### DIFF
--- a/ts/torch_handler/text_classifier.py
+++ b/ts/torch_handler/text_classifier.py
@@ -113,7 +113,7 @@ class TextClassifier(TextHandler):
         token_reference = TokenReferenceBase()
         logger.info("input_text shape %s", len(text_tensor.shape))
         logger.info("get_insights target %s", target)
-        offsets = torch.tensor([0])
+        offsets = torch.tensor([0]).to(self.device)
 
         all_tokens = self.get_word_token(all_tokens)
         logger.info("text_tensor tokenized shape %s", text_tensor.shape)


### PR DESCRIPTION
## Description

The issue is not filed and here is the explanation. The text classification example fails on explanations on GPU with the error that offsets are on cpu while required to be on GPU. This PR fixes the issue by converting offset in the text_classifier handler to the current device. This issue has caused the failure on running the this example through kfserving as well, logs are attached.

Fixes #(issue)
This PR fixes the issue by converting offset in the text_classifier handler to the current device.
## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

- Logs
Here are the logs when it was failing and logs of the working example after the change. 
[text_classification_expalin_gpu_working.logs.txt](https://github.com/pytorch/serve/files/5691314/text_classification_expalin_gpu_working.logs.txt)
[text_classifier_expalantion_gpu_error.logs.txt](https://github.com/pytorch/serve/files/5691326/text_classifier_expalantion_gpu_error.logs.txt)
[kfserving_text_classification_explain_GPU_error.logs.txt](https://github.com/pytorch/serve/files/5691327/kfserving_text_classification_explain_GPU_error.logs.txt)



