### PR TITLE
binaries: Fix conda packaging process

### DIFF
--- a/binaries/build.py
+++ b/binaries/build.py
@@ -33,7 +33,7 @@ def build():
     # Build TS & MA on Conda if available
     conda_build_exit_code = 0
     if is_conda_env():
-        conda_build_exit_code = conda_build(ts_wheel_path, ma_wheel_path)
+        conda_build_exit_code = conda_build()
 
     # If any one of the steps fail, exit with error
     if ts_build_exit_code != 0:

--- a/binaries/conda/build_packages.py
+++ b/binaries/conda/build_packages.py
@@ -1,29 +1,34 @@
 import os
 import sys
 import argparse
+import subprocess
 
 conda_build_dir = os.path.dirname(os.path.abspath(__file__))
-REPO_ROOT = os.path.join(conda_build_dir, "..", "..")
+REPO_ROOT = subprocess.Popen(
+    ['git', 'rev-parse', '--show-toplevel'],
+    stdout=subprocess.PIPE
+).communicate()[0].rstrip().decode('utf-8')
 
-
-def conda_build(ts_wheel_path, ma_wheel_path):
+def conda_build():
     print("## Started torchserve and modelarchiver conda build")
-    print(f"## Using torchserve wheel: {ts_wheel_path}")
-    print(f"## Using model archiver wheel: {ma_wheel_path}")
 
     with open(os.path.join(REPO_ROOT, "ts", "version.txt")) as ts_vf:
         ts_version = ''.join(ts_vf.read().split())
     with open(os.path.join(REPO_ROOT, "model-archiver", "model_archiver", "version.txt")) as ma_vf:
         ma_version = ''.join(ma_vf.read().split())
+    with open(os.path.join(REPO_ROOT, "workflow-archiver", "workflow_archiver", "version.txt")) as ma_vf:
+        wa_version = ''.join(ma_vf.read().split())
 
     os.environ["TORCHSERVE_VERSION"] = ts_version
     os.environ["TORCH_MODEL_ARCHIVER_VERSION"] = ma_version
-
-    os.environ["TORCHSERVE_WHEEL"] = ts_wheel_path
-    os.environ["TORCH_MODEL_ARCHIVER_WHEEL"] = ma_wheel_path
+    os.environ["TORCH_WORKFLOW_ARCHIVER_VERSION"] = wa_version
+    os.environ["TORCHSERVE_ROOT_DIR"] = REPO_ROOT
 
     python_versions = ["3.6", "3.7", "3.8"]
-    packages = [os.path.join(conda_build_dir, "torchserve"), os.path.join(conda_build_dir, "torch-model-archiver")]
+    packages = [
+        os.path.join(conda_build_dir, pkg)
+        for pkg in ["torchserve", "torch-model-archiver", "torch-workflow-archiver"]
+    ]
 
     for pkg in packages:
         for pyv in python_versions:
@@ -39,8 +44,6 @@ def conda_build(ts_wheel_path, ma_wheel_path):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Conda Build for torchserve and torch-model-archiver")
-    parser.add_argument("--ts-wheel", type=str, required=True, help="torchserve wheel path")
-    parser.add_argument("--ma-wheel", type=str, required=True, help="torch-model-archiver wheel path")
     args = parser.parse_args()
 
-    conda_build(args.ts_wheel, args.ma_wheel)
+    conda_build()

--- a/binaries/conda/torch-model-archiver/build.bat
+++ b/binaries/conda/torch-model-archiver/build.bat
@@ -1,2 +1,0 @@
-pip install --no-deps "%TORCH_MODEL_ARCHIVER_WHEEL%"
-if errorlevel 1 exit 1

--- a/binaries/conda/torch-model-archiver/build.sh
+++ b/binaries/conda/torch-model-archiver/build.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-set -eou pipefail
-
-pip install --no-deps "${TORCH_MODEL_ARCHIVER_WHEEL}"

--- a/binaries/conda/torch-workflow-archiver/meta.yaml
+++ b/binaries/conda/torch-workflow-archiver/meta.yaml
@@ -1,9 +1,9 @@
 package:
-  name: torch-model-archiver
-  version: "{{ environ.get('TORCH_MODEL_ARCHIVER_VERSION') }}"
+  name: torch-workflow-archiver
+  version: "{{ environ.get('TORCH_WORKFLOW_ARCHIVER_VERSION') }}"
 
 source:
-  path: "{{ environ.get('TORCHSERVE_ROOT_DIR') }}/model-archiver"
+  path: "{{ environ.get('TORCHSERVE_ROOT_DIR') }}/workflow-archiver"
 
 requirements:
   build:
@@ -21,4 +21,4 @@ build:
 
 about:
   home: https://github.com/pytorch/serve
-  summary: 'Model serving on PyTorch'
+  summary: 'Workflow serving on PyTorch'

--- a/binaries/conda/torchserve/build.bat
+++ b/binaries/conda/torchserve/build.bat
@@ -1,2 +1,0 @@
-pip install --no-deps "%TORCHSERVE_WHEEL%"
-if errorlevel 1 exit 1

--- a/binaries/conda/torchserve/build.sh
+++ b/binaries/conda/torchserve/build.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-set -eou pipefail
-
-pip install --no-deps "${TORCHSERVE_WHEEL}"

--- a/binaries/conda/torchserve/meta.yaml
+++ b/binaries/conda/torchserve/meta.yaml
@@ -2,6 +2,9 @@ package:
   name: torchserve
   version: "{{ environ.get('TORCHSERVE_VERSION') }}"
 
+source:
+  path: "{{ environ.get('TORCHSERVE_ROOT_DIR') }}"
+
 requirements:
   build:
     - python
@@ -14,9 +17,7 @@ requirements:
     - future
 
 build:
-  noarch: generic
-  script_env:
-    - TORCHSERVE_WHEEL
+  script: "{{ PYTHON }} -m pip install . -vv"
 
 about:
   home: https://github.com/pytorch/serve


### PR DESCRIPTION
Conda packages weren't actually getting created correctly, this should
resolve that issue by creating conda packages directly instead of basing
them on previously built wheel packages

Tested with:

```bash
❯ docker run --rm -i continuumio/miniconda3 <<-EOF
conda install -y python=3.7
conda install -y -c pytorch-test torch-model-archiver torch-workflow-archiver torchserve
EOF
...
## Package Plan ##

  environment location: /opt/conda

  added / updated specs:
    - torch-model-archiver
    - torch-workflow-archiver
    - torchserve


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    freetype-2.10.4            |       h5ab3b9f_0         596 KB
    future-0.18.2              |           py37_1         631 KB
    jpeg-9b                    |       h024ee3a_2         214 KB
    lcms2-2.12                 |       h3be6417_0         312 KB
    libpng-1.6.37              |       hbc83047_0         278 KB
    libtiff-4.1.0              |       h2733197_1         449 KB
    lz4-c-1.9.3                |       h2531618_0         186 KB
    olefile-0.46               |           py37_0          50 KB
    pillow-8.2.0               |   py37he98fc37_0         622 KB
    psutil-5.8.0               |   py37h27cfd23_1         329 KB
    torch-model-archiver-0.4.0 |           py37_0          23 KB  pytorch-test
    torch-workflow-archiver-0.1.0|           py37_0          20 KB  pytorch-test
    torchserve-0.4.0           |           py37_0        17.3 MB  pytorch-test
    zstd-1.4.9                 |       haebb681_0         480 KB
    ------------------------------------------------------------
                                           Total:        21.4 MB
```

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

