### PR TITLE
fixing error in comment in text_to_speech_synthesizer handler

### DIFF
--- a/examples/text_to_speech_synthesizer/waveglow_handler.py
+++ b/examples/text_to_speech_synthesizer/waveglow_handler.py
@@ -74,7 +74,9 @@ class WaveGlowSpeechSynthesizer(BaseHandler):
 
     def preprocess(self, data):
         """
-         Scales, crops, and normalizes a PIL image for a MNIST model,
+         converts text to sequence of IDs using tacatron2 text_to_sequence
+         with english cleaners to transform text and standardize input
+         (ex: lowercasing, expanding abbreviations and numbers, etc.)
          returns an Numpy array
         """
         text = data[0].get("data")


### PR DESCRIPTION
## Description

In the text_to_speech sample, the handler was likely copied from the image reco example first, so there were still comments in the preprocess function that indicated image processing, instead of text processing (which was actually happening). This fixes the comments. No change funcitonally. 

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)
This is a surface level change to comments that were incorrect, no functional change required so did not run tests.

## Feature/Issue validation/testing

Please describe the tests [UT/IT] that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced. 
Please also list any relevant details for your test configuration.

N/A: This is a surface level change to comments, no functional change required so did not run tests.

## Checklist:

N/A: This is a surface level change to comments, no functional change required so did not run tests.
