### PR TITLE
Update permissions on nightly-build.yml

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -20,6 +20,8 @@ jobs:
         run: |
           set -eux
           pip install twine
+          sudo apt-get update
+          sudo apt-get install sudo -y
           python ts_scripts/install_dependencies.py --cuda=cu102 --environment=dev
           pip install -e .
 

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -20,8 +20,6 @@ jobs:
         run: |
           set -eux
           pip install twine
-          apt-get update
-          apt-get install sudo -y
           python ts_scripts/install_dependencies.py --cuda=cu102 --environment=dev
           pip install -e .
 

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -21,7 +21,6 @@ jobs:
           set -eux
           pip install twine
           sudo apt-get update
-          sudo apt-get install sudo -y
           python ts_scripts/install_dependencies.py --cuda=cu102 --environment=dev
           pip install -e .
 


### PR DESCRIPTION
Nightly build build fails right now when apt-get update is run because of a permission denied issue

So either we remove these two lines or add sudo - what do you think is best? @nskool 

Also I wonder how necessary this flag is for `install_dependencies.py` `--cuda=cu102` not sure how github actions plays with GPU runners

https://github.com/pytorch/serve/actions/runs/1852465948