### PR TITLE
fix workflow archiver build version wrong

### DIFF
--- a/workflow-archiver/setup.py
+++ b/workflow-archiver/setup.py
@@ -49,7 +49,7 @@ def get_nightly_version():
     return today.strftime("%Y.%m.%d")
 
 if __name__ == '__main__':
-    version = detect_workflow_archiver_version()
+    #version = detect_workflow_archiver_version()
     name = 'torch-workflow-archiver'
 
     # Clever code to figure out if setup.py was trigger by ts_scripts/push_nightly.sh


### PR DESCRIPTION
#### problem
```
run python  binaries/build.py
=>
./dist/torchserve-0.6.0-py2.py3-none-any.whl
./model-archiver/dist/torch_model_archiver-0.6.0-py2.py3-none-any.whl
./workflow-archiver/dist/torch_workflow_archiver-0.2.4b20220512-py2.py3-none-any.whl
```

#### Test log
```
run python  binaries/build.py
=>
./dist/torchserve-0.6.0-py2.py3-none-any.whl
./model-archiver/dist/torch_model_archiver-0.6.0-py2.py3-none-any.whl
./workflow-archiver/dist/torch_workflow_archiver-0.2.4-py2.py3-none-any.whl
```


