### PR TITLE
optimize frontend build performance

### DIFF
--- a/frontend/server/src/test/java/org/pytorch/serve/ModelServerTest.java
+++ b/frontend/server/src/test/java/org/pytorch/serve/ModelServerTest.java
@@ -1020,7 +1020,11 @@ public class ModelServerTest {
         Assert.assertEquals(TestUtils.getHttpStatus(), HttpResponseStatus.INSUFFICIENT_STORAGE);
         channel.close().sync();
         channel = TestUtils.connect(ConnectorType.MANAGEMENT_CONNECTOR, configManager);
+        TestUtils.setResult(null);
+        TestUtils.setLatch(new CountDownLatch(1));
         TestUtils.unregisterModel(channel, "memory_error", null, false);
+        TestUtils.getLatch().await();
+        channel.close().sync();
     }
 
     @Test(

--- a/frontend/server/src/test/java/org/pytorch/serve/ModelServerTest.java
+++ b/frontend/server/src/test/java/org/pytorch/serve/ModelServerTest.java
@@ -1020,7 +1020,7 @@ public class ModelServerTest {
         Assert.assertEquals(TestUtils.getHttpStatus(), HttpResponseStatus.INSUFFICIENT_STORAGE);
         channel.close().sync();
         channel = TestUtils.connect(ConnectorType.MANAGEMENT_CONNECTOR, configManager);
-        TestUtils.unregisterModel(channel, "memory_error", null, true);
+        TestUtils.unregisterModel(channel, "memory_error", null, false);
     }
 
     @Test(
@@ -1060,7 +1060,7 @@ public class ModelServerTest {
         TestUtils.setLatch(new CountDownLatch(1));
         Assert.assertNotNull(channel);
 
-        TestUtils.unregisterModel(channel, "pred-err", null, true);
+        TestUtils.unregisterModel(channel, "pred-err", null, false);
         TestUtils.getLatch().await();
         Assert.assertEquals(TestUtils.getHttpStatus(), HttpResponseStatus.OK);
     }
@@ -1578,8 +1578,11 @@ public class ModelServerTest {
     public void testUnregisterModelVersionNotFound() throws InterruptedException {
         Channel channel = TestUtils.connect(ConnectorType.MANAGEMENT_CONNECTOR, configManager);
         Assert.assertNotNull(channel);
+        TestUtils.setResult(null);
+        TestUtils.setLatch(new CountDownLatch(1));
 
-        TestUtils.unregisterModel(channel, "noopversioned", "1.3.1", true);
+        TestUtils.unregisterModel(channel, "noopversioned", "1.3.1", false);
+        TestUtils.getLatch().await();
 
         ErrorResponse resp = JsonUtils.GSON.fromJson(TestUtils.getResult(), ErrorResponse.class);
         Assert.assertEquals(resp.getCode(), HttpResponseStatus.NOT_FOUND.code());
@@ -1593,18 +1596,26 @@ public class ModelServerTest {
     public void testUnregisterModelTimeout()
             throws InterruptedException, NoSuchFieldException, IllegalAccessException {
         Channel channel = TestUtils.connect(ConnectorType.MANAGEMENT_CONNECTOR, configManager);
+        Assert.assertNotNull(channel);
+        TestUtils.setResult(null);
+        TestUtils.setLatch(new CountDownLatch(1));
         TestUtils.setConfiguration(configManager, "unregister_model_timeout", "0");
 
-        TestUtils.unregisterModel(channel, "noop_v1.0", null, true);
+        TestUtils.unregisterModel(channel, "noop_v1.0", null, false);
+        TestUtils.getLatch().await();
 
         ErrorResponse resp = JsonUtils.GSON.fromJson(TestUtils.getResult(), ErrorResponse.class);
         Assert.assertEquals(resp.getCode(), HttpResponseStatus.REQUEST_TIMEOUT.code());
         Assert.assertEquals(resp.getMessage(), "Timed out while cleaning resources: noop_v1.0");
 
         channel = TestUtils.connect(ConnectorType.MANAGEMENT_CONNECTOR, configManager);
+        Assert.assertNotNull(channel);
+        TestUtils.setResult(null);
+        TestUtils.setLatch(new CountDownLatch(1));
         TestUtils.setConfiguration(configManager, "unregister_model_timeout", "120");
 
-        TestUtils.unregisterModel(channel, "noop_v1.0", null, true);
+        TestUtils.unregisterModel(channel, "noop_v1.0", null, false);
+        TestUtils.getLatch().await();
         Assert.assertEquals(TestUtils.getHttpStatus(), HttpResponseStatus.OK);
     }
 

--- a/frontend/server/src/test/java/org/pytorch/serve/SnapshotTest.java
+++ b/frontend/server/src/test/java/org/pytorch/serve/SnapshotTest.java
@@ -240,8 +240,12 @@ public class SnapshotTest {
         TestUtils.setResult(null);
         TestUtils.setLatch(new CountDownLatch(1));
         TestUtils.registerModel(managementChannel, "noop.mar", "noop_zero", false, false);
+        TestUtils.getLatch().await();
         waitForSnapshot(2000);
-        TestUtils.unregisterModel(managementChannel, "noop_zero", null, true);
+
+        TestUtils.setLatch(new CountDownLatch(1));
+        TestUtils.unregisterModel(managementChannel, "noop_zero", null, false);
+        TestUtils.getLatch().await();
         validateSnapshot("snapshot9.cfg");
         waitForSnapshot();
     }

--- a/frontend/server/src/test/java/org/pytorch/serve/WorkflowTest.java
+++ b/frontend/server/src/test/java/org/pytorch/serve/WorkflowTest.java
@@ -454,7 +454,7 @@ public class WorkflowTest {
         TestUtils.setLatch(new CountDownLatch(1));
         Assert.assertNotNull(channel);
 
-        TestUtils.unregisterWorkflow(channel, "pred-err", true);
+        TestUtils.unregisterWorkflow(channel, "pred-err", false);
         TestUtils.getLatch().await();
         Assert.assertEquals(TestUtils.getHttpStatus(), HttpResponseStatus.OK);
     }


### PR DESCRIPTION
## Description

The frontend test unregistermodel uses sync mode. It takes about 5 min for this action. The fixing is using async mode to call unregistermodel and also guarantees the thread is terminated via countlatch.

Fixes #(issue)
#1306 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the tests [UT/IT] that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced. 
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

reduce frontend build from 20min to 5min 32s
- UT/IT execution results

- Logs

## Checklist:

- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] New and existing unit tests pass locally with these changes?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
