### PR TITLE
fixed nvidia key sign bug

### DIFF
--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -38,7 +38,7 @@ do
         -g|--gpu)
           MACHINE=gpu
           DOCKER_TAG="pytorch/torchserve:latest-gpu"
-          BASE_IMAGE="nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04"
+          BASE_IMAGE="nvidia/cuda:10.2-cudnn8-runtime-ubuntu18.04"
           CUDA_VERSION="cu102"
           shift
           ;;


### PR DESCRIPTION
## Description

We were using an older version of cudnn in our `build_image.sh` which was causing

```
7 5.133 W: GPG error: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC
#7 5.133 E: The repository 'https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease' is not signed.
```

Fixes part 3 of #1621 - will address other issues in subsequent PRs

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Feature/Issue validation/testing

Please describe the tests [UT/IT] that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

Succesfully ran

```
/build_image.sh -g --cv=cu113 -bt=dev
/build_image.sh -g --cv=cu102 -bt=dev
/build_image.sh -g --cv=cu113 -bt=production
/build_image.sh -g --cv=cu102 -bt=production
./build_image.sh -g --cv=cu113 -bt=benchmark
./build_image.sh -g --cv=cu102 -bt=benchmark

```

- Logs

### With fix

```
(serve) ➜  docker git:(dockerpermfix) ✗ ./build_image.sh -g --cv=cu102 -bt=production
[+] Building 191.7s (23/23) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                         0.0s
 => => transferring dockerfile: 4.49kB                                                                                                                       0.0s
 => [internal] load .dockerignore                                                                                                                            0.0s
 => => transferring context: 2B                                                                                                                              0.0s
 => resolve image config for docker.io/docker/dockerfile:experimental                                                                                        0.6s
 => CACHED docker-image://docker.io/docker/dockerfile:experimental@sha256:600e5c62eedff338b3f7a0850beb7c05866e0ef27b2d2e8c02aa468e78496ff5                   0.0s
 => [internal] load metadata for docker.io/nvidia/cuda:10.2-cudnn8-runtime-ubuntu18.04                                                                       0.9s
 => [internal] load build context                                                                                                                            0.0s
 => => transferring context: 541B                                                                                                                            0.0s
 => [compile-image 1/8] FROM docker.io/nvidia/cuda:10.2-cudnn8-runtime-ubuntu18.04@sha256:00a2544a91ced50ca63154beafc3560e109563ac0098632b0cd3d32fad80add4  58.0s
 => => resolve docker.io/nvidia/cuda:10.2-cudnn8-runtime-ubuntu18.04@sha256:00a2544a91ced50ca63154beafc3560e109563ac0098632b0cd3d32fad80add4                 0.0s
 => => sha256:00a2544a91ced50ca63154beafc3560e109563ac0098632b0cd3d32fad80add4 2.00kB / 2.00kB                                                               0.0s
 => => sha256:f9ff1bc9cd1af2ce34fa1f9d8808044a885f0f30550f1932c9dc2d2e8699bae9 10.40kB / 10.40kB                                                             0.0s
 => => sha256:5a4c6c52d847d845d2b23e5a54f90b3121cb2b4de20a48e0e241a9ea5b92bc3e 7.22MB / 7.22MB                                                               0.5s
 => => sha256:f09791745eb65f4a3496144f8f251c06f5ae9ba96bfdd457b59a4e40f353044d 9.55MB / 9.55MB                                                               0.7s
 => => sha256:2beb24024110a4fa3395ca6658da5789f570ba14730f391c8aebb3ba8741250f 186B / 186B                                                                   0.4s
 => => sha256:3b068041ee3d92aaaa96de47bb535845301313f18275ef581ba62c81248be2bb 6.43kB / 6.43kB                                                               0.6s
 => => extracting sha256:5a4c6c52d847d845d2b23e5a54f90b3121cb2b4de20a48e0e241a9ea5b92bc3e                                                                    0.3s
 => => sha256:429b4c3a7649668d363d7c3342c19b77a43487683547b9dee3b65ff79bbbfca1 759.75MB / 759.75MB                                                          26.6s
 => => sha256:db1219a58b7d2c8ab336eb644bf15ebe8f4b1fdbe46421880625cb645d7ec452 62.79kB / 62.79kB                                                             0.8s
 => => sha256:4ee529648248e6b2a919075edb41b8d60f4d27691d7ddb942c430295b785d8f8 367.39MB / 367.39MB                                                          16.4s
 => => extracting sha256:f09791745eb65f4a3496144f8f251c06f5ae9ba96bfdd457b59a4e40f353044d                                                                    0.3s
 => => extracting sha256:2beb24024110a4fa3395ca6658da5789f570ba14730f391c8aebb3ba8741250f                                                                    0.0s
 => => extracting sha256:3b068041ee3d92aaaa96de47bb535845301313f18275ef581ba62c81248be2bb                                                                    0.0s
 => => extracting sha256:429b4c3a7649668d363d7c3342c19b77a43487683547b9dee3b65ff79bbbfca1                                                                   20.5s
 => => extracting sha256:db1219a58b7d2c8ab336eb644bf15ebe8f4b1fdbe46421880625cb645d7ec452                                                                    0.1s
 => => extracting sha256:4ee529648248e6b2a919075edb41b8d60f4d27691d7ddb942c430295b785d8f8                                                                   10.2s
 => [runtime-image 2/9] RUN --mount=type=cache,target=/var/cache/apt     apt-get update &&     DEBIAN_FRONTEND=noninteractive apt-get install --no-install  40.1s
 => [compile-image 2/8] RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt     apt-get update &&     apt remove python-pip  python3-pip &&     DEBIAN  44.8s
 => [runtime-image 3/9] RUN useradd -m model-server     && mkdir -p /home/model-server/tmp                                                                   0.3s
 => [compile-image 3/8] RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1     && update-alternatives --install /usr/local/bin/p  0.3s
 => [compile-image 4/8] RUN python3.8 -m venv /home/venv                                                                                                     1.4s
 => [compile-image 5/8] RUN python -m pip install -U pip setuptools                                                                                          4.2s
 => [compile-image 6/8] RUN export USE_CUDA=1                                                                                                                0.2s
 => [compile-image 7/8] RUN TORCH_VER=$(curl --silent --location https://pypi.org/pypi/torch/json | python -c "import sys, json, pkg_resources; releases =  56.4s
 => [compile-image 8/8] RUN python -m pip install -U setuptools && python -m pip install --no-cache-dir captum torchtext torchserve torch-model-archiver     3.9s
 => [runtime-image 4/9] COPY --chown=model-server --from=compile-image /home/venv /home/venv                                                                 5.3s
 => [runtime-image 5/9] COPY dockerd-entrypoint.sh /usr/local/bin/dockerd-entrypoint.sh                                                                      0.0s
 => [runtime-image 6/9] RUN chmod +x /usr/local/bin/dockerd-entrypoint.sh     && chown -R model-server /home/model-server                                    0.2s
 => [runtime-image 7/9] COPY config.properties /home/model-server/config.properties                                                                          0.0s
 => [runtime-image 8/9] RUN mkdir /home/model-server/model-store && chown -R model-server /home/model-server/model-store                                     0.3s
 => [runtime-image 9/9] WORKDIR /home/model-server                                                                                                           0.0s
 => exporting to image                                                                                                                                       9.2s
 => => exporting layers                                                                                                                                      9.1s
 => => writing image sha256:92b108c31fc13960d750de4d0db01f8acd48cb4aff9fc9b904f1c3715cff064b                                                                 0.0s
 => => naming to docker.io/pytorch/torchserve:latest-gpu
```

