### PR TITLE
Fix broken sphinx install for doc build

### DIFF
--- a/.github/workflows/doc-automation.yml
+++ b/.github/workflows/doc-automation.yml
@@ -19,7 +19,8 @@ jobs:
         python3 -m pip install -U sphinx
         python3 -m pip install setuptools
         python3 -m pip install torch
-        python3 -m pip install -e git+git://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
+        git clone https://github.com/pytorch/pytorch_sphinx_theme
+        python3 -m pip install -e pytorch_sphinx_theme
         python3 -m pip install recommonmark
         python3 -m pip install katex
         python3 -m pip install sphinxcontrib.katex

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -212,11 +212,6 @@ Set nvidia environment variables. For example:
 
 ### Enable metrics api
 * `enable_metrics_api` : Enable or disable metric apis i.e. it can be either `true` or `false`. Default: true (Enabled)
-* `metrics_format` : Use this to specify metric report format . At present, the only supported and default value for this is `prometheus'
-		     This is used in conjunction with `enable_metrics_api` option above.
-
-### Enable metrics api
-* `enable_metrics_api` : Enable or disable metric apis i.e. it can be either `true` or `false`. Default: true (Enabled)
 * `metrics_format` : Use this to specify metric report format . At present, the only supported and default value for this is `prometheus`
 		     This is used in conjunction with `enable_metrics_api` option above.
 


### PR DESCRIPTION
Issue: New doc build broken with unauthenticated git clone which is now deprecated https://github.com/pytorch/serve/actions/runs/2175184712

This PR fixes that issue and was tested and worked on my local fork https://github.com/msaroufim/serve/actions/runs/2186065934

Fixed the issue in upstream docs here https://github.com/pytorch/pytorch_sphinx_theme/pull/162