### PR TITLE
Java 11 support in github action

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -14,6 +14,10 @@ jobs:
         with:
           python-version: 3.8
           architecture: x64
+      - name: Setup Java 11
+      - uses: actions/setup-java@v2
+        with:
+          java-version: '11'
       - name: Checkout TorchSeve
         uses: actions/checkout@v2
       - name: Install dependencies
@@ -23,8 +27,6 @@ jobs:
           sudo apt-get update
           python ts_scripts/install_dependencies.py --cuda=cu102 --environment=dev
           pip install -e .
-
-
       - name: Push nightly
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Add Java 11 setup so that java frontend build doesn't fail
