### PR TITLE
upgrade to py38

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,26 +23,33 @@ ARG BASE_IMAGE=ubuntu:18.04
 ENV PYTHONUNBUFFERED TRUE
 
 RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt \
+    #apt --fix-broken -y install && \
     apt-get update && \
+    apt remove python-pip  python3-pip && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
     g++ \
-    python3-dev \
-    python3-distutils \
+    python3.8 \
+    python3.8-dev \
+    python3.8-distutils \
+    python3.8-venv \
     python3-venv \
     openjdk-11-jre-headless \
     curl \
     && rm -rf /var/lib/apt/lists/* \
     && cd /tmp \
     && curl -O https://bootstrap.pypa.io/get-pip.py \
-    && python3 get-pip.py
+    && python3.8 get-pip.py
 
-RUN python3 -m venv /home/venv
+
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1 \ 
+    && update-alternatives --install /usr/local/bin/pip pip /usr/local/bin/pip3.8 1
+
+RUN python3.8 -m venv /home/venv
 
 ENV PATH="/home/venv/bin:$PATH"
 
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1 \
-    && update-alternatives --install /usr/local/bin/pip pip /usr/local/bin/pip3 1
+RUN python -m pip install -U pip setuptools
 
 # This is only useful for cuda env
 RUN export USE_CUDA=1
@@ -54,16 +61,16 @@ RUN TORCH_VER=$(curl --silent --location https://pypi.org/pypi/torch/json | pyth
     if echo "$BASE_IMAGE" | grep -q "cuda:"; then \
         # Install CUDA version specific binary when CUDA version is specified as a build arg
         if [ "$CUDA_VERSION" ]; then \
-            pip install --no-cache-dir torch==$TORCH_VER+$CUDA_VERSION torchvision==$TORCH_VISION_VER+$CUDA_VERSION -f https://download.pytorch.org/whl/torch_stable.html; \
+            python -m pip install --no-cache-dir torch==$TORCH_VER+$CUDA_VERSION torchvision==$TORCH_VISION_VER+$CUDA_VERSION -f https://download.pytorch.org/whl/torch_stable.html; \
         # Install the binary with the latest CUDA version support
         else \
-            pip install --no-cache-dir torch torchvision; \
+            python -m pip install --no-cache-dir torch torchvision; \
         fi \
     # Install the CPU binary
     else \
-        pip install --no-cache-dir torch==$TORCH_VER+cpu torchvision==$TORCH_VISION_VER+cpu -f https://download.pytorch.org/whl/torch_stable.html; \
+        python -m pip install --no-cache-dir torch==$TORCH_VER+cpu torchvision==$TORCH_VISION_VER+cpu -f https://download.pytorch.org/whl/torch_stable.html; \
     fi
-RUN pip install -U setuptools && pip install --no-cache-dir captum torchtext torchserve torch-model-archiver
+RUN python -m pip install -U setuptools && python -m pip install --no-cache-dir captum torchtext torchserve torch-model-archiver
 
 # Final image for production
 FROM ${BASE_IMAGE} AS runtime-image
@@ -73,9 +80,9 @@ ENV PYTHONUNBUFFERED TRUE
 RUN --mount=type=cache,target=/var/cache/apt \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
-    python3 \
-    python3-distutils \
-    python3-dev \
+    python3.8 \
+    python3.8-distutils \
+    python3.8-dev \
     openjdk-11-jre-headless \
     build-essential \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
## Description

Please include a summary of the feature or issue being fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #(issue)
#1432 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the tests [UT/IT] that you ran to verify your changes and relevent result summary. Provide instructions so it can be reproduced. 
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- UT/IT execution results

- Logs
./build_image.sh -g -cv cu102
[+] Building 23.7s (23/23) FINISHED
 => [internal] load build definition from Dockerfile             0.0s
 => => transferring dockerfile: 4.36kB                           0.0s
 => [internal] load .dockerignore                                0.0s
 => => transferring context: 2B                                  0.0s
 => resolve image config for docker.io/docker/dockerfile:experi  0.2s
 => CACHED docker-image://docker.io/docker/dockerfile:experimen  0.0s
 => [internal] load metadata for docker.io/nvidia/cuda:10.2-cud  0.1s
 => [internal] load build context                                0.0s
 => => transferring context: 80B                                 0.0s
 => [compile-image 1/8] FROM docker.io/nvidia/cuda:10.2-cudnn7-  0.0s
 => CACHED [compile-image 2/8] RUN --mount=type=cache,id=apt-de  0.0s
 => CACHED [compile-image 3/8] RUN update-alternatives --instal  0.0s
 => CACHED [compile-image 4/8] RUN python3.8 -m venv /home/venv  0.0s
 => CACHED [compile-image 5/8] RUN python -m pip install -U pip  0.0s
 => CACHED [compile-image 6/8] RUN export USE_CUDA=1             0.0s
 => CACHED [compile-image 7/8] RUN TORCH_VER=$(curl --silent --  0.0s
 => CACHED [compile-image 8/8] RUN python -m pip install -U set  0.0s
 => CACHED [runtime-image 2/9] RUN --mount=type=cache,target=/v  0.0s
 => CACHED [runtime-image 3/9] RUN useradd -m model-server       0.0s
 => [runtime-image 4/9] COPY --chown=model-server --from=compi  10.3s
 => [runtime-image 5/9] COPY dockerd-entrypoint.sh /usr/local/b  0.0s
 => [runtime-image 6/9] RUN chmod +x /usr/local/bin/dockerd-ent  0.3s
 => [runtime-image 7/9] COPY config.properties /home/model-serv  0.0s
 => [runtime-image 8/9] RUN mkdir /home/model-server/model-stor  0.4s
 => [runtime-image 9/9] WORKDIR /home/model-server               0.0s
 => exporting to image                                          12.0s
 => => exporting layers                                         12.0s
 => => writing image sha256:ad936561d7f9f00f1b39635fbd9b9c84e1f  0.0s
 => => naming to docker.io/pytorch/torchserve:latest-gpu         0.0s

docker run --rm -it -p 8080:8080 -p 8081:8081 -p 8082:8082 -p 7070:7070 -p 7071:7071 pytorch/torchserve:latest-gpu
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
2022-02-16T04:44:05,444 [INFO ] main org.pytorch.serve.servingsdk.impl.PluginsManager - Initializing plugins manager...
2022-02-16T04:44:05,574 [INFO ] main org.pytorch.serve.ModelServer -
Torchserve version: 0.5.2
TS Home: /home/venv/lib/python3.8/site-packages
Current directory: /home/model-server
Temp directory: /home/model-server/tmp
Number of GPUs: 0
Number of CPUs: 32
Max heap size: 30688 M
Python executable: /home/venv/bin/python
Config file: /home/model-server/config.properties
Inference address: http://0.0.0.0:8080
Management address: http://0.0.0.0:8081
Metrics address: http://0.0.0.0:8082
Model Store: /home/model-server/model-store
Initial Models: N/A
Log dir: /home/model-server/logs
Metrics dir: /home/model-server/logs
Netty threads: 32
Netty client threads: 0
Default workers per model: 32
Blacklist Regex: N/A
Maximum Response Size: 6553500
Maximum Request Size: 6553500
Limit Maximum Image Pixels: true
Prefer direct buffer: false
Allowed Urls: [file://.*|http(s)?://.*]
Custom python dependency for model allowed: false
Metrics report format: prometheus
Enable metrics API: true
Workflow Store: /home/model-server/model-store
## Checklist:

- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] New and existing unit tests pass locally with these changes?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
