### PR TITLE
Kfserving Bert readme update

### DIFF
--- a/kubernetes/kfserving/Huggingface_readme.md
+++ b/kubernetes/kfserving/Huggingface_readme.md
@@ -36,6 +36,7 @@ NUM_WORKERS=1
 number_of_netty_threads=4
 job_queue_size=10
 model_store=/mnt/models/model-store
+model_snapshot={"name":"startup.cfg","modelCount":1,"models":{"BERTSeqClassification":{"1.0":{"defaultVersion":true,"marName":"BERTSeqClassification.mar","minWorkers":1,"maxWorkers":5,"batchSize":1,"maxBatchDelay":5000,"responseTimeout":120}}}}
 ```
 
 * Set service envelope environment variable
@@ -45,18 +46,16 @@ The
 
 * start Torchserve by invoking the below command:
 ```
-torchserve --start --model-store model_store --ncs --models bert=BERTSeqClassification.mar
+torchserve --start --model-store model_store
 
 ```
+## Start KFServing (Local testing)
 
-## Model Register for KFServing:
-
-Hit the below curl request to register the model
+Run the following commmand in a separate terminal
 
 ```
-  curl -X POST "localhost:8081/models?model_name=bert&url=BERTSeqClassification.mar&batch_size=4&max_batch_delay=5000&initial_workers=3&synchronous=true"
+python kfserving_wrapper/__main__.py
 ```
-Please note that the batch size, the initial worker and synchronous values can be changed at your discretion and they are optional.
 
 ## Request and Response
 
@@ -64,7 +63,7 @@ Please note that the batch size, the initial worker and synchronous values can b
 
 When the curl request is made, ensure that the request is made inisde of the serve folder.
 ```
-curl -H "Content-Type: application/json" --data @kubernetes/kfserving/kf_request_json/bert.json http://127.0.0.1:8085/v1/models/bert:predict
+curl -H "Content-Type: application/json" --data @kubernetes/kfserving/kf_request_json/bert.json http://127.0.0.1:8080/v1/models/bert:predict
 ```
 
 The Prediction response is as below :
@@ -81,7 +80,7 @@ The Prediction response is as below :
 Torchserve supports KFServing Captum Explanations for Eager Models only.
 
 ```bash
-curl -H "Content-Type: application/json" --data @kubernetes/kfserving/kf_request_json/bert.json http://127.0.0.1:8085/v1/models/bert:explain
+curl -H "Content-Type: application/json" --data @kubernetes/kfserving/kf_request_json/bert.json http://127.0.0.1:8080/v1/models/bert:explain
 ```
 
 The Explanation response is as below :

--- a/kubernetes/kfserving/Huggingface_readme.md
+++ b/kubernetes/kfserving/Huggingface_readme.md
@@ -46,7 +46,7 @@ The
 
 * start Torchserve by invoking the below command:
 ```
-torchserve --start --model-store model_store
+torchserve --start --ts-config /mnt/models/config/config.properties
 
 ```
 ## Start KFServing (Local testing)

--- a/kubernetes/kfserving/mnist_readme.md
+++ b/kubernetes/kfserving/mnist_readme.md
@@ -19,7 +19,8 @@ management_address=http://127.0.0.0:8081
 number_of_netty_threads=4
 enable_envvars_config=true
 job_queue_size=10
-model_store=model-store
+model_store=/mnt/models/model-store
+model_snapshot={"name":"startup.cfg","modelCount":1,"models":{"mnist":{"1.0":{"defaultVersion":true,"marName":"mnist.mar","minWorkers":1,"maxWorkers":5,"batchSize":1,"maxBatchDelay":5000,"responseTimeout":120}}}}
 ```
 
 * Set service envelope environment variable
@@ -30,18 +31,17 @@ KFServing v1 and v2 protocols
 
 * start Torchserve by invoking the below command:
 ```
-torchserve --start --model-store model_store --ncs --models mnist=mnist.mar
+torchserve --start --ts-config /mnt/models/config/config.properties
 
 ```
 
-## Model Register for KFServing:
+## Start KFServing (Local testing)
 
-Hit the below curl request to register the model
+Run the following commmand in a separate terminal
 
 ```
-curl -X POST "localhost:8081/models?model_name=mnist&url=mnist.mar&batch_size=4&max_batch_delay=5000&initial_workers=3&synchronous=true"
+python kfserving_wrapper/__main__.py
 ```
-Please note that the batch size, the initial worker and synchronous values can be changed at your discretion and they are optional.
 
 ## Request and Response
 
