### PR TITLE
Skipping mmf pytest as it doesn't support PT 1.10 

### DIFF
--- a/examples/MMF-activity-recognition/README.md
+++ b/examples/MMF-activity-recognition/README.md
@@ -29,6 +29,8 @@ If you installed using pip, then you need install Pyav :
 
 MMF currenly is using Transformers 3.4.0, in case you have other version installed in your enviroment, this would be the best instead of installing it directly, add the MMF Github and 'av', in the requirements.txt and pass it to the model archiver using -r flag. You can read more about serving models with thrid party dependencies [here](https://github.com/pytorch/serve/tree/master/docs/use_cases.md#serve-custom-models-with-third-party-dependency).
 
+***Note, MMF currenly does not support Pytorch 1.10, please make sure you are using Pytorch 1.9***
+
 #### Getting started on Serving
 
 To make the mar file, we will use model_archiver as follows.

--- a/test/pytest/test_handler.py
+++ b/test/pytest/test_handler.py
@@ -4,6 +4,7 @@ import json
 import test_utils
 import numpy as np
 import ast 
+import pytest
 REPO_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../")
 snapshot_file_kf = os.path.join(REPO_ROOT,"test/config_kf.properties")
 snapshot_file_tf = os.path.join(REPO_ROOT,"test/config_ts.properties")
@@ -248,7 +249,8 @@ def test_huggingface_bert_batch_inference():
     ## Assert that 2 responses are returned from the same batch
     assert response == 'Not AcceptedNot Accepted'
     test_utils.unregister_model('BERTSeqClassification')
-    
+
+@pytest.mark.skip(reason="MMF doesn't support PT 1.10 yet")
 def test_MMF_activity_recognition_model_register_and_inference_on_valid_model():
   
     test_utils.start_torchserve(snapshot_file = snapshot_file_tf)


### PR DESCRIPTION
## Description

This PR skips the MMF pytest as it doesn't support PT 1.10 yet and adds the note to the doc.


- Logs
https://gist.github.com/HamidShojanazeri/49ac7a837e8b2ae8b548d1bd70191a8d
## Checklist:

- [ X] Have you added tests that prove your fix is effective or that this feature works?
- [ ] New and existing unit tests pass locally with these changes?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ X] Have you made corresponding changes to the documentation?
