### PR TITLE
Optimized image preprocessing for image classification 

### DIFF
--- a/ts/torch_handler/image_classifier.py
+++ b/ts/torch_handler/image_classifier.py
@@ -19,7 +19,7 @@ if os.environ.get("TS_IPEX_ENABLE", "false") == "true":
         import accimage
         ipex_enabled = True
     except ImportError as error:
-        logger.warning("Please instlal accimage for optimized preprocessing")
+        logger.warning("Please install accimage for optimized preprocessing")
  
 
 


### PR DESCRIPTION
We have been observing that TorchServe preprocessing time for image classification is a bottleneck - preprocessing time takes a very long time (longer than the actual inference time itself). You can verify this by modifying the [HandlerTime in the base_handler](https://github.com/pytorch/serve/blob/master/ts/torch_handler/base_handler.py#L228). 

The preprocessing overhead is mostly caused from [image_processing steps in the image_classifier](https://github.com/pytorch/serve/blob/master/ts/torch_handler/image_classifier.py#L21). 

The preprocessing time can be reduced by (1) removing unnecessary aten::copy operations; (2) replacing costly [torch.stack call in the vision_handler](https://github.com/pytorch/serve/blob/master/ts/torch_handler/vision_handler.py#L56); (3) using accimage package which uses the Intel IPP library. 

Below is the profiling result of this optimized preprocessing tested _without torchserve_ (just copied preprocessing code to another python file) tested on batch size = 128, and input image is the default torchserve [kitten.jpg](https://github.com/pytorch/serve/blob/master/examples/image_classifier/kitten.jpg) for image classification. The CPU time speedup is 3.03x. 

![optimized_preprocessing_without_torchserve](https://user-images.githubusercontent.com/93151422/161319539-5418a1a9-a6eb-4724-bd48-25bed57ca05a.jpg)

Below is some sample results on applying this optimized preprocessing to TorchServe. The end-to-end throughput speedup is almost 2x. 

shared config:
[default torchserve ab params](https://github.com/pytorch/serve/blob/master/benchmarks/benchmark-ab.py#L18)
batch_size = 128
cpu_launcher_enabled=true
cpu_launcher_args=--node_id 0

**pytorch_fp32_original_preprocessing**
**ts e2e throughput**: 86.78
**preprocessing_time_mean**: 1212.27 

**pytorch_fp32_new_preprocessing**
**ts e2e throughput**: 163.17
**preprocessing_time_mean**: 457.78
**throughput speedup: 1.8802719520626872 
preprocessing time speedup: 2.6481497662632707**

Below are profiling results that show similar optimization as before without TorchServe. 
(1) ipex with original preprocessing 
![ipex_original_preprocessing_ts](https://user-images.githubusercontent.com/93151422/161320079-abb4422e-6c8a-453b-82f1-ac79419efba7.jpg)

(2) ipex with optimized preprocessing 
![ipex_optimized_preprocessing_ts](https://user-images.githubusercontent.com/93151422/161320124-e7d87f22-e97a-43f0-878d-cd24b6c0ac78.jpg)


Currently, I've made the code change so that the _optimized_preprocessing is only applied when ipex_enable=true_. But this optimization is applicable to without ipex as well (as shown by the first profiling results outside of torchserve). 

Let me know of your thoughts, and am curious to know if this preprocessing overhead has already been an aware issue with current use-cases. Thanks. 

