### PR TITLE
Add an exception for torch<1.8.1

### DIFF
--- a/ts/torch_handler/base_handler.py
+++ b/ts/torch_handler/base_handler.py
@@ -6,17 +6,17 @@ Also, provides handle method per torch serve custom model specification
 import abc
 import logging
 import os
-from pkg_resources import packaging
 import importlib.util
 import time
 import torch
+from pkg_resources import packaging
 from ..utils.util import list_classes_from_module, load_label_mapping
 
 if packaging.version.parse(torch.__version__) >= packaging.version.parse("1.8.1"):
     from torch.profiler import profile, record_function, ProfilerActivity
     PROFILER_AVAILABLE = True
 else:
-    PROFILER_AVAILABLE = False 
+    PROFILER_AVAILABLE = False
 
 
 logger = logging.getLogger(__name__)

--- a/ts/torch_handler/base_handler.py
+++ b/ts/torch_handler/base_handler.py
@@ -6,11 +6,17 @@ Also, provides handle method per torch serve custom model specification
 import abc
 import logging
 import os
+from pkg_resources import packaging
 import importlib.util
 import time
 import torch
-from torch.profiler import profile, record_function, ProfilerActivity
 from ..utils.util import list_classes_from_module, load_label_mapping
+
+if packaging.version.parse(torch.__version__) >= packaging.version.parse("1.8.1"):
+    from torch.profiler import profile, record_function, ProfilerActivity
+    PROFILER_AVAILABLE = True
+else:
+    PROFILER_AVAILABLE = False 
 
 
 logger = logging.getLogger(__name__)
@@ -211,7 +217,11 @@ class BaseHandler(abc.ABC):
 
         is_profiler_enabled = os.environ.get("ENABLE_TORCH_PROFILER", None)
         if is_profiler_enabled:
-            output, _ = self._infer_with_profiler(data=data)
+            if PROFILER_AVAILABLE:
+                output, _ = self._infer_with_profiler(data=data)
+            else:
+                raise RuntimeError("Profiler is enabled but current version of torch does not support."
+                                   "Install torch>=1.8.1 to use profiler.")
         else:
             if self._is_describe():
                 output = [self.describe_handle()]


### PR DESCRIPTION
## Description
To support old versions of torch <1.8.1, added an exception for importing `torch.profiler`.

Fixes #1548 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)



- Logs

## Checklist:

- [x] Have you added tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?
