### PR TITLE
Ascii decode error when reading file using python inside docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -68,6 +68,7 @@ RUN pip install --no-cache-dir torchtext torchserve torch-model-archiver
 # Final image for production
 FROM ${BASE_IMAGE} AS runtime-image
 
+ENV LANG C.UTF-8
 ENV PYTHONUNBUFFERED TRUE
 
 RUN --mount=type=cache,target=/var/cache/apt \


### PR DESCRIPTION
## Description

When executing python script while opening file in read mode containing non-ascii chars give
```python
Traceback (most recent call last):
  File "src/data_exploration/data_explore.py", line 39, in <module>
    query = f.read()
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe4 in position 310: ordinal not in range(128)
```

Fixes https://github.com/pytorch/serve/issues/821

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Feature/Issue validation/testing

1. Build docker image
```bash
DOCKER_BUILDKIT=1 docker build --file Dockerfile --build-arg BASE_IMAGE=nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04 -t torchserve:gpu .
```

2. Read a file containing Japanese characters using python, No ascii decode error anymore
test.txt
```
# 左連接ID left context id
```
```bash
(base) ➜  docker git:(fix_821_ascii_decode_error) ✗ docker run --net=host -e AWS_DEFAULT_REGION=ap-northeast-1 -it torchserve:gpu bash
model-server@docker-desktop:~$ python
Python 3.6.9 (default, Jan 26 2021, 15:33:00) 
[GCC 8.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> open('test.txt').read()
'# 左連接ID left context id\n'
>>> 
```

- Logs

## Checklist:

- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] New and existing unit tests pass locally with these changes?
