### PR TITLE
Fixed typo in cuda version in docker_nightly.py

### DIFF
--- a/docker/docker_nightly.py
+++ b/docker/docker_nightly.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":
 
     # Build Nightly images and append the date in the name
     try_and_handle(f"./build_image.sh -bt dev -t {organization}/{cpu_version}", dry_run)
-    try_and_handle(f"./build_image.sh -bt dev -g -cv 102 -t {organization}/{gpu_version}", dry_run)
+    try_and_handle(f"./build_image.sh -bt dev -g -cv cu102 -t {organization}/{gpu_version}", dry_run)
 
     # Push Nightly images to official PyTorch Dockerhub account
     try_and_handle(f"docker push {organization}/{cpu_version}", dry_run)


### PR DESCRIPTION
## Description
Apologies for this fix,this was an extra commit I introduced after showing logs on the last PR 

Fixes https://github.com/pytorch/serve/actions/runs/2345149011
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

### Before
- https://github.com/pytorch/serve/actions/runs/2345149011

### After

**Dry_run**
```
Executing command: ./build_image.sh -bt dev -t marksaroufim/torchserve-nightly:cpu-2022.05.18
Executing command: ./build_image.sh -bt dev -g -cv cu102 -t marksaroufim/torchserve-nightly:gpu-2022.05.18
Executing command: docker push marksaroufim/torchserve-nightly:cpu-2022.05.18
Executing command: docker push marksaroufim/torchserve-nightly:gpu-2022.05.18
Executing command: docker tag marksaroufim/torchserve-nightly:cpu-2022.05.18 marksaroufim/torchserve-nightly:latest-cpu
Executing command: docker tag marksaroufim/torchserve-nightly:gpu-2022.05.18 marksaroufim/torchserve-nightly:latest-gpu
Executing command: docker push marksaroufim/torchserve-nightly:latest-cpu
Executing command: docker push marksaroufim/torchserve-nightly:latest-gpu
```

**Build image now succeeds**

```
base) ➜  docker git:(msaroufim-patch-13) python docker_nightly.py --organization marksaroufim
[+] Building 256.8s (12/12) FINISHED
 => [internal] load build definition from Dockerfile.dev                                                                                           0.0s
 => => transferring dockerfile: 41B                                                                                                                0.0s
 => [internal] load .dockerignore                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                    0.0s
 => resolve image config for docker.io/docker/dockerfile:experimental                                                                              0.4s
 => CACHED docker-image://docker.io/docker/dockerfile:experimental@sha256:600e5c62eedff338b3f7a0850beb7c05866e0ef27b2d2e8c02aa468e78496ff5         0.0s
 => [internal] load metadata for docker.io/library/ubuntu:18.04                                                                                    0.4s
 => CACHED [compile-image 1/3] FROM docker.io/library/ubuntu:18.04@sha256:d21b6ba9e19feffa328cb3864316e6918e30acfd55e285b5d3df1d8ca3c7fd3f         0.0s
 => [compile-image 2/3] RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt     apt-get update &&     DEBIAN_FRONTEND=noninteractive apt-get  66.1s
 => [compile-image 3/3] RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1     && update-alternatives --install /usr/l  0.3s
 => [dev-image 1/2] RUN if [ "cpu" = "gpu" ]; then export USE_CUDA=1; fi     && git clone https://github.com/pytorch/serve.git     && cd serve   176.6s
 => [dev-image 2/2] WORKDIR /home/model-server                                                                                                     0.0s
 => [final-image 1/1] RUN echo "dev image creation completed"                                                                                      0.3s
 => exporting to image                                                                                                                            12.4s
 => => exporting layers                                                                                                                           12.4s
 => => writing image sha256:b5545e82597345f9ec38e1281de41267820aacb13218cf5b61082f3a60336703                                                       0.0s
 => => naming to docker.io/marksaroufim/torchserve-nightly:cpu-2022.05.18                                                                          0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
[+] Building 296.4s (14/14) FINISHED
 => [internal] load build definition from Dockerfile.dev                                                                                           0.0s
 => => transferring dockerfile: 41B                                                                                                                0.0s
 => [internal] load .dockerignore                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                    0.0s
 => resolve image config for docker.io/docker/dockerfile:experimental                                                                              1.2s
 => [auth] docker/dockerfile:pull token for registry-1.docker.io                                                                                   0.0s
 => CACHED docker-image://docker.io/docker/dockerfile:experimental@sha256:600e5c62eedff338b3f7a0850beb7c05866e0ef27b2d2e8c02aa468e78496ff5         0.0s
 => [internal] load metadata for docker.io/nvidia/cuda:10.2-cudnn8-runtime-ubuntu18.04                                                             0.7s
 => [auth] nvidia/cuda:pull token for registry-1.docker.io                                                                                         0.0s
 => CACHED [compile-image 1/3] FROM docker.io/nvidia/cuda:10.2-cudnn8-runtime-ubuntu18.04@sha256:00a2544a91ced50ca63154beafc3560e109563ac0098632b  0.0s
 => [compile-image 2/3] RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt     apt-get update &&     DEBIAN_FRONTEND=noninteractive apt-get  79.0s
 => [compile-image 3/3] RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1     && update-alternatives --install /usr/l  0.3s
 => [dev-image 1/2] RUN if [ "gpu" = "gpu" ]; then export USE_CUDA=1; fi     && git clone https://github.com/pytorch/serve.git     && cd serve   191.0s
 => [dev-image 2/2] WORKDIR /home/model-server                                                                                                     0.0s
 => [final-image 1/1] RUN echo "dev image creation completed"                                                                                      0.4s
 => exporting to image                                                                                                                            23.5s
 => => exporting layers                                                                                                                           23.5s
 => => writing image sha256:4a8f8e7e6ff2edeaf47097205ba352e7085c533a1a4afe79d26cbf58f9f5c729                                                       0.0s
 => => naming to docker.io/marksaroufim/torchserve-nightly:gpu-2022.05.18
```

- Logs
- https://github.com/pytorch/serve/actions/runs/2345149011
