### PR TITLE
Update docs/conf.py

### DIFF
--- a/.github/workflows/doc-automation.yml
+++ b/.github/workflows/doc-automation.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.8]
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -151,7 +151,7 @@ def setup(app):
 
     # In Sphinx 1.8 it was renamed to `add_css_file`, 1.7 and prior it is
     # `add_stylesheet` (deprecated in 1.8).
-    add_css = getattr(app, 'add_css_file', getattr(app, 'add_stylesheet'))
+    add_css = getattr(app, 'add_css_file')
     for css_file in html_css_files:
         add_css(css_file)
 


### PR DESCRIPTION
## Problem
Github Actions CI broken for docs
https://github.com/pytorch/serve/runs/2768376058?check_suite_focus=true where add_stylesheet is no longer found

## Context
Any update to the /docs folder will trigger an updated CI job

## Test plan
To test I forked serve, made the updates and checked the CI output
1. Click fork button
2. Make updates in PR
3. Enable Github Actions in forked repo
4. Check Github Actions tab https://github.com/msaroufim/serve/runs/2776573236?check_suite_focus=true

![Screen Shot 2021-06-08 at 11 02 29 AM](https://user-images.githubusercontent.com/3282513/121234849-05c69400-c849-11eb-95cd-7a44e05545c1.png)

![Screen Shot 2021-06-08 at 11 02 53 AM](https://user-images.githubusercontent.com/3282513/121234905-14ad4680-c849-11eb-888e-51861689b507.png)