@@ -55,7 +55,7 @@ python img2bytearray.py <imagefile>
 
 When the curl request is made, ensure that the request is made inisde of the serve folder.
 ```bash
- curl -H "Content-Type: application/json" --data @kubernetes/kfserving/kf_request_json/mnist.json http://127.0.0.1:8085/v1/models/mnist:predict
+ curl -H "Content-Type: application/json" --data @kubernetes/kfserving/kf_request_json/mnist.json http://127.0.0.1:8080/v1/models/mnist:predict
 ```
 The default Inference Port for Torchserve is 8080, while for KFServing it is 8085
 
@@ -75,7 +75,7 @@ The Prediction response is as below :
 Torchserve supports KFServing Captum Explanations for Eager Models only.
 
 ```bash
- curl -H "Content-Type: application/json" --data @kubernetes/kfserving/kf_request_json/mnist.json http://127.0.0.1:8085/v1/models/mnist:explain
+ curl -H "Content-Type: application/json" --data @kubernetes/kfserving/kf_request_json/mnist.json http://127.0.0.1:8080/v1/models/mnist:explain
 ```
 
 The Explanation response is as below :

--- a/kubernetes/kfserving/text_classifier_readme.md
+++ b/kubernetes/kfserving/text_classifier_readme.md
@@ -29,7 +29,8 @@ management_address=http://127.0.0.0:8081
 number_of_netty_threads=4
 enable_envvars_config=true
 job_queue_size=10
-model_store=model-store
+model_store=/mnt/models/model-store
+model_snapshot={"name":"startup.cfg","modelCount":1,"models":{"my_text_classifier":{"1.0":{"defaultVersion":true,"marName":"my_text_classifier.mar","minWorkers":1,"maxWorkers":5,"batchSize":1,"maxBatchDelay":5000,"responseTimeout":120}}}}
 ```
 
 * Set service envelope environment variable
@@ -40,18 +41,17 @@ KFServing v1 and v2 protocols
 
 * start Torchserve by invoking the below command:
 ```
-torchserve --start --model-store model_store --ncs --models my_tc=my_text_classifier.mar
+torchserve --start --ts-config /mnt/models/config/config.properties
 
 ```
 
-## Model Register for KFServing:
+## Start KFServing (Local testing)
 
-Hit the below curl request to register the model
+Run the following commmand in a separate terminal
 
 ```
-curl -X POST "localhost:8081/models?model_name=my_tc&url=my_text_classifier.mar&batch_size=4&max_batch_delay=5000&initial_workers=3&synchronous=true"
+python kfserving_wrapper/__main__.py
 ```
-Please note that the batch size, the initial worker and synchronous values can be changed at your discretion and they are optional.
 
 ## Request and Response
 
@@ -59,7 +59,7 @@ Please note that the batch size, the initial worker and synchronous values can b
 When the curl request is made, ensure that the request is made inisde of the serve folder.
 
 ```bash
- curl -H "Content-Type: application/json" --data @kubernetes/kfserving/kf_request_json/text_classifier.json http://127.0.0.1:8085/v1/models/my_tc:predict
+ curl -H "Content-Type: application/json" --data @kubernetes/kfserving/kf_request_json/text_classifier.json http://127.0.0.1:8080/v1/models/my_text_classifier:predict
 ```
 
 
@@ -83,7 +83,7 @@ The Prediction response is as below :
 Torchserve supports KFServing Captum Explanations for Eager Models only.
 
 ```bash
- curl -H "Content-Type: application/json" --data @kubernetes/kfserving/kf_request_json/text_classifier.json http://127.0.0.1:8085/v1/models/my_tc:explain
+ curl -H "Content-Type: application/json" --data @kubernetes/kfserving/kf_request_json/text_classifier.json http://127.0.0.1:8080/v1/models/my_text_classifier:explain
 ```
 
 
@@ -140,7 +140,7 @@ But the batch size should still be set at 1, when we register the model. Explain
 Server Health check API returns the model's state for inference
 
 ```bash
-curl -X GET "http://127.0.0.1:8081/v1/models/my_tc"
+curl -X GET "http://127.0.0.1:8081/v1/models/my_text_classifier"
 ```
 
 The response is as below:


### PR DESCRIPTION
Signed-off-by: Shrinath Suresh <shrinath@ideas2it.com>

## Description

Updating the following instructions in KFServing readme

1. Torserve start command has `--models bert=BERTSeqClassification.mar` argument which is incorrect. KFserving expects the model snapshot to be present in config.properties - Added model_snapshot entry
2. Separate model registration step is not needed, as the model will get registered from snapshot.
3. KFserving inference should be run on port `8080`.  When the example is testing with torchserve alone, it should be tested with `8085`. In this usecase, the inference curl should use `8080`
4. For the users testing the code locally, kfserving start command is missing. Added the instruction for the same.

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the tests [UT/IT] that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced. 
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- UT/IT execution results
Existing UTs

- Logs

## Checklist:

- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] New and existing unit tests pass locally with these changes?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?
