### PR TITLE
Make sure /home/venv is writeable by model-server user in dev docker image

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -47,11 +47,6 @@ RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt \
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1 \
     && update-alternatives --install /usr/local/bin/pip pip /usr/local/bin/pip3.8 1
 
-RUN python3.8 -m venv /home/venv
-ENV PATH="/home/venv/bin:$PATH"
-
-RUN python -m pip install -U pip setuptools
-
 # Build Dev Image
 FROM compile-image AS dev-image
 ARG MACHINE_TYPE=cpu
@@ -60,6 +55,8 @@ RUN if [ "$MACHINE_TYPE" = "gpu" ]; then export USE_CUDA=1; fi \
     && git clone https://github.com/pytorch/serve.git \
     && cd serve \
     && git checkout ${BRANCH_NAME} \
+    && python3.8 -m venv /home/venv \
+    && python -m pip install -U pip setuptools \
     && if [ -z "$CUDA_VERSION" ]; then python ts_scripts/install_dependencies.py --environment=dev; else python ts_scripts/install_dependencies.py --environment=dev  --cuda $CUDA_VERSION; fi \
     && python ts_scripts/install_from_src.py \
     && useradd -m model-server \
@@ -68,7 +65,8 @@ RUN if [ "$MACHINE_TYPE" = "gpu" ]; then export USE_CUDA=1; fi \
     && chmod +x /usr/local/bin/dockerd-entrypoint.sh \
     && chown -R model-server /home/model-server \
     && cp docker/config.properties /home/model-server/config.properties \
-    && mkdir /home/model-server/model-store && chown -R model-server /home/model-server/model-store
+    && mkdir /home/model-server/model-store && chown -R model-server /home/model-server/model-store \
+    && chown -R model-server /home/venv
 
 EXPOSE 8080 8081 8082 7070 7071
 USER model-server


### PR DESCRIPTION
## Description

This PR moves the creation of the virtualenv to a place where we can change the owner to model-server without creating another layer. This ensures that users of the docker image can install packages without changing to root user.

Fixes #(issue)
#1499 
## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the tests [UT/IT] that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced. 
Please also list any relevant details for your test configuration.

- [ ] Test A
Build docker with: 
`./build_image.sh -bt dev`
Start docker:
docker run -ti --rm docker.io/pytorch/torchserve:dev-cpu bash
model-server@90d7c57df607:~$ ls -la /home/
total 16
drwxr-xr-x 1 root         root         4096 Mar 16 01:09 .
drwxr-xr-x 1 root         root         4096 Mar 16 02:21 ..
drwxr-xr-x 4 model-server model-server 4096 Mar 16 01:09 model-server
drwxr-xr-x 6 model-server root         4096 Mar 16 01:07 venv
Run pip install [any package] to test if installing packages works
- [ ] Test B

- Logs

## Checklist:

- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
