### PR TITLE
Remove logs from warm up period before calculating stats and unbreak bechmark-ab.py

### DIFF
--- a/benchmarks/benchmark-ab.py
+++ b/benchmarks/benchmark-ab.py
@@ -37,6 +37,7 @@ TMP_DIR = default_ab_params['report_location']
 execution_params = default_ab_params.copy()
 result_file = os.path.join(TMP_DIR, "benchmark/result.txt")
 metric_log = os.path.join(TMP_DIR, "benchmark/logs/model_metrics.log")
+warm_up_lines = None
 
 
 def json_provider(file_path, cmd_name):
@@ -135,6 +136,9 @@ def warm_up():
              f"{execution_params['content_type']} {execution_params['inference_url']}/{execution_params['inference_model_url']} > {result_file}"
     
     execute(ab_cmd, wait=True)
+
+    global warm_up_lines
+    warm_up_lines = sum(1 for _ in open(metric_log))
 
 
 def run_benchmark():
@@ -290,6 +294,10 @@ metrics = {"predict.txt": "PredictionTime",
 def extract_metrics():
     with open(metric_log) as f:
         lines = f.readlines()
+
+    if warm_up_lines:
+        click.secho(f'Dropping {warm_up_lines} warmup lines from log', fg='green')
+        lines = lines[warm_up_lines:]
 
     for k, v in metrics.items():
         all_lines = []

--- a/benchmarks/benchmark-ab.py
+++ b/benchmarks/benchmark-ab.py
@@ -30,13 +30,13 @@ default_ab_params = {'url': "https://torchserve.pytorch.org/mar_files/resnet-18.
                      'backend_profiling': False,
                      'config_properties': 'config.properties',
                      'inference_model_url': 'predictions/benchmark',
-                     'report_location': tempfile.gettempdir()
+                     'report_location': tempfile.gettempdir(),
+                     'tmp_dir': tempfile.gettempdir(),
                      }
                      
-TMP_DIR = default_ab_params['report_location']
 execution_params = default_ab_params.copy()
-result_file = os.path.join(TMP_DIR, "benchmark/result.txt")
-metric_log = os.path.join(TMP_DIR, "benchmark/logs/model_metrics.log")
+result_file = os.path.join(execution_params['tmp_dir'], "benchmark/result.txt")
+metric_log = os.path.join(execution_params['tmp_dir'], "benchmark/logs/model_metrics.log")
 
 
 def json_provider(file_path, cmd_name):
@@ -67,11 +67,15 @@ def json_provider(file_path, cmd_name):
               help='config.properties path, Default config.properties')
 @click.option('--inference_model_url', '-imu', default='predictions/benchmark',
               help='Inference function url - can be either for predictions or explanations. Default predictions/benchmark')
