### PR TITLE
Use sys.executable instead of hard coding

### DIFF
--- a/ts_scripts/install_dependencies.py
+++ b/ts_scripts/install_dependencies.py
@@ -1,7 +1,6 @@
 import os
 import platform
 import argparse
-from shutil import which
 import sys
 from pathlib import Path
 from print_env_info import run_and_parse_first_match

--- a/ts_scripts/install_dependencies.py
+++ b/ts_scripts/install_dependencies.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import argparse
+from shutil import which
 import sys
 from pathlib import Path
 from print_env_info import run_and_parse_first_match
@@ -37,23 +38,24 @@ class Common():
                 sys.exit(1)
             else:
                 os.system(
-                    f"python -m pip install -U -r requirements/torch_{cuda_version}_{platform.system().lower()}.txt"
+                    f"{sys.executable} -m pip install -U -r requirements/torch_{cuda_version}_{platform.system().lower()}.txt"
                 )
         else:
             os.system(
-                f"python -m pip install -U -r requirements/torch_{platform.system().lower()}.txt"
+                f"{sys.executable} -m pip install -U -r requirements/torch_{platform.system().lower()}.txt"
             )
 
     def install_python_packages(self, cuda_version, requirements_file_path):
-        if os.system("conda") == 0:
+        check = "where" if platform.system() == "Windows" else "which"
+        if os.system(f"{check} conda") == 0:
             # conda install command should run before the pip install commands
             # as it may reinstall the packages with different versions
             os.system("conda install -y conda-build")
 
         self.install_torch_packages(cuda_version)
-        os.system("python -m pip install -U pip setuptools")
+        os.system(f"{sys.executable} -m pip install -U pip setuptools")
         # developer.txt also installs packages from common.txt
-        os.system("python -m pip install -U -r {0}".format(requirements_file_path))
+        os.system(f"{sys.executable} -m pip install -U -r {requirements_file_path}")
         # If conda is available install conda-build package
 
     def install_node_packages(self):


### PR DESCRIPTION
## Description

Predefined 'python' can be different from the command which is really executed.
So replace 'python' with sys.executable


Fixes #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
