### PR TITLE
add --build_with_ipex to build torchserve docker with ipex 

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -19,6 +19,10 @@ ARG BRANCH_NAME=master
 ARG MACHINE_TYPE=cpu
 ARG CUDA_VERSION
 
+ARG BUILD_WITH_IPEX
+ARG IPEX_VERSION=1.11.0
+ARG IPEX_URL=https://software.intel.com/ipex-whl-stable
+
 ENV PYTHONUNBUFFERED TRUE
 
 RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt \
@@ -44,6 +48,8 @@ RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt \
     && curl -O https://bootstrap.pypa.io/get-pip.py \
     && python3.8 get-pip.py
 
+RUN if [ "$BUILD_WITH_IPEX" = "true" ]; then apt-get update && apt-get install -y libjemalloc-dev libomp-dev && rm -rf /var/lib/apt/lists/*; fi 
+
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1 \
     && update-alternatives --install /usr/local/bin/pip pip /usr/local/bin/pip3.8 1
 
@@ -58,6 +64,7 @@ RUN if [ "$MACHINE_TYPE" = "gpu" ]; then export USE_CUDA=1; fi \
     && python3.8 -m venv /home/venv \
     && python -m pip install -U pip setuptools \
     && if [ -z "$CUDA_VERSION" ]; then python ts_scripts/install_dependencies.py --environment=dev; else python ts_scripts/install_dependencies.py --environment=dev  --cuda $CUDA_VERSION; fi \
+    && if [ "$BUILD_WITH_IPEX" = "true" ]; then python -m pip install --no-cache-dir intel_extension_for_pytorch==${IPEX_VERSION} -f ${IPEX_URL}; fi \
     && python ts_scripts/install_from_src.py \
     && useradd -m model-server \
     && mkdir -p /home/model-server/tmp \
@@ -95,6 +102,8 @@ RUN set -ex \
   && tar xzvf /var/tmp/apache-maven-$MAVEN_VERSION-bin.tar.gz -C $MAVEN_HOME --strip-components=1 \
   && update-alternatives --install /usr/bin/mvn mvn /opt/maven/bin/mvn 10000 \
   && mkdir -p $MAVEN_CONFIG
+  
+RUN if [ "$BUILD_WITH_IPEX" = "true" ]; then ENV LD_PRELOAD "/usr/lib/x86_64-linux-gnu/libjemalloc.so"; fi 
 
 FROM ${BUILD_TYPE}-image AS final-image
 ARG BUILD_TYPE

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -48,8 +48,6 @@ RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt \
     && curl -O https://bootstrap.pypa.io/get-pip.py \
     && python3.8 get-pip.py
 
-RUN if [ "$BUILD_WITH_IPEX" = "true" ]; then apt-get update && apt-get install -y libjemalloc-dev libomp-dev && rm -rf /var/lib/apt/lists/*; fi 
-
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1 \
     && update-alternatives --install /usr/local/bin/pip pip /usr/local/bin/pip3.8 1
 
@@ -102,8 +100,6 @@ RUN set -ex \
   && tar xzvf /var/tmp/apache-maven-$MAVEN_VERSION-bin.tar.gz -C $MAVEN_HOME --strip-components=1 \
   && update-alternatives --install /usr/bin/mvn mvn /opt/maven/bin/mvn 10000 \
   && mkdir -p $MAVEN_CONFIG
-  
-RUN if [ "$BUILD_WITH_IPEX" = "true" ]; then ENV LD_PRELOAD "/usr/lib/x86_64-linux-gnu/libjemalloc.so"; fi 
 
 FROM ${BUILD_TYPE}-image AS final-image
 ARG BUILD_TYPE

--- a/docker/README.md
+++ b/docker/README.md
@@ -34,6 +34,7 @@ Use `build_image.sh` script to build the docker images. The script builds the `p
 |-bt, --buildtype|Which type of docker image to build. Can be one of : production, dev, codebuild|
 |-t, --tag|Tag name for image. If not specified, script uses torchserve default tag names.|
 |-cv, --cudaversion| Specify to cuda version to use. Supported values `cu92`, `cu101`, `cu102`, `cu111`, `cu113`. Default `cu102`|
+|-i, --build-with-ipex| Specify to build with intel_extension_for_pytorch. If not specified, script builds without intel_extension_for_pytorch.|
 |--codebuild| Set if you need [AWS CodeBuild](https://aws.amazon.com/codebuild/)|
 
 
@@ -122,6 +123,12 @@ Creates a docker image with `torchserve` and `torch-model-archiver` installed fr
 ./build_image.sh -bt dev -t torchserve-dev:1.0
 ```
 
+ - For creating image with Intel® Extension for PyTorch*:
+
+```bash
+./build_image.sh -bt dev -i -t torchserve-ipex:1.0
+```
+
 **CODEBUILD ENVIRONMENT IMAGES**
 
 Creates a docker image for codebuild environment
@@ -177,6 +184,12 @@ For specific versions you can pass in the specific tag to use (ex: pytorch/torch
 
 ```bash
 docker run --rm -it -p 8080:8080 -p 8081:8081 -p 8082:8082 -p 7070:7070 -p 7071:7071  pytorch/torchserve:0.1.1-cpu
+```
+
+#### Start CPU container with Intel® Extension for PyTorch*
+
+```bash
+docker run --rm -it -p 8080:8080 -p 8081:8081 -p 8082:8082 -p 7070:7070 -p 7071:7071  torchserve-ipex:1.0
 ```
 
 #### Start GPU container

--- a/docker/README.md
+++ b/docker/README.md
@@ -227,16 +227,26 @@ To create mar [model archive] file for TorchServe deployment, you can use follow
 1. Start container by sharing your local model-store/any directory containing custom/example mar contents as well as model-store directory (if not there, create it)
 
 ```bash
-docker run --rm -it -p 8080:8080 -p 8081:8081 --name mar -v $(pwd)/model-store:/home/model-server/model-store -v $(pwd)/examples:/home/model-server/examples  pytorch/torchserve:latest
+docker run --rm -it -p 8080:8080 -p 8081:8081 --name mar -v $(pwd)/model-store:/home/model-server/model-store -v $(pwd)/examples:/home/model-server/examples pytorch/torchserve:latest
 ```
 
-1. List your container or skip this if you know container name
+1.a. If starting container with Intel® Extension for PyTorch*, add the following lines in `config.properties` to enable IPEX and launcher with its default configuration.
+```
+ipex_enable=true
+cpu_launcher_enable=true
+```
+
+```bash
+docker run --rm -it -p 8080:8080 -p 8081:8081 --name mar -v $(pwd)/config.properties:/home/model-server/config.properties -v $(pwd)/model-store:/home/model-server/model-store -v $(pwd)/examples:/home/model-server/examples torchserve-ipex:1.0
+```
+
+2. List your container or skip this if you know container name
 
 ```bash
 docker ps
 ```
 
-2. Bind and get the bash prompt of running container
+3. Bind and get the bash prompt of running container
 
 ```bash
 docker exec -it <container_name> /bin/bash
@@ -244,13 +254,13 @@ docker exec -it <container_name> /bin/bash
 
 You will be landing at /home/model-server/.
 
-3. Download the model weights if you have not done so already (they are not part of the repo)
+4. Download the model weights if you have not done so already (they are not part of the repo)
 
 ```bash
 curl -o /home/model-server/examples/image_classifier/densenet161-8d451a50.pth https://download.pytorch.org/models/densenet161-8d451a50.pth
 ```
 
-4. Now Execute torch-model-archiver command e.g.
+5. Now Execute torch-model-archiver command e.g.
 
 ```bash
 torch-model-archiver --model-name densenet161 --version 1.0 --model-file /home/model-server/examples/image_classifier/densenet_161/model.py --serialized-file /home/model-server/examples/image_classifier/densenet161-8d451a50.pth --export-path /home/model-server/model-store --extra-files /home/model-server/examples/image_classifier/index_to_name.json --handler image_classifier
@@ -258,7 +268,7 @@ torch-model-archiver --model-name densenet161 --version 1.0 --model-file /home/m
 
 Refer [torch-model-archiver](../model-archiver/README.md) for details.
 
-5. desnet161.mar file should be present at /home/model-server/model-store
+6. desnet161.mar file should be present at /home/model-server/model-store
 
 # Running TorchServe in a Production Docker Environment.
 

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -107,5 +107,5 @@ elif [ $BUILD_TYPE == "benchmark" ]
 then
   DOCKER_BUILDKIT=1 docker build --pull --no-cache --file Dockerfile.benchmark --build-arg USE_LOCAL_SERVE_FOLDER=$USE_LOCAL_SERVE_FOLDER --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg BRANCH_NAME=$BRANCH_NAME --build-arg CUDA_VERSION=$CUDA_VERSION --build-arg MACHINE_TYPE=$MACHINE -t $DOCKER_TAG .
 else
-  DOCKER_BUILDKIT=1 docker build --pull --no-cache --file Dockerfile.dev -t $DOCKER_TAG --build-arg BUILD_TYPE=$BUILD_TYPE --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg BRANCH_NAME=$BRANCH_NAME --build-arg CUDA_VERSION=$CUDA_VERSION --build-arg MACHINE_TYPE=$MACHINE --build-arg BUILD_WITH_IPEX=$BUILD_WITH_IPEX --progress=plain .
+  DOCKER_BUILDKIT=1 docker build --pull --no-cache --file Dockerfile.dev -t $DOCKER_TAG --build-arg BUILD_TYPE=$BUILD_TYPE --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg BRANCH_NAME=$BRANCH_NAME --build-arg CUDA_VERSION=$CUDA_VERSION --build-arg MACHINE_TYPE=$MACHINE --build-arg BUILD_WITH_IPEX=$BUILD_WITH_IPEX .
 fi

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -9,6 +9,7 @@ BASE_IMAGE="ubuntu:18.04"
 CUSTOM_TAG=false
 CUDA_VERSION=""
 USE_LOCAL_SERVE_FOLDER=false
+BUILD_WITH_IPEX=false
 
 for arg in "$@"
 do
@@ -22,6 +23,7 @@ do
           echo "-cv, --cudaversion specify to cuda version to use"
           echo "-t, --tag specify tag name for docker image"
           echo "-lf, --use-local-serve-folder specify this option for the benchmark image if the current 'serve' folder should be used during automated benchmarks"
+          echo "-i, --build-with-ipex specify to build with intel_extension_for_pytorch"
           exit 0
           ;;
         -b|--branch_name)
@@ -54,7 +56,11 @@ do
           shift
           ;;
         -lf|--use-local-serve-folder)
-          USE_LOCAL_SERVE_FOLDER=true
+          USE_LOCAL_SERVE_FOLDER=true        
+          shift
+          ;;
+        -i|--build-with-ipex)
+          BUILD_WITH_IPEX=true
           shift
           ;;
         -cv|--cudaversion)
@@ -101,5 +107,5 @@ elif [ $BUILD_TYPE == "benchmark" ]
 then
   DOCKER_BUILDKIT=1 docker build --pull --no-cache --file Dockerfile.benchmark --build-arg USE_LOCAL_SERVE_FOLDER=$USE_LOCAL_SERVE_FOLDER --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg BRANCH_NAME=$BRANCH_NAME --build-arg CUDA_VERSION=$CUDA_VERSION --build-arg MACHINE_TYPE=$MACHINE -t $DOCKER_TAG .
 else
-  DOCKER_BUILDKIT=1 docker build --pull --no-cache --file Dockerfile.dev -t $DOCKER_TAG --build-arg BUILD_TYPE=$BUILD_TYPE --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg BRANCH_NAME=$BRANCH_NAME --build-arg CUDA_VERSION=$CUDA_VERSION --build-arg MACHINE_TYPE=$MACHINE .
+  DOCKER_BUILDKIT=1 docker build --pull --no-cache --file Dockerfile.dev -t $DOCKER_TAG --build-arg BUILD_TYPE=$BUILD_TYPE --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg BRANCH_NAME=$BRANCH_NAME --build-arg CUDA_VERSION=$CUDA_VERSION --build-arg MACHINE_TYPE=$MACHINE --build-arg BUILD_WITH_IPEX=$BUILD_WITH_IPEX --progress=plain .
 fi


### PR DESCRIPTION
This PR (1) adds `--build_with_ipex` to [build_image.sh](https://github.com/pytorch/serve/blob/master/docker/build_image.sh) to create docker image of torchserve with ipex (2) added instructions/steps to follow in docker README 

Users can simply run `./build_image.sh -bt dev -i -t torchserve-ipex:1.0`