### PR TITLE
Add captum as dependency for TorchServe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,7 @@ class BuildPlugins(Command):
 if __name__ == '__main__':
     version = detect_model_server_version()
 
-    requirements = ['Pillow', 'psutil', 'future', 'packaging']
+    requirements = ['Pillow', 'psutil', 'future', 'packaging', 'captum']
 
     setup(
         name='torchserve',


### PR DESCRIPTION
## Description

Add captum as dependency for TorchServe

## Feature/Issue validation/testing

Tested on Linux/MacOS

```
python setup.py bdist_wheel --universal
pip install dist/torchserve-0.3.0b20201217-py2.py3-none-any.whl
```

## Checklist:

- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] New and existing unit tests pass locally with these changes?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
