### PR TITLE
Updating HuggingFace example

### DIFF
--- a/examples/Huggingface_Transformers/Download_Transformer_models.py
+++ b/examples/Huggingface_Transformers/Download_Transformer_models.py
@@ -13,25 +13,24 @@ print('Transformers version',transformers.__version__)
 set_seed(1)
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
-def transformers_model_dowloader(mode,pretrained_model_name,num_labels,do_lower_case,max_length,torchscript):
+def transformers_model_dowloader(mode,pretrained_model_name,num_labels,max_length,torchscript):
     print("Download model and tokenizer", pretrained_model_name)
     #loading pre-trained model and tokenizer
     if mode== "sequence_classification":
         config = AutoConfig.from_pretrained(pretrained_model_name,num_labels=num_labels,torchscript=torchscript)
         model = AutoModelForSequenceClassification.from_pretrained(pretrained_model_name, config=config)
-        tokenizer = AutoTokenizer.from_pretrained(pretrained_model_name,do_lower_case=do_lower_case)
     elif mode== "question_answering":
         config = AutoConfig.from_pretrained(pretrained_model_name,torchscript=torchscript)
         model = AutoModelForQuestionAnswering.from_pretrained(pretrained_model_name,config=config)
-        tokenizer = AutoTokenizer.from_pretrained(pretrained_model_name,do_lower_case=do_lower_case)
     elif mode== "token_classification":
         config= AutoConfig.from_pretrained(pretrained_model_name,num_labels=num_labels,torchscript=torchscript)
         model = AutoModelForTokenClassification.from_pretrained(pretrained_model_name, config=config)
-        tokenizer = AutoTokenizer.from_pretrained(pretrained_model_name,do_lower_case=do_lower_case)
+    
+    tokenizer = AutoTokenizer.from_pretrained(pretrained_model_name)
 
-        # NOTE : for demonstration purposes, we do not go through the fine-tune processing here.
-        # A Fine_tunining process based on your needs can be added.
-        # An example of  Fine_tuned model has been provided in the README.
+    # NOTE : for demonstration purposes, we do not go through the fine-tune processing here.
+    # A Fine_tunining process based on your needs can be added.
+    # An example of  Fine_tuned model has been provided in the README.
 
     NEW_DIR = "./Transformer_model"
     try:
@@ -61,7 +60,6 @@ if __name__== "__main__":
     mode = settings["mode"]
     model_name = settings["model_name"]
     num_labels = int(settings["num_labels"])
-    do_lower_case = settings["do_lower_case"]
     max_length = settings["max_length"]
     save_mode = settings["save_mode"]
     if save_mode == "torchscript":
@@ -69,4 +67,4 @@ if __name__== "__main__":
     else:
         torchscript = False
 
-    transformers_model_dowloader(mode,model_name, num_labels,do_lower_case, max_length, torchscript)
+    transformers_model_dowloader(mode,model_name, num_labels, max_length, torchscript)

--- a/examples/Huggingface_Transformers/Transformer_handler_generalized.py
+++ b/examples/Huggingface_Transformers/Transformer_handler_generalized.py
@@ -71,14 +71,9 @@ class TransformersSeqClassifierHandler(BaseHandler, ABC):
             logger.warning("Missing the checkpoint or state_dict.")
 
         if any(fname for fname in os.listdir(model_dir) if fname.startswith("vocab.") and os.path.isfile(fname)):
-            self.tokenizer = AutoTokenizer.from_pretrained(
-                model_dir, do_lower_case=self.setup_config["do_lower_case"]
-            )
+            self.tokenizer = AutoTokenizer.from_pretrained(model_dir)
         else:
-            self.tokenizer = AutoTokenizer.from_pretrained(
-                self.setup_config["model_name"],
-                do_lower_case=self.setup_config["do_lower_case"],
-            )
+            self.tokenizer = AutoTokenizer.from_pretrained(self.setup_config["model_name"])
 
         self.model.to(self.device)
         self.model.eval()

--- a/examples/Huggingface_Transformers/setup_config.json
+++ b/examples/Huggingface_Transformers/setup_config.json
@@ -1,7 +1,6 @@
 {
  "model_name":"bert-base-uncased",
  "mode":"sequence_classification",
- "do_lower_case":"True",
  "num_labels":"2",
  "save_mode":"pretrained",
  "max_length":"150"


### PR DESCRIPTION
WIP

This PR is just to get the HF example working with transformers 4.6, I will create a separate PR to improve the tutorial. Depending on time I'll look at captum as well

Updated tokenizer - the new tokenizer takes in upper or lower casing with the model name not explicitly https://huggingface.co/transformers/model_doc/auto.html#autotokenizer


Before change logs: https://gist.github.com/msaroufim/87c6a3f3937958adfc00c2ea27570f0d
After change logs:

```
$ :~/serve/examples/Huggingface_Transformers/Transformer_model
config.json        special_tokens_map.json  tokenizer_config.json
pytorch_model.bin  tokenizer.json           vocab.txt
```


To repro
```
gh pr checkout 1063
pip install transformers
torch-model-archiver --model-name BERTSeqClassification --version 1.0 --serialized-file Transformer_model/pytorch_model.bin --handler ./Transformer_handler_generalized.py --extra-files "Transformer_model/config.json,./setup_config.json,./Seq_classification_artifacts/index_to_name.json"
torchserve --start --model-store model_store --models my_tc=BERTSeqClassification.mar
```

In a separate window

`curl -X POST http://127.0.0.1:8080/predictions/my_tc -T ./Seq_classification_artifacts/sample_text.txt`
