### PR TITLE
Migrate CI to Github Actions

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -15,7 +15,6 @@ jobs:
       - name: Install dependencies
         run: |
           python ts_scripts/install_dependencies.py --environment=dev
-          python torchserve_sanity.py
       - name: Torchserve Sanity
         run: python torchserve_sanity.py
       - name: mvn install

--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -16,7 +16,10 @@ jobs:
         run: |
           python ts_scripts/install_dependencies.py --environment=dev
       - name: Torchserve Sanity
-        run: python torchserve_sanity.py
+        run: | 
+          cd ..
+          python serve/torchserve_sanity.py
+          cd serve
       - name: mvn install
         run: cd serving-sdk/ && mvn clean install -q && cd ../
 

--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -1,6 +1,9 @@
 name: CI CPU
 
 on: push
+concurrency: 
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   nightly:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -1,0 +1,24 @@
+name: CI CPU
+
+on: push
+jobs:
+  nightly:
+    runs-on: [self-hosted, cpu]
+    steps:
+      - name: Setup Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+          architecture: x64
+      - name: Checkout TorchServe
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          python ts_scripts/install_dependencies.py --environment=dev
+          python torchserve_sanity.py
+      - name: Torchserve Sanity
+        run: python torchserve_sanity.py
+      - name: mvn install
+        run: cd serving-sdk/ && mvn clean install -q && cd ../
+
+

--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -5,7 +5,7 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  ci:
+  ci-cpu:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -3,7 +3,12 @@ name: CI CPU
 on: push
 jobs:
   nightly:
-    runs-on: [self-hosted, cpu]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+
     steps:
       - name: Setup Python 3.8
         uses: actions/setup-python@v2

--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -10,6 +10,11 @@ jobs:
         with:
           python-version: 3.8
           architecture: x64
+      - name: Setup Java 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
       - name: Checkout TorchServe
         uses: actions/checkout@v2
       - name: Install dependencies

--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -17,9 +17,7 @@ jobs:
           python ts_scripts/install_dependencies.py --environment=dev
       - name: Torchserve Sanity
         run: | 
-          cd ..
-          python serve/torchserve_sanity.py
-          cd serve
+          python torchserve_sanity.py
       - name: mvn install
         run: cd serving-sdk/ && mvn clean install -q && cd ../
 

--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -5,7 +5,7 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  nightly:
+  ci:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci_gpu.yml
+++ b/.github/workflows/ci_gpu.yml
@@ -8,6 +8,14 @@ jobs:
   ci-gpu:
     runs-on: [self-hosted, ci-gpu]
     steps:
+      - name: Clean up previous run
+        run: |
+          echo "Cleaning up previous run"
+          cd $RUNNER_WORKSPACE
+          pwd
+          cd ..
+          pwd
+          rm -rf _tool
       - name: Setup Python 3.8
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/ci_gpu.yml
+++ b/.github/workflows/ci_gpu.yml
@@ -1,6 +1,9 @@
 name: CI GPU
 
 on: push
+concurrency: 
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   nightly:
     runs-on: [self-hosted, ci-gpu]

--- a/.github/workflows/ci_gpu.yml
+++ b/.github/workflows/ci_gpu.yml
@@ -5,7 +5,7 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  nightly:
+  ci:
     runs-on: [self-hosted, ci-gpu]
     steps:
       - name: Setup Python 3.8

--- a/.github/workflows/ci_gpu.yml
+++ b/.github/workflows/ci_gpu.yml
@@ -1,0 +1,23 @@
+name: CI GPU
+
+on: push
+jobs:
+  nightly:
+    runs-on: [self-hosted, gpu]
+    steps:
+      - name: Setup Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+          architecture: x64
+      - name: Checkout TorchServe
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          python ts_scripts/install_dependencies.py --environment=dev
+          python torchserve_sanity.py
+      - name: Torchserve Sanity
+        run: python torchserve_sanity.py
+      - name: mvn install
+        run: cd serving-sdk/ && mvn clean install -q && cd ../
+

--- a/.github/workflows/ci_gpu.yml
+++ b/.github/workflows/ci_gpu.yml
@@ -10,6 +10,11 @@ jobs:
         with:
           python-version: 3.8
           architecture: x64
+      - name: Setup Java 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
       - name: Checkout TorchServe
         uses: actions/checkout@v2
       - name: Install dependencies

--- a/.github/workflows/ci_gpu.yml
+++ b/.github/workflows/ci_gpu.yml
@@ -15,7 +15,6 @@ jobs:
       - name: Install dependencies
         run: |
           python ts_scripts/install_dependencies.py --environment=dev --cuda=cu102
-          python torchserve_sanity.py
       - name: Torchserve Sanity
         run: python torchserve_sanity.py
       - name: mvn install

--- a/.github/workflows/ci_gpu.yml
+++ b/.github/workflows/ci_gpu.yml
@@ -5,6 +5,9 @@ jobs:
   nightly:
     runs-on: [self-hosted, ci-gpu]
     steps:
+      - name: Clean up previous run
+        run: |
+          rm -rf "${{ github.workspace }}"
       - name: Setup Python 3.8
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/ci_gpu.yml
+++ b/.github/workflows/ci_gpu.yml
@@ -3,7 +3,7 @@ name: CI GPU
 on: push
 jobs:
   nightly:
-    runs-on: [self-hosted, gpu]
+    runs-on: [self-hosted, ci-gpu]
     steps:
       - name: Setup Python 3.8
         uses: actions/setup-python@v2

--- a/.github/workflows/ci_gpu.yml
+++ b/.github/workflows/ci_gpu.yml
@@ -5,7 +5,7 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  ci:
+  ci-gpu:
     runs-on: [self-hosted, ci-gpu]
     steps:
       - name: Setup Python 3.8

--- a/.github/workflows/ci_gpu.yml
+++ b/.github/workflows/ci_gpu.yml
@@ -8,9 +8,6 @@ jobs:
   nightly:
     runs-on: [self-hosted, ci-gpu]
     steps:
-      - name: Clean up previous run
-        run: |
-          rm -rf "${{ github.workspace }}"
       - name: Setup Python 3.8
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/ci_gpu.yml
+++ b/.github/workflows/ci_gpu.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Install dependencies
         run: |
-          python ts_scripts/install_dependencies.py --environment=dev
+          python ts_scripts/install_dependencies.py --environment=dev --cuda=cu102
           python torchserve_sanity.py
       - name: Torchserve Sanity
         run: python torchserve_sanity.py

--- a/torchserve_sanity.py
+++ b/torchserve_sanity.py
@@ -55,8 +55,4 @@ def cleanup():
 
 
 if __name__ == '__main__':
-    from pygit2 import Repository
-    git_branch = Repository('.').head.shorthand
-    build_hdr_printer.main(git_branch)
-
     torchserve_sanity()


### PR DESCRIPTION
An end to end CI pipeline for Linux CPU and GPU, Mac and Windows using Github Actions - benefits are
* No need for sagemaker neo bot anymore
* No flakiness 
* Anyone can click on logs
* Can split logs in steps
* Nicer integration with Github CI
* Color highlighting and search in logs
* Easy retry functionality without empty PRs to trigger builds
* Added support for Mac, Linux and Window

Fixes #1568 


You can validate this works here https://github.com/pytorch/serve/runs/6089163894?check_suite_focus=true