### PR TITLE
Github Action Nightly Build

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,0 +1,34 @@
+## Call setup.py with pytorch credentials
+## Ignore tests
+# Where is this pushed and under what name?
+
+name: Push Nightly
+
+on:
+  # run every day at 11:15am
+  schedule:
+    - cron:  '15 11 * * *'
+
+jobs:
+  nightly:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Setup Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+          architecture: x64
+      - name: Checkout TorchSeve
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          set -eux
+          pip install -e .
+          pip install twine
+#       - name: Run tests
+#         run: python -m unittest discover --verbose --start-directory . --pattern "*_test.py"
+      - name: Push nightly
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: ts_scripts/push_nightly.sh
+        

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -19,10 +19,13 @@ jobs:
       - name: Install dependencies
         run: |
           set -eux
-          pip install -e .
           pip install twine
-#       - name: Run tests
-#         run: python -m unittest discover --verbose --start-directory . --pattern "*_test.py"
+          apt-get update
+          apt-get install sudo -y
+          python ts_scripts/install_dependencies.py --cuda=cu102 --environment=dev
+          pip install -e .
+
+
       - name: Push nightly
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,7 +1,3 @@
-## Call setup.py with pytorch credentials
-## Ignore tests
-# Where is this pushed and under what name?
-
 name: Push Nightly
 
 on:

--- a/setup.py
+++ b/setup.py
@@ -142,12 +142,15 @@ class BuildPlugins(Command):
 
 
 if __name__ == '__main__':
-    from argparse import ArgumentParser
-    parser = ArgumentParser()
-    parser.add_argument("--override-name", default='torchserve')
-    args = parser.parse_args()
-    name = args.override_name
     # Get nightly version if nightly in name
+    name = 'torchserve'
+
+    # Clever code to figure out if setup.py was trigger by ts_scripts/push_nightly.sh
+    NAME_ARG = "--override-name"
+    if NAME_ARG in sys.argv:
+        idx = sys.argv.index(NAME_ARG)
+        name = sys.argv.pop(idx + 1)
+        sys.argv.pop(idx)
     is_nightly = "nightly" in name
 
     version = get_nightly_version() if is_nightly else detect_model_server_version()

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,9 @@ def pypi_description():
     with open('PyPiDescription.rst') as df:
         return df.read()
 
+def get_nightly_version():
+    today = date.today()
+    return f"{today.year}.{today.month}.{today.day}"
 
 def detect_model_server_version():
     sys.path.append(os.path.abspath("ts"))
@@ -139,12 +142,25 @@ class BuildPlugins(Command):
 
 
 if __name__ == '__main__':
