### PR TITLE
fix snapsht test for default manifest case

### DIFF
--- a/test/pytest/test_snapshot.py
+++ b/test/pytest/test_snapshot.py
@@ -199,9 +199,9 @@ def test_replace_mar_file_with_dummy():
         response = requests.get('http://127.0.0.1:8081/models/')
         assert json.loads(response.content)['models'][0]['modelName'] == "densenet161"
     except:
-        assert True, "Correct Model mar file not found"
+        assert False, "Default manifest does not work"
     else:
-        assert False, "Something is not right!! Successfully started Torchserve with a dummy mar file"
+        assert True, "Successfully started Torchserve with a dummy mar file (ie. default manifest"
     finally:
         test_utils.delete_all_snapshots()
         test_utils.delete_model_store()


### PR DESCRIPTION
## Description

This [snapshot test case](https://github.com/pytorch/serve/blob/master/test/pytest/test_snapshot.py#L179) is invalid since default manifest should work according to the original code.