### PR TITLE
Fixes mnist postman windows fail

### DIFF
--- a/test/postman/kf_inference_data.json
+++ b/test/postman/kf_inference_data.json
@@ -1,6 +1,6 @@
 [
 {
-    "url":"https://torchserve.pytorch.org/mar_files/mnist.mar ",
+    "url":"https://torchserve.pytorch.org/mar_files/mnist.mar",
     "model_name":"mnist",
     "worker":1,
     "synchronous":"true",


### PR DESCRIPTION
## Description

This fixes the mnist failures that occurs in the mnist postman tests on windows.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Feature/Issue validation/testing

- Logs
[windows_regression_logs.log](https://github.com/pytorch/serve/files/5702660/windows_regression_logs.log)


## Checklist:

- [x] Have you added tests that prove your fix is effective or that this feature works?
- [x] New and existing unit tests pass locally with these changes?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?