-    version = detect_model_server_version()
+    # Get nightly version if nightly in name
+    name = 'torchserve'
+
+    # Clever code to figure out if setup.py was trigger by ts_scripts/push_nightly.sh
+    NAME_ARG = "--override-name"
+    if NAME_ARG in sys.argv:
+        idx = sys.argv.index(NAME_ARG)
+        name = sys.argv.pop(idx + 1)
+        sys.argv.pop(idx)
+    is_nightly = "nightly" in name
+
+    version = get_nightly_version() if is_nightly else detect_model_server_version()
+
+    print(f"-- {name} building version: {version}")
 
     requirements = ['Pillow', 'psutil', 'future', 'packaging']
 
     setup(
-        name='torchserve',
+        name=name,
         version=version,
         description=
         'TorchServe is a tool for serving neural net models for inference',

--- a/setup.py
+++ b/setup.py
@@ -142,15 +142,12 @@ class BuildPlugins(Command):
 
 
 if __name__ == '__main__':
+    from argparse import ArgumentParser
+    parser = ArgumentParser()
+    parser.add_argument("--override-name", default='torchserve')
+    args = parser.parse_args()
+    name = args.override_name
     # Get nightly version if nightly in name
-    name = 'torchserve'
-
-    # Clever code to figure out if setup.py was trigger by ts_scripts/push_nightly.sh
-    NAME_ARG = "--override-name"
-    if NAME_ARG in sys.argv:
-        idx = sys.argv.index(NAME_ARG)
-        name = sys.argv.pop(idx + 1)
-        sys.argv.pop(idx)
     is_nightly = "nightly" in name
 
     version = get_nightly_version() if is_nightly else detect_model_server_version()

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ def pypi_description():
 
 def get_nightly_version():
     today = date.today()
-    return f"{today.year}.{today.month}.{today.day}"
+    return today.strftime("%Y.%m.%d")
 
 def detect_model_server_version():
     sys.path.append(os.path.abspath("ts"))

--- a/ts_scripts/push_nightly.sh
+++ b/ts_scripts/push_nightly.sh
@@ -13,4 +13,4 @@ fi
 python3 -m twine upload \
     --username __token__ \
     --password "$PYPI_TOKEN" \
-    dist/torchx_nightly-*
+    dist/torchserve_nightly-*

--- a/ts_scripts/push_nightly.sh
+++ b/ts_scripts/push_nightly.sh
@@ -5,12 +5,12 @@ rm -r dist || true
 
 python setup.py --override-name torchserve-nightly bdist_wheel
 
-if [ -z "$PYPI_TOKEN" ]; then
-    echo "must specify PYPI_TOKEN"
-    exit 1
-fi
+# if [ -z "$PYPI_TOKEN" ]; then
+#     echo "must specify PYPI_TOKEN"
+#     exit 1
+# fi
 
-python3 -m twine upload \
-    --username __token__ \
-    --password "$PYPI_TOKEN" \
-    dist/torchserve_nightly-*
+# python3 -m twine upload \
+#     --username __token__ \
+#     --password "$PYPI_TOKEN" \
+#     dist/torchserve_nightly-*

--- a/ts_scripts/push_nightly.sh
+++ b/ts_scripts/push_nightly.sh
@@ -1,0 +1,16 @@
+set -ex
+
+rm -r dist || true
+
+
+python setup.py --override-name torchserve-nightly bdist_wheel
+
+if [ -z "$PYPI_TOKEN" ]; then
+    echo "must specify PYPI_TOKEN"
+    exit 1
+fi
+
+python3 -m twine upload \
+    --username __token__ \
+    --password "$PYPI_TOKEN" \
+    dist/torchx_nightly-*

--- a/ts_scripts/push_nightly.sh
+++ b/ts_scripts/push_nightly.sh
@@ -5,12 +5,12 @@ rm -r dist || true
 
 python setup.py --override-name torchserve-nightly bdist_wheel
 
-# if [ -z "$PYPI_TOKEN" ]; then
-#     echo "must specify PYPI_TOKEN"
-#     exit 1
-# fi
+if [ -z "$PYPI_TOKEN" ]; then
+    echo "must specify PYPI_TOKEN"
+    exit 1
+fi
 
-# python3 -m twine upload \
-#     --username __token__ \
-#     --password "$PYPI_TOKEN" \
-#     dist/torchserve_nightly-*
+python3 -m twine upload \
+    --username __token__ \
+    --password "$PYPI_TOKEN" \
+    dist/torchserve_nightly-*


### PR DESCRIPTION
Using this PR as a draft for Github Action nightly builds - does this work? I think the only missing thing is making sure if `ts_scripts/install_dependencies.py` is needed for the build @nskool 

Otherwise I can create a new project called `torchserve-nightly` on pypi and after I upload my personal access token we should be good to go? @seemethere 

repurposed the workflow here from @d4l3k  https://github.com/pytorch/torchx/blob/main/.github/workflows/nightly.yaml

TODO - can potentially do this in another PR
* Enable `DRY_RUN` by default
* Add last git hash to PKG_INFO
* Use github to publish artifacts


# Local test
1. Run commands from github actions script one by one - the last one should print
```
(serve) ubuntu@ip-172-31-25-104:~/serve$ python setup.py --override-name torchserve-nightly bdist_wheel
-- torchserve-nightly building version: 2022.2.14
```
2. If you have access to the `PYPI_TOKEN` you can try uploading a release otherwise you can go to the egg info folder and verify the information in `PKG_INFO` which will look like

```
Metadata-Version: 2.1
Name: torchserve-nightly
Version: 2022.2.14
```

And if you go `dist/` then you'll see a file named `torchserve_nightly-2022.2.14-py3-none-any.whl`

Output available here: https://pypi.org/project/torchserve-nightly/2022.2.14/