### Without fix

```
(serve) ➜  docker git:(dockerpermfix) ✗ ./build_image.sh -g --cv=cu102 -bt=production
[+] Building 7.2s (11/24)
 => [internal] load build definition from Dockerfile                                                                                                         0.0s
 => => transferring dockerfile: 37B                                                                                                                          0.0s
 => [internal] load .dockerignore                                                                                                                            0.0s
 => => transferring context: 2B                                                                                                                              0.0s
 => resolve image config for docker.io/docker/dockerfile:experimental                                                                                        1.1s
 => [auth] docker/dockerfile:pull token for registry-1.docker.io                                                                                             0.0s
 => CACHED docker-image://docker.io/docker/dockerfile:experimental@sha256:600e5c62eedff338b3f7a0850beb7c05866e0ef27b2d2e8c02aa468e78496ff5                   0.0s
 => [internal] load metadata for docker.io/nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04                                                                       0.6s
 => [auth] nvidia/cuda:pull token for registry-1.docker.io                                                                                                   0.0s
 => [internal] load build context                                                                                                                            0.0s
 => => transferring context: 80B                                                                                                                             0.0s
 => CACHED [compile-image 1/8] FROM docker.io/nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04@sha256:f95d5833f0e9ae06b8a9ebd28ca2760a87e43e7ac717603b3ff56d2498  0.0s
 => ERROR [compile-image 2/8] RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt     apt-get update &&     apt remove python-pip  python3-pip &&     D  5.2s
 => ERROR [runtime-image 2/9] RUN --mount=type=cache,target=/var/cache/apt     apt-get update &&     DEBIAN_FRONTEND=noninteractive apt-get install --no-in  5.2s
------
 > [compile-image 2/8] RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt     apt-get update &&     apt remove python-pip  python3-pip &&     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y     ca-certificates     g++     python3.8     python3.8-dev     python3.8-distutils     python3.8-venv     python3-venv     openjdk-11-jre-headless     curl     && rm -rf /var/lib/apt/lists/*     && cd /tmp     && curl -O https://bootstrap.pypa.io/get-pip.py     && python3.8 get-pip.py:
#11 0.544 Get:1 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease [1581 B]
#11 0.575 Ign:2 https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64  InRelease
#11 0.598 Get:3 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]
#11 0.600 Get:4 https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64  Release [564 B]
#11 0.629 Get:5 https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64  Release.gpg [833 B]
#11 0.659 Err:1 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease
#11 0.659   The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC
#11 0.732 Get:6 http://archive.ubuntu.com/ubuntu bionic InRelease [242 kB]
#11 0.761 Get:7 https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64  Packages [73.8 kB]
#11 1.005 Get:8 http://security.ubuntu.com/ubuntu bionic-security/main amd64 Packages [2747 kB]
#11 1.571 Get:9 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]
#11 1.627 Get:10 http://security.ubuntu.com/ubuntu bionic-security/restricted amd64 Packages [921 kB]
#11 1.660 Get:11 http://security.ubuntu.com/ubuntu bionic-security/multiverse amd64 Packages [21.1 kB]
#11 1.660 Get:12 http://security.ubuntu.com/ubuntu bionic-security/universe amd64 Packages [1501 kB]
#11 1.768 Get:13 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]
#11 1.958 Get:14 http://archive.ubuntu.com/ubuntu bionic/multiverse amd64 Packages [186 kB]
#11 2.046 Get:15 http://archive.ubuntu.com/ubuntu bionic/main amd64 Packages [1344 kB]
#11 2.428 Get:16 http://archive.ubuntu.com/ubuntu bionic/restricted amd64 Packages [13.5 kB]
#11 2.429 Get:17 http://archive.ubuntu.com/ubuntu bionic/universe amd64 Packages [11.3 MB]
#11 3.094 Get:18 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages [2277 kB]
#11 3.213 Get:19 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse amd64 Packages [29.8 kB]
#11 3.214 Get:20 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [3195 kB]
#11 3.435 Get:21 http://archive.ubuntu.com/ubuntu bionic-updates/restricted amd64 Packages [966 kB]
#11 3.450 Get:22 http://archive.ubuntu.com/ubuntu bionic-backports/main amd64 Packages [12.2 kB]
#11 3.451 Get:23 http://archive.ubuntu.com/ubuntu bionic-backports/universe amd64 Packages [12.9 kB]
#11 4.138 Reading package lists...
#11 5.150 W: GPG error: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC
#11 5.150 E: The repository 'https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease' is not signed.
------
------
 > [runtime-image 2/9] RUN --mount=type=cache,target=/var/cache/apt     apt-get update &&     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y     python3.8     python3.8-distutils     python3.8-dev     openjdk-11-jre-headless     build-essential     && rm -rf /var/lib/apt/lists/*     && cd /tmp:
#9 0.541 Get:1 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease [1581 B]
#9 0.578 Ign:2 https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64  InRelease
#9 0.595 Get:3 http://security.ubuntu.com/ubuntu bionic-security InRelease [88.7 kB]
#9 0.601 Get:4 https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64  Release [564 B]
#9 0.627 Get:5 https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64  Release.gpg [833 B]
#9 0.656 Err:1 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease
#9 0.656   The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC
#9 0.731 Get:6 http://archive.ubuntu.com/ubuntu bionic InRelease [242 kB]
#9 0.759 Get:7 https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64  Packages [73.8 kB]
#9 1.006 Get:8 http://security.ubuntu.com/ubuntu bionic-security/universe amd64 Packages [1501 kB]
#9 1.517 Get:9 http://security.ubuntu.com/ubuntu bionic-security/restricted amd64 Packages [921 kB]
#9 1.565 Get:10 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]
#9 1.609 Get:11 http://security.ubuntu.com/ubuntu bionic-security/main amd64 Packages [2747 kB]
#9 1.736 Get:12 http://security.ubuntu.com/ubuntu bionic-security/multiverse amd64 Packages [21.1 kB]
#9 1.762 Get:13 http://archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]
#9 1.950 Get:14 http://archive.ubuntu.com/ubuntu bionic/restricted amd64 Packages [13.5 kB]
#9 1.955 Get:15 http://archive.ubuntu.com/ubuntu bionic/main amd64 Packages [1344 kB]
#9 2.396 Get:16 http://archive.ubuntu.com/ubuntu bionic/universe amd64 Packages [11.3 MB]
#9 3.062 Get:17 http://archive.ubuntu.com/ubuntu bionic/multiverse amd64 Packages [186 kB]
#9 3.065 Get:18 http://archive.ubuntu.com/ubuntu bionic-updates/restricted amd64 Packages [966 kB]
#9 3.125 Get:19 http://archive.ubuntu.com/ubuntu bionic-updates/multiverse amd64 Packages [29.8 kB]
#9 3.126 Get:20 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages [2277 kB]
#9 3.231 Get:21 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [3195 kB]
#9 3.406 Get:22 http://archive.ubuntu.com/ubuntu bionic-backports/main amd64 Packages [12.2 kB]
#9 3.406 Get:23 http://archive.ubuntu.com/ubuntu bionic-backports/universe amd64 Packages [12.9 kB]
#9 4.115 Reading package lists...
#9 5.142 W: GPG error: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC
#9 5.142 E: The repository 'https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease' is not signed.
------
executor failed running [/bin/sh -c apt-get update &&     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y     python3.8     python3.8-distutils     python3.8-dev     openjdk-11-jre-headless     build-essential     && rm -rf /var/lib/apt/lists/*     && cd /tmp]: exit code: 100
```
