### PR TITLE
Set the Default Envelope for Workflow Functions

### DIFF
--- a/frontend/server/src/main/java/org/pytorch/serve/wlm/ModelManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/wlm/ModelManager.java
@@ -125,7 +125,7 @@ public final class ModelManager {
             manifest.getModel().setModelVersion("1.0");
             manifest.getModel().setModelName(modelName);
             manifest.getModel().setHandler(new File(handler).getName());
-
+            manifest.getModel().setEnvelope(configManager.getTsServiceEnvelope());
             File f = new File(handler.substring(0, handler.lastIndexOf(':')));
             archive = new ModelArchive(manifest, url, f.getParentFile(), true);
         } else {


### PR DESCRIPTION
## Description

Set the Default Envelope for Workflow Functions

Fixes #1549

### Problems to Fix

Currently:

### The envelope of the workflow function is not set correctly.

> https://github.com/pytorch/serve/blob/6a191f822f2e759c2aad07b8f9eacbedcb039827/frontend/server/src/main/java/org/pytorch/serve/wlm/ModelManager.java#L122

While the models' envelope are set to the default envelope specified in config.properties, the workflow funcitons' envelope is null.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

~~ New feature (non-breaking change which adds functionality)~~
~~Breaking change (fix or feature that would cause existing functionality to not work as expected)~~
~~This change requires a documentation update~~

## Feature/Issue validation/testing

Please describe the tests [UT/IT] that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced. 
Please also list any relevant details for your test configuration.

- [x] Test A
    1. On master branch.
    2. Don't set the envelope in `config.properties`. Run the container with the workflow mnist I provided above, or the example workflow dog_breed_classification. The prediction will succeed.
    3. Set the `service_envelope=kservev2`, run the container with the workflow in `2.`. The workflow function is registered with null envelope.
    4. Switch to this pull request branch.
    5. build the frontend and cp the jar into ts/frontend/.
    6. repeat `Step 3.`, The workflow function is registered with kserve v2 envelope.


## Checklist:

- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?

