### PR TITLE
updated java dependencies to java 16

### DIFF
--- a/ts_scripts/install_dependencies.py
+++ b/ts_scripts/install_dependencies.py
@@ -60,7 +60,7 @@ class Linux(Common):
         os.system(f"{self.sudo_cmd}apt-get update")
 
     def install_java(self):
-        os.system(f"{self.sudo_cmd}apt-get install -y openjdk-11-jdk")
+        os.system(f"{self.sudo_cmd}apt-get install -y openjdk-16-jdk-headless")
 
     def install_nodejs(self):
         python_path = Path(sys.executable).resolve()
@@ -93,9 +93,9 @@ class Darwin(Common):
 
         os.system("brew tap AdoptOpenJDK/openjdk")
         if out >= "2.7":
-            os.system("brew install --cask adoptopenjdk11")
+            os.system("brew install --cask adoptopenjdk16")
         else:
-            os.system("brew cask install adoptopenjdk11")
+            os.system("brew cask install adoptopenjdk16")
 
     def install_nodejs(self):
         os.system("brew unlink node")


### PR DESCRIPTION
JDK 16 is the highest version available on ubuntu and mac os x so updating installing dependencies

* Mac: https://github.com/AdoptOpenJDK/homebrew-openjdk
* Ubuntu: https://packages.ubuntu.com/hirsute/openjdk-16-jdk-headless

OS X version working fine locally, haven't tested the Ubuntu version yet