### PR TITLE
Add support to publish metrics to cloudwatch

### DIFF
--- a/benchmarks/automated/README.md
+++ b/benchmarks/automated/README.md
@@ -10,8 +10,8 @@ Check out a sample vgg11 model config at the path: `tests/suite/vgg11.yaml`
 -- [AmazonEC2ContainerRegistryFullAccess](https://console.aws.amazon.com/iam/home#policies/arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess) <br>
 -- [AmazonEC2FullAccess](https://console.aws.amazon.com/iam/home#policies/arn:aws:iam::aws:policy/AmazonEC2FullAccess) <br>
 -- [AmazonS3FullAccess](https://console.aws.amazon.com/iam/home#policies/arn:aws:iam::aws:policy/AmazonS3FullAccess) <br>
--- [IAMFullAccess](https://console.aws.amazon.com/iam/home#policies/arn:aws:iam::aws:policy/IAMFullAccess) 
-<br (or at the least iam:passrole).
+-- [IAMFullAccess](https://console.aws.amazon.com/iam/home#policies/arn:aws:iam::aws:policy/IAMFullAccess) (or at the least iam:passrole). <br>
+-- [CloudWatchFullAccess](https://console.aws.amazon.com/iam/home#/policies/arn:aws:iam::aws:policy/CloudWatchFullAccess$jsonEditor) <br>
 
 * [Create](https://docs.aws.amazon.com/cli/latest/reference/ecr/create-repository.html) an ECR repository with the name “torchserve-benchmark” in the us-west-2 region, e.g.
 ```

--- a/benchmarks/automated/tests/suite/bert_cpu.yaml
+++ b/benchmarks/automated/tests/suite/bert_cpu.yaml
@@ -7,9 +7,6 @@ bert:
         batch_delay: 100
         batch_size:
             - 1
-            - 2
-            - 4
-            - 8
         input: "https://raw.githubusercontent.com/pytorch/serve/master/examples/Huggingface_Transformers/Seq_classification_artifacts/sample_text.txt"
         requests: 10000
         concurrency: 100

--- a/benchmarks/automated/tests/suite/bert_cpu.yaml
+++ b/benchmarks/automated/tests/suite/bert_cpu.yaml
@@ -7,6 +7,9 @@ bert:
         batch_delay: 100
         batch_size:
             - 1
+            - 2
+            - 4
+            - 8
         input: "https://raw.githubusercontent.com/pytorch/serve/master/examples/Huggingface_Transformers/Seq_classification_artifacts/sample_text.txt"
         requests: 10000
         concurrency: 100
@@ -16,5 +19,4 @@ bert:
             - "cpu"
             - "gpus": "all"
 instance_types: #special keyword not recognized as a 'model', define instance types per yaml file.
-    - "p3.8xlarge"
-    - "c5.4xlarge"
+    - "m6i.4xlarge"

--- a/benchmarks/automated/tests/suite/bert_multi_gpu.yaml
+++ b/benchmarks/automated/tests/suite/bert_multi_gpu.yaml
@@ -20,4 +20,3 @@ bert:
             - "gpus": "all"
 instance_types: #special keyword not recognized as a 'model', define instance types per yaml file.
     - "p3.8xlarge"
-    - "c5.4xlarge"

--- a/benchmarks/automated/tests/suite/fastrcnn.yaml
+++ b/benchmarks/automated/tests/suite/fastrcnn.yaml
@@ -20,3 +20,4 @@ fastrcnn:
             - "gpus": "all"
 instance_types: #special keyword not recognized as a 'model', define instance types per yaml file.
     - "p3.8xlarge"
+    - "m6i.4xlarge"

--- a/benchmarks/automated/tests/suite/fastrcnn.yaml
+++ b/benchmarks/automated/tests/suite/fastrcnn.yaml
@@ -20,4 +20,3 @@ fastrcnn:
             - "gpus": "all"
 instance_types: #special keyword not recognized as a 'model', define instance types per yaml file.
     - "p3.8xlarge"
-    - "c5.4xlarge"

--- a/benchmarks/automated/tests/suite/mnist.yaml
+++ b/benchmarks/automated/tests/suite/mnist.yaml
@@ -20,4 +20,4 @@ mnist:
             - "gpus": "all"
 instance_types: #special keyword not recognized as a 'model', define instance types per yaml file.
     - "p3.8xlarge"
-    - "c5.4xlarge"
+    - "m6i.4xlarge"

--- a/benchmarks/automated/tests/suite/vgg11.yaml
+++ b/benchmarks/automated/tests/suite/vgg11.yaml
@@ -38,4 +38,4 @@ vgg11:
             - "gpus": "all"
 instance_types: #special keyword not recognized as a 'model', define instance types per yaml file.
     - "p3.8xlarge"
-    - "c5.4xlarge"
+    - "m6i.4xlarge"

--- a/benchmarks/automated/tests/suite/vgg16.yaml
+++ b/benchmarks/automated/tests/suite/vgg16.yaml
@@ -38,4 +38,4 @@ vgg16:
             - "gpus": "all"
 instance_types: #special keyword not recognized as a 'model', define instance types per yaml file.
     - "p3.8xlarge"
-    - "c5.4xlarge"
+    - "m6i.4xlarge"

--- a/benchmarks/automated/tests/utils/apache_bench.py
+++ b/benchmarks/automated/tests/utils/apache_bench.py
@@ -149,7 +149,7 @@ class ApacheBenchHandler(object):
             data = f.readlines()
         artifacts["Benchmark"] = "AB"
         artifacts["Batch Size"] = batch_size
-        artifacts["Mode"] = mode
+        artifacts["Mode"] = mode # This is the pytorch mode i.e. eager or scripted, as specified in <model>.yaml
         artifacts["Model"] = self.model_name
         artifacts["Concurrency"] = concurrency
         artifacts["Requests"] = requests
@@ -188,6 +188,8 @@ class ApacheBenchHandler(object):
 
         artifacts["instance_type"] = curr_instance_type
 
+        # 'BENCHMARK_CONTEXT' is set internally at AWS for certain benchmark jobs.
+        # When it's not available, 'DevTest' is used.
         dashboard_context = os.getenv("BENCHMARK_CONTEXT", "DevTest")
 
         cloudwatchMetricsHandler = cloudwatch_utils.CloudWatchMetricsHandler(

--- a/benchmarks/automated/tests/utils/benchmark.py
+++ b/benchmarks/automated/tests/utils/benchmark.py
@@ -168,7 +168,7 @@ class BenchmarkHandler:
 
                     # Generate report (note: needs to happen after torchserve has stopped)
                     apacheBenchHandler.generate_report(
-                        requests=requests, concurrency=concurrency, connection=self.connection
+                        requests=requests, concurrency=concurrency, batch_size=batch_size, mode=mode,connection=self.connection
                     )
 
                     # Move artifacts into a common folder.

--- a/benchmarks/automated/tests/utils/cloudwatch.py
+++ b/benchmarks/automated/tests/utils/cloudwatch.py
@@ -25,17 +25,17 @@ LOCAL_TMP_DIR = "/tmp"
 
 
 class CloudWatchMetricsHandler:
-    def __init__(self, context="dashboard", namespace="TORCHSERVE_DEV_METRICS"):
+    def __init__(self, context="DevTest", sub_namespace="TestModel"):
         self.client = boto3.Session(region_name=DEFAULT_REGION).client("cloudwatch")
         self.context = context
-        self.namespace = f"TORCHSERVE_{context.upper()}_METRICS_TEST"
+        self.namespace = f"TorchServe/{context.title()}/{sub_namespace.title()}"
 
     def push(self, name, unit, value, metrics_info):
         # dimensions = [{"Name": "BenchmarkContextTest", "Value":self.context}]
         dimensions = []
 
         for key in metrics_info:
-            dimensions.append({"Name": key, "Value": metrics_info.get(key)})
+            dimensions.append({"Name": key, "Value": str(metrics_info.get(key))})
 
         try:
             response = self.client.put_metric_data(
@@ -47,24 +47,13 @@ class CloudWatchMetricsHandler:
 
         return response
 
-    def push_benchmark_metrics(self, metric_name, unit, benchmark_dict):
-
-        # Extract value and dimensions from benchmark_dict
-
-        value = benchmark_dict.get("Model_p90")
+    def push_benchmark_metrics(self, benchmark_dict):
 
         # CloudWatch allows a maximum of 10 dimensions for a metric, so only the most important are published here
-        info = {
-            "Model_latency_p50": benchmark_dict.get("Model_p50"),
-            "Model_latency_p90": benchmark_dict.get("Model_p90"),
-            "Model_latency_p99": benchmark_dict.get("Model_p99"),
-            "TS_latency_p50": benchmark_dict.get("TS latency P50"),
-            "TS_latency_p90": benchmark_dict.get("TS latency P90"),
-            "TS_latency_p99": benchmark_dict.get("TS latency P99"),
-            "TS_throughput": benchmark_dict.get("TS throughput"),
-            "TS_error_rate": str(benchmark_dict.get("TS error rate")),
-        }
+        info = {"Instance Type": benchmark_dict.get("instance_type"), "Batch Size": benchmark_dict.get("Batch Size")}
 
-        self.push(metric_name, unit, value, info)
+        self.push("Model Latency P90", "Milliseconds", benchmark_dict.get("Model_p90"), info)
+        self.push("TS Throughput", "Count/Second", benchmark_dict.get("TS throughput"), info)
+        self.push("TS Error Rate", "Count/Second", str(benchmark_dict.get("TS error rate")), info)
 
-        LOGGER.info(f"Benchmark metrics for {metric_name} pushed to cloudwatch")
+        LOGGER.info(f"Benchmark metric pushed to cloudwatch")

--- a/benchmarks/automated/tests/utils/cloudwatch.py
+++ b/benchmarks/automated/tests/utils/cloudwatch.py
@@ -1,0 +1,70 @@
+import csv
+import os
+import time
+import re
+import boto3
+import uuid
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import numpy as n
+
+from inspect import signature
+from retrying import retry
+from fabric2 import Connection
+from botocore.config import Config
+from botocore.exceptions import ClientError
+
+from invoke import run, sudo
+from invoke.context import Context
+
+from . import DEFAULT_REGION, IAM_INSTANCE_PROFILE, AMI_ID, LOGGER, S3_BUCKET_BENCHMARK_ARTIFACTS
+
+TMP_DIR = "/home/ubuntu"
+LOCAL_TMP_DIR = "/tmp"
+
+
+class CloudWatchMetricsHandler:
+    def __init__(self, context="dashboard", namespace="TORCHSERVE_DEV_METRICS"):
+        self.client = boto3.Session(region_name=DEFAULT_REGION).client("cloudwatch")
+        self.context = context
+        self.namespace = f"TORCHSERVE_{context.upper()}_METRICS_TEST"
+
+    def push(self, name, unit, value, metrics_info):
+        # dimensions = [{"Name": "BenchmarkContextTest", "Value":self.context}]
+        dimensions = []
+
+        for key in metrics_info:
+            dimensions.append({"Name": key, "Value": metrics_info.get(key)})
+
+        try:
+            response = self.client.put_metric_data(
+                MetricData=[{"MetricName": name, "Dimensions": dimensions, "Unit": unit, "Value": float(value)}],
+                Namespace=self.namespace,
+            )
+        except Exception as e:
+            raise Exception(str(e))
+
+        return response
+
+    def push_benchmark_metrics(self, metric_name, unit, benchmark_dict):
+
+        # Extract value and dimensions from benchmark_dict
+
+        value = benchmark_dict.get("Model_p90")
+
+        # CloudWatch allows a maximum of 10 dimensions for a metric, so only the most important are published here
+        info = {
+            "Model_latency_p50": benchmark_dict.get("Model_p50"),
+            "Model_latency_p90": benchmark_dict.get("Model_p90"),
+            "Model_latency_p99": benchmark_dict.get("Model_p99"),
+            "TS_latency_p50": benchmark_dict.get("TS latency P50"),
+            "TS_latency_p90": benchmark_dict.get("TS latency P90"),
+            "TS_latency_p99": benchmark_dict.get("TS latency P99"),
+            "TS_throughput": benchmark_dict.get("TS throughput"),
+            "TS_error_rate": str(benchmark_dict.get("TS error rate")),
+        }
+
+        self.push(metric_name, unit, value, info)
+
+        LOGGER.info(f"Benchmark metrics for {metric_name} pushed to cloudwatch")

--- a/benchmarks/automated/tests/utils/ts.py
+++ b/benchmarks/automated/tests/utils/ts.py
@@ -154,6 +154,7 @@ class TorchServeHandler(object):
         self.connection.run("ps axl|grep -e '--no-stream'| grep -v color | awk '{print $3}' | xargs kill -9", warn=True)
         self.connection.run(f"cp nohup.out nohup.{model_name}.{num_workers}.{batch_size}", warn=True)
         self.connection.run(f"rm nohup.out", warn=True)
+        time.sleep(3)
 
     def plot_stats_graph(self, model_name, mode_name, num_workers, batch_size):
         """
@@ -162,6 +163,9 @@ class TorchServeHandler(object):
         import matplotlib.pyplot as plt
 
         LOGGER.info(f"Generating graphs")
+
+        if not self.is_local_execution:
+            self.connection.get(f"free.{model_name}.{num_workers}.{batch_size}", f"free.{model_name}.{num_workers}.{batch_size}")
 
         # plot graphs from the utility 'free'
         with open(f"free.{model_name}.{num_workers}.{batch_size}") as f:

--- a/ci/benchmark/buildspec.yml
+++ b/ci/benchmark/buildspec.yml
@@ -1,0 +1,17 @@
+# Build Spec for AWS CodeBuild CI
+
+version: 0.2
+
+phases:
+  install:
+    commands:
+      - apt-get update
+      - apt-get install sudo -y
+      - git clone https://www.github.com/nskool/serve.git
+      - cd serve
+      - git checkout cw_metrics
+      - pip install -r benchmarks/automated/requirements.txt
+
+  build:
+    commands:
+      - python benchmarks/automated/run_benchmark.py --run-only ${MODEL_NAME}

--- a/ci/benchmark/buildspec.yml
+++ b/ci/benchmark/buildspec.yml
@@ -9,7 +9,6 @@ phases:
       - apt-get install sudo -y
       - git clone https://www.github.com/pytorch/serve.git
       - cd serve
-      - git checkout cw_metrics
       - pip install -r benchmarks/automated/requirements.txt
 
   build:

--- a/ci/benchmark/buildspec.yml
+++ b/ci/benchmark/buildspec.yml
@@ -7,7 +7,7 @@ phases:
     commands:
       - apt-get update
       - apt-get install sudo -y
-      - git clone https://www.github.com/nskool/serve.git
+      - git clone https://www.github.com/pytorch/serve.git
       - cd serve
       - git checkout cw_metrics
       - pip install -r benchmarks/automated/requirements.txt


### PR DESCRIPTION
## Description

This PR adds support to publish metrics to cloudwatch, when the benchmark automated script is run. 


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Trigger the benchmark run as follows:
1. Create an ec2 role with attached IAM role for permissions mentioned here: https://github.com/pytorch/serve/tree/master/benchmarks/automated
2. On the ec2 instance, clone this PR: 
`git clone https://www.github.com/pytorch/serve.git`
`cd serve`
`git fetch origin pull/1414/head:<BRANCHNAME>`, where <BRANCHNAME> is a branch of your choice.
3. `python benchmarks/automated/run_benchmark.py --run-only mnist 2>&1 | tee ~/logs/op_remote_mnist.log`
2. Check the cloudwatch metrics in AWS console to view the pushed metrics.

- UT/IT execution results

- Logs

## Checklist:

- [x] Have you added tests that prove your fix is effective or that this feature works?
- [x] New and existing unit tests pass locally with these changes?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?
