### PR TITLE
added nvgpu to common dependencies

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -8,3 +8,5 @@ captum
 packaging
 numpy; sys_platform != 'win32'
 numpy==1.19.3; sys_platform == 'win32' #see https://tinyurl.com/y3dm3h86
+nvgpu; sys_platform != 'win32'
+nvgpu==0.8.0; sys_platform == 'win32'

--- a/requirements/developer.txt
+++ b/requirements/developer.txt
@@ -4,8 +4,6 @@ pytest
 pylint==2.6.0
 pytest-mock
 pytest-cov
-nvgpu; sys_platform != 'win32'
-nvgpu==0.8.0; sys_platform == 'win32'
 grpcio
 protobuf
 grpcio-tools


### PR DESCRIPTION
Fixes

for EC2 ubuntu base gpu torchserve fails to start due to missing nvgpu package
https://github.com/pytorch/serve/blob/ff4d90bfe18556739bee8465b83acb99f99be4a7/ts/metrics/system_metrics.py#L61