### PR TITLE
Inference API ping response fixed

### DIFF
--- a/docs/inference_api.md
+++ b/docs/inference_api.md
@@ -37,7 +37,7 @@ If the server is running, the response is:
 
 ```json
 {
-  "health": "healthy!"
+  "status": "Healthy"
 }
 ```
 


### PR DESCRIPTION
Signed-off-by: Abhay PS <psabhay@gmail.com>

## Documentation fixed

In the docs, the inference API's ping response is not correct. Docs are now updated with the correct response of inference API's ping endpoint.

## Type of change

- [ ] This change requires a documentation update

