### PR TITLE
Update docker README.md

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -211,30 +211,26 @@ To create mar [model archive] file for TorchServe deployment, you can use follow
 1. Start container by sharing your local model-store/any directory containing custom/example mar contents as well as model-store directory (if not there, create it)
 
 ```bash
-docker run --rm -it -p 8080:8080 -p 8081:8081 --name mar -v $(pwd)/model-store:/home/model-server/model-store -v $(pwd)/examples:/home/model-server/examples  torchserve:latest
-```
-
-1. List your container or skip this if you know cotainer name
-
-```bash
-docker ps
+docker run --rm -it -p 8080:8080 -p 8081:8081 --name mar -v $(pwd)/model-store:/home/model-server/model-store -v $(pwd)/examples:/home/model-server/examples  pytorch/torchserve:latest
 ```
 
 2. Bind and get the bash prompt of running container
 
 ```bash
-docker exec -it <container_name> /bin/bash
+docker exec -it mar /bin/bash
 ```
 
 You will be landing at /home/model-server/.
 
-3. Download the model weights if you have not done so already (they are not part of the repo)
+If you have already downloaded and archived a model then skip steps 3 and 4
+
+3. On your local machine download the model weights if you have not done so already. Your local and docker directories were shared at step 1
 
 ```bash
 curl -o /home/model-server/examples/image_classifier/densenet161-8d451a50.pth https://download.pytorch.org/models/densenet161-8d451a50.pth
 ```
 
-4. Now Execute torch-model-archiver command e.g.
+4. On your local machine execute torch-model-archiver command e.g.
 
 ```bash
 torch-model-archiver --model-name densenet161 --version 1.0 --model-file /home/model-server/examples/image_classifier/densenet_161/model.py --serialized-file /home/model-server/examples/image_classifier/densenet161-8d451a50.pth --export-path /home/model-server/model-store --extra-files /home/model-server/examples/image_classifier/index_to_name.json --handler image_classifier


### PR DESCRIPTION
* In step 1, user sets up a name for the container so just use it in step 2
* Step 3-4 aren't super clear that these commands need to be run locally. Can't run wget or curl on the docker instance without root access or changing the dockerfile
* pytorch/ needs to be added to container name otherwise it won't be found

This is purely a documentation change so below is N/A

## Description

Please include a summary of the feature or issue being fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #(issue)

## Type of change

- [ x] This change requires a documentation update