+@click.option('--report_location', '-rl', default=tempfile.gettempdir(),
+              help=f'Target location of benchmark report. Default {tempfile.gettempdir()}')
+@click.option('--tmp_dir', '-td', default=tempfile.gettempdir(),
+              help=f'Location for temporal files. Default {tempfile.gettempdir()}')
 
 @click_config_file.configuration_option(provider=json_provider, implicit=False,
                                         help="Read configuration from a JSON file")
 def benchmark(test_plan, url, gpus, exec_env, concurrency, requests, batch_size, batch_delay, input, workers,
-              content_type, image, docker_runtime, backend_profiling, config_properties, inference_model_url, report_location):
+              content_type, image, docker_runtime, backend_profiling, config_properties, inference_model_url, report_location, tmp_dir):
     input_params = {'url': url,
                     'gpus': gpus,
                     'exec_env': exec_env,
@@ -87,7 +91,8 @@ def benchmark(test_plan, url, gpus, exec_env, concurrency, requests, batch_size,
                     'backend_profiling': backend_profiling,
                     'config_properties': config_properties,
                     'inference_model_url': inference_model_url,
-                    'report_location': report_location
+                    'report_location': report_location,
+                    'tmp_dir': tmp_dir,
                     }
 
     # set ab params
@@ -131,7 +136,7 @@ def warm_up():
     register_model()
 
     click.secho("\n\nExecuting warm-up ...", fg='green')
-    ab_cmd = f"ab -c {execution_params['concurrency']}  -n {execution_params['requests']/10} -k -p {TMP_DIR}/benchmark/input -T " \
+    ab_cmd = f"ab -c {execution_params['concurrency']}  -n {execution_params['requests']/10} -k -p {execution_params['tmp_dir']}/benchmark/input -T " \
              f"{execution_params['content_type']} {execution_params['inference_url']}/{execution_params['inference_model_url']} > {result_file}"
     
     execute(ab_cmd, wait=True)
@@ -143,7 +148,7 @@ def warm_up():
 
 def run_benchmark():
     click.secho("\n\nExecuting inference performance tests ...", fg='green')
-    ab_cmd = f"ab -c {execution_params['concurrency']}  -n {execution_params['requests']} -k -p {TMP_DIR}/benchmark/input -T " \
+    ab_cmd = f"ab -c {execution_params['concurrency']}  -n {execution_params['requests']} -k -p {execution_params['tmp_dir']}/benchmark/input -T " \
              f"{execution_params['content_type']} {execution_params['inference_url']}/{execution_params['inference_model_url']} > {result_file}"
     
     execute(ab_cmd, wait=True)
@@ -191,8 +196,8 @@ def local_torserve_start():
     click.secho("*Setting up model store...", fg='green')
     prepare_local_dependency()
     click.secho("*Starting local Torchserve instance...", fg='green')
-    execute(f"torchserve --start --model-store {TMP_DIR}/model_store "
-            f"--ts-config {TMP_DIR}/benchmark/conf/{execution_params['config_properties_name']} > {TMP_DIR}/benchmark/logs/model_metrics.log")
+    execute(f"torchserve --start --model-store {execution_params['tmp_dir']}/model_store "
+            f"--ts-config {execution_params['tmp_dir']}/benchmark/conf/{execution_params['config_properties_name']} > {execution_params['tmp_dir']}/benchmark/logs/model_metrics.log")
     time.sleep(3)
 
 
@@ -223,7 +228,7 @@ def docker_torchserve_start():
     inference_port = urlparse(execution_params['inference_url']).port
     management_port = urlparse(execution_params['management_url']).port
     docker_run_cmd = f"docker run {execution_params['docker_runtime']} {backend_profiling} --name ts --user root -p {inference_port}:{inference_port} -p {management_port}:{management_port} " \
-                     f"-v {TMP_DIR}:/tmp {enable_gpu} -itd {docker_image} " \
+                     f"-v {execution_params['tmp_dir']}:/tmp {enable_gpu} -itd {docker_image} " \
                      f"\"torchserve --start --model-store /home/model-server/model-store " \
                          f"--ts-config /tmp/benchmark/conf/{execution_params['config_properties_name']} > /tmp/benchmark/logs/model_metrics.log\""
     execute(docker_run_cmd, wait=True)
@@ -231,8 +236,8 @@ def docker_torchserve_start():
 
 
 def prepare_local_dependency():
-    shutil.rmtree(os.path.join(TMP_DIR, 'model_store/'), ignore_errors=True)
-    os.makedirs(os.path.join(TMP_DIR, "model_store/"), exist_ok=True)
+    shutil.rmtree(os.path.join(execution_params['tmp_dir'], 'model_store/'), ignore_errors=True)
+    os.makedirs(os.path.join(execution_params['tmp_dir'], "model_store/"), exist_ok=True)
     prepare_common_dependency()
 
 
@@ -242,12 +247,14 @@ def prepare_docker_dependency():
 
 def prepare_common_dependency():
     input = execution_params['input']
-    shutil.rmtree(os.path.join(TMP_DIR, "benchmark"), ignore_errors=True)
-    os.makedirs(os.path.join(TMP_DIR, "benchmark/conf"), exist_ok=True)
-    os.makedirs(os.path.join(TMP_DIR, "benchmark/logs"), exist_ok=True)
+    shutil.rmtree(os.path.join(execution_params['tmp_dir'], "benchmark"), ignore_errors=True)
+    shutil.rmtree(os.path.join(execution_params['report_location'], "benchmark"), ignore_errors=True)
+    os.makedirs(os.path.join(execution_params['tmp_dir'], "benchmark/conf"), exist_ok=True)
+    os.makedirs(os.path.join(execution_params['tmp_dir'], "benchmark/logs"), exist_ok=True)
+    os.makedirs(os.path.join(execution_params['report_location'], "benchmark"), exist_ok=True)
 
-    shutil.copy(execution_params['config_properties'], os.path.join(TMP_DIR, 'benchmark/conf/'))
-    shutil.copyfile(input, os.path.join(TMP_DIR, 'benchmark/input'))
+    shutil.copy(execution_params['config_properties'], os.path.join(execution_params['tmp_dir'], 'benchmark/conf/'))
+    shutil.copyfile(input, os.path.join(execution_params['tmp_dir'], 'benchmark/input'))
 
 
 
@@ -276,7 +283,7 @@ def update_exec_params(input_param):
     getAPIS()
 
             
-def generate_report(warm_up_lines=None):
+def generate_report(warm_up_lines):
     click.secho("\n\nGenerating Reports...", fg='green')
     extract_metrics(warm_up_lines=warm_up_lines)
     generate_csv_output()
@@ -291,13 +298,12 @@ metrics = {"predict.txt": "PredictionTime",
            "worker_thread.txt": "WorkerThreadTime"}
 
 
-def extract_metrics(warm_up_lines=None):
+def extract_metrics(warm_up_lines):
     with open(metric_log) as f:
         lines = f.readlines()
 
-    if warm_up_lines:
-        click.secho(f'Dropping {warm_up_lines} warmup lines from log', fg='green')
-        lines = lines[warm_up_lines:]
+    click.secho(f'Dropping {warm_up_lines} warmup lines from log', fg='green')
+    lines = lines[warm_up_lines:]
 
     for k, v in metrics.items():
         all_lines = []
@@ -306,7 +312,7 @@ def extract_metrics(warm_up_lines=None):
             if pattern.search(line):
                 all_lines.append(line.split("|")[0].split(':')[3].strip())
 
-        out_fname = f'{TMP_DIR}/benchmark/{k}'
+        out_fname = os.path.join(*(execution_params['tmp_dir'], 'benchmark', k))
         click.secho(f"\nWriting extracted {v} metrics to {out_fname} ", fg='green')
         with open(out_fname, 'w') as outf:
             all_lines = map(lambda x: x + '\n', all_lines)
@@ -323,7 +329,7 @@ def generate_csv_output():
     click.secho(f"Saving benchmark results to {execution_params['report_location']}")
 
     artifacts = {}
-    with open(f"{execution_params['report_location']}/benchmark/result.txt") as f:
+    with open(result_file) as f:
         data = f.readlines()
 
     artifacts['Benchmark'] = "AB"
@@ -341,7 +347,7 @@ def generate_csv_output():
     artifacts['TS latency mean'] = extract_entity(data, 'Time per request:.*mean\)', -3)
     artifacts['TS error rate'] = int(artifacts['TS failed requests']) / execution_params['requests'] * 100
 
-    with open(os.path.join(execution_params['report_location'], 'benchmark/predict.txt')) as f:
+    with open(os.path.join(execution_params['tmp_dir'], 'benchmark/predict.txt')) as f:
         lines = f.readlines()
         lines.sort(key=float)
         artifacts['Model_p50'] = lines[line50].strip()
@@ -349,7 +355,7 @@ def generate_csv_output():
         artifacts['Model_p99'] = lines[line99].strip()
 
     for m in metrics:
-        df = pd.read_csv(f"{execution_params['report_location']}/benchmark/{m}", header=None, names=['data'])
+        df = pd.read_csv(os.path.join(*(execution_params['tmp_dir'], 'benchmark', m)), header=None, names=['data'])
         artifacts[m.split('.txt')[0] + "_mean"] = df['data'].values.mean().round(2)
 
     with open(os.path.join(execution_params['report_location'], 'benchmark/ab_report.csv'), 'w') as csv_file:
@@ -369,7 +375,7 @@ def extract_entity(data, pattern, index, delim=" "):
 
 def generate_latency_graph():
     click.secho("*Preparing graphs...", fg='green')
-    df = pd.read_csv(os.path.join(execution_params['report_location'], 'benchmark/predict.txt'), header=None, names=['latency'])
+    df = pd.read_csv(os.path.join(execution_params['tmp_dir'], 'benchmark/predict.txt'), header=None, names=['latency'])
     iteration = df.index
     latency = df.latency
     a4_dims = (11.7, 8.27)
@@ -386,7 +392,7 @@ def generate_profile_graph():
 
     plot_data = {}
     for m in metrics:
-        df = pd.read_csv(f"{execution_params['report_location']}/benchmark/{m}", header=None)
+        df = pd.read_csv(f"{execution_params['tmp_dir']}/benchmark/{m}", header=None)
         m = m.split('.txt')[0]
         plot_data[f"{m}_index"] = df.index
         plot_data[f"{m}_values"] = df.values


### PR DESCRIPTION
## Description

Please include a summary of the feature or issue being fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

When running a benchmark with benchmark-ab.py script we run a warmup phase before benchmarking a model in the main stage. Part of the statistics collected for the report are extracted from the TorchServe log file. During this extraction we include the log lines from the warmup phase which dilutes the statistics (i.e. PredictionTime, HandlerTime, QueueTime, WorkerThreadTime) in the report. Due to this we systematically underestimate TorchServe's performance.

Additionally, this RP unbreaks benchmarkss/benchmark-ab.py which got broken due to a missing positional parameter (report_location) in a recent commit. A new parameter tmp_dir is introduced which allows final report location and tmp directory be in separate locations.

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the tests [UT/IT] that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced. 
Please also list any relevant details for your test configuration.

To test run: 
$ cd serve/benchmark
$ python benchmark-ab.py --config config.json --requests 1000
content config.json:
{
  "url":"https://torch-deploy-benchmarks.s3.amazonaws.com/BERTSeqClassification.mar",
  "requests": 10000,
  "concurrency": 100,
  "input": "sample.txt",
  "batch_delay": 100,
  "batch_size": 8,
  "content_type":"application/text",
  "workers": 4
}
content sample.txt:
Apples are especially bad for your health [SEP] Eating apples is a health risk

- [ ] Test A
run before fix
- [ ] Test B
run after fix

- UT/IT execution results
During generation of the benchmark report we create several txt files in /tmp/benchmark and filter out the times we're interested in (https://github.com/pytorch/serve/blob/65cd16b980400a28551ce76b8ef14288f18ee49b/benchmarks/benchmark-ab.py#L287)
before fix:
$ wc -l /tmp/benchmark/*.txt
 138 /tmp/benchmark/handler_time.txt
 138 /tmp/benchmark/predict.txt
  46 /tmp/benchmark/result.txt
1100 /tmp/benchmark/waiting_time.txt
 146 /tmp/benchmark/worker_thread.txt

(1000 request + 100 warmup requests) / 8 samples per batch = 138 batches

after fix:
$ wc -l /tmp/benchmark/*.txt
 125 /tmp/benchmark/handler_time.txt
 125 /tmp/benchmark/predict.txt
  46 /tmp/benchmark/result.txt
1000 /tmp/benchmark/waiting_time.txt
 125 /tmp/benchmark/worker_thread.txt

1000 request / 8 samples per batch = 125 batches

- Logs
[log_before_fix.txt](https://github.com/pytorch/serve/files/8018155/log_before_fix.txt)
[log_after_fix.txt](https://github.com/pytorch/serve/files/8018156/log_after_fix.txt)

## Checklist:

- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] New and existing unit tests pass locally with these changes?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
