### PR TITLE
Update Pillow to 8.2.0 for security

### DIFF
--- a/kubernetes/kfserving/image_transformer/setup.py
+++ b/kubernetes/kfserving/image_transformer/setup.py
@@ -39,7 +39,7 @@ setup(
         "numpy>=1.16.3",
         "kubernetes >= 9.0.0",
         "torchvision>=0.4.0",
-        "pillow==8.1.1"
+        "pillow==8.2.0"
     ],
     tests_require=tests_require,
     extras_require={'test': tests_require}


### PR DESCRIPTION
+GitHub has detected that a package defined in the kubernetes/kfserving/image_transformer/setup.py file of the pytorch/serve repository contains a security vulnerability.

+Package name: Pillow
+Affected versions: >= 2.4.0, < 8.2.0
+Fixed in version: 8.2.0
+Severity: CRITICAL
+
+Identifier(s):
+GHSA-77gc-v2xv-rvvh
+CVE-2021-25287
+
+Reference(s):
+https://nvd.nist.gov/vuln/detail/CVE-2021-25287
+https://github.com/advisories/GHSA-77gc-v2xv-rvvh