### PR TITLE
[WIP] DALI integration

### DIFF
--- a/ts/torch_handler/image_classifier.py
+++ b/ts/torch_handler/image_classifier.py
@@ -18,16 +18,12 @@ class ImageClassifier(VisionHandler):
     topk = 5
     # These are the standard Imagenet dimensions
     # and statistics
-    mean_ = [[[0.4850]],[[0.4560]],[[0.4060]]]
-    mean_ = torch.as_tensor(mean_)
-
-    std_ = [[[0.229]],[[0.224]],[[0.225]]]
-    std_ = torch.as_tensor(std_)
-
-
     image_processing = transforms.Compose([
+        transforms.Resize(256),
+        transforms.CenterCrop(224),
         transforms.ToTensor(),
-        transforms.Normalize(mean=mean_,std=std_, inplace=True)
+        transforms.Normalize(mean=[0.485, 0.456, 0.406],
+                             std=[0.229, 0.224, 0.225])
     ])
 
     def set_max_result_classes(self, topk):

--- a/ts/torch_handler/image_classifier.py
+++ b/ts/torch_handler/image_classifier.py
@@ -18,12 +18,16 @@ class ImageClassifier(VisionHandler):
     topk = 5
     # These are the standard Imagenet dimensions
     # and statistics
+    mean_ = [[[0.4850]],[[0.4560]],[[0.4060]]]
+    mean_ = torch.as_tensor(mean_)
+
+    std_ = [[[0.229]],[[0.224]],[[0.225]]]
+    std_ = torch.as_tensor(std_)
+
+
     image_processing = transforms.Compose([
-        transforms.Resize(256),
-        transforms.CenterCrop(224),
         transforms.ToTensor(),
-        transforms.Normalize(mean=[0.485, 0.456, 0.406],
-                             std=[0.229, 0.224, 0.225])
+        transforms.Normalize(mean=mean_,std=std_, inplace=True)
     ])
 
     def set_max_result_classes(self, topk):

--- a/ts/torch_handler/text_handler.py
+++ b/ts/torch_handler/text_handler.py
@@ -12,8 +12,8 @@ import torch
 import torch.nn.functional as F
 from torchtext.data.utils import get_tokenizer
 from captum.attr import LayerIntegratedGradients
-from .base_handler import BaseHandler
-from .contractions import CONTRACTION_MAP
+from ts.torch_handler.base_handler import BaseHandler
+from ts.torch_handler import CONTRACTION_MAP
 
 logger = logging.getLogger(__name__)
 

--- a/ts/torch_handler/vision_handler.py
+++ b/ts/torch_handler/vision_handler.py
@@ -16,34 +16,82 @@ from nvidia.dali.fn import image_decoder
 from nvidia.dali.pipeline import pipeline_def
 import nvidia.dali.types as types
 import nvidia.dali.fn as fn
+import nvidia.dali
 from nvidia.dali.plugin.pytorch import DALIGenericIterator
 
 
-### TOREMOVE: Notes to self
-###
-## There are a few things that make our image handlers slow
-## We stack tensors and pass them around in lists instead of creating a batched tensor
-# Indexing into it and then passing that whole tensor in one go
-## Any for loop in our handler code is code smell
+"""
+## TOREMOVE: Notes to self
+##
+# There are a few things that make our image handlers slow
+# We stack tensors and pass them around in lists instead of creating a batched tensor
+Indexing into it and then passing that whole tensor in one go
+# Any for loop in our handler code is code smell. This is a simple change that'll make things much faster
 
-### DALI specific
-### We can build a DALI pipeline once in initialization and then pass in input tensors one by one in the same way that
-### https://github.com/triton-inference-server/dali_backend/blob/main/client/dali_grpc_client.py
-### DALI seems to not mind manually reading input images as lists :?
+## DALI specific
+## We can build a DALI pipeline once in initialization and then pass in input tensors one by one in the same way that
+## https://github.com/triton-inference-server/dali_backend/blob/main/client/dali_grpc_client.py
+## DALI seems to not mind manually reading input images as lists :?
+## DALI only has Ubuntu support so can't drop legacy pipeline and supports Keppler and above
+## DALI will shine in CPU bottlenecked siutations so best benchmark is  Amazon EC2 P3.16xlarge,
+
+Initial goal was to only use NVJPEG decoding but that's a DALI op
+so will require us to run a full pipeline - do we also need to use their dataa loader?
+
+DALI decode and read assume a JPEG image is being read from disk wheras in our handlers we are given a List[torch.Tensor]
+@pipeline_def
+def simple_pipeline():
+    jpegs, labels = fn.readers.file(file_root=image_dir)
+    images = fn.decoders.image(jpegs, device='cpu')
+
+    return images, labels
 
 
-@pipeline_def(num_threads=4, device_id=0, batch_size=1) #batch_size = 128
+pipe_out = pipe.run()
+print(pipe_out)
+
+The output is not a torch.Tensor either
+(TensorListCPU(
+    [[[[255 255 255]
+      [255 255 255]
+
+The graph can be serialized save_graph_to_dot_file(filename, show_tensors=False, show_ids=False, use_colors=False)¶
+
+How to do conversions of DALITensor to a generic torch tensor feed_input(data_node, data, layout=None, cuda_stream=None, use_copy_kernel=False)
+
+DALI supports several different layouts https://docs.nvidia.com/deeplearning/dali/user-guide/docs/data_types.html#interpreting-tensor-layout-strings
+So it should give us free support for video
+
+Not all ops are supported on GPU, most are mixed https://docs.nvidia.com/deeplearning/dali/user-guide/docs/supported_ops.html
+
+DALI expects to read input data in its own format, you can customize this behavior with an
+
+
+# Can copy to a numpy array but then this will be slow
+# images.detach().numpy()
+# Decoder takes in jpeg images and not torch tensors
+# images = fn.decoders.image(images) # This is a CPU only operation
+
+"""
+
+@pipeline_def(num_threads=4, device_id=0, batch_size=2) #batch_size = 128
 def get_dali_pipeline(data):
+    images = []
+    for image in data:
 
-    for images in data:
-        images = fn.decoders.image(images) # This is a CPU only operation
-        images = fn.resize(images, resize_x=256, resize_y=256)
-        images = fn.decoders.image_random_crop(images, output_type=types.RGB)
-        images = fn.crop_mirror_normalize(images,
-                                        mean=[0.485 * 255,0.456 * 255,0.406 * 255],
-                                        std=[0.229 * 255,0.224 * 255,0.225 * 255],
-                                        mirror=fn.random.coin_flip())
+
+        # images = fn.decoders.image_random_crop(images, output_type=types.RGB)
+
+        # images = fn.resize(images, resize_x=256, resize_y=256)
+        # images = fn.crop_mirror_normalize(images,
+                                        # mean=[0.485 * 255,0.456 * 255,0.406 * 255],
+                                        # std=[0.229 * 255,0.224 * 255,0.225 * 255],
+                                        # mirror=fn.random.coin_flip())
+        images.append(image)
+        
     return images
+
+
 
 class VisionHandler(BaseHandler, ABC):
     """
@@ -51,10 +99,12 @@ class VisionHandler(BaseHandler, ABC):
     """
 
     def initialize(self, data):
-        pipe = get_dali_pipeline(data)
+        self.pipe = get_dali_pipeline(data)
+        self.pipe.build()
+        output = self.pipe.run()
+
         # print(data)
-        pipe.build()
-        output = pipe.run()
+
         return output
 
     def preprocess(self, data):
@@ -67,12 +117,23 @@ class VisionHandler(BaseHandler, ABC):
             list : The preprocess function returns the input image as a list of float tensors.
         """
 
+        batch_size = 2
         images = self.initialize(data)
+
+        # https://docs.nvidia.com/deeplearning/dali/user-guide/docs/plugins/pytorch_plugin_api.html#nvidia.dali.plugin.pytorch.feed_ndarray
+        # pytorch_tensor = torch.empty(batch_size, 3, 224, 224)
+
+        # nvidia.dali.plugin.pytorch.feed_ndarray(images, pytorch_tensor)
+        
+        output = nvidia.dali.plugin.pytorch.DALIGenericIterator(pipelines=[self.pipe], output_map="hello")
+
+
+        # print(image)
+
         return images
 
         ## Allocated a tensor instead of putting images in a list
         # batch_size = len(data)
-        # images = torch.empty(batch_size, 3, 224, 224)
 
         # for i in range(len(data)):
         #     row = data[i]

--- a/ts/torch_handler/vision_handler.py
+++ b/ts/torch_handler/vision_handler.py
@@ -4,26 +4,37 @@
 Base module for all vision handlers
 """
 from abc import ABC
+from csv import get_dialect
 import io
 import base64
 import torch
 from PIL import Image
 from captum.attr import IntegratedGradients
-from .base_handler import BaseHandler
+from ts.torch_handler.base_handler import BaseHandler
 
+from nvidia.dali.fn import image_decoder
+from nvidia.dali.pipeline import pipeline_def
+import nvidia.dali.types as types
+import nvidia.dali.fn as fn
+from nvidia.dali.plugin.pytorch import DALIGenericIterator
+
+@pipeline_def(num_threads=4, device_id=0, batch_size=1) #batch_size = 128
+def get_dali_pipeline(data):
+
+    for images in data:
+        images = fn.decoders.image(images)
+        images = fn.resize(images, resize_x=256, resize_y=256)
+        images = fn.decoders.image_random_crop(images, device="mixed", output_type=types.RGB)
+        images = fn.crop_mirror_normalize(images,
+                                        mean=[0.485 * 255,0.456 * 255,0.406 * 255],
+                                        std=[0.229 * 255,0.224 * 255,0.225 * 255],
+                                        mirror=fn.random.coin_flip())
+    return images
 
 class VisionHandler(BaseHandler, ABC):
     """
     Base class for all vision handlers
     """
-    def initialize(self, context):
-        super().initialize(context)
-        self.ig = IntegratedGradients(self.model)
-        self.initialized = True
-        properties = context.system_properties
-        if not properties.get("limit_max_image_pixels"):
-            Image.MAX_IMAGE_PIXELS = None
-
     def preprocess(self, data):
         """The preprocess function of MNIST program converts the input data to a float tensor
 
@@ -33,28 +44,28 @@ class VisionHandler(BaseHandler, ABC):
         Returns:
             list : The preprocess function returns the input image as a list of float tensors.
         """
-        images = []
+        pipe = get_dali_pipeline(data)
+        pipe.build()
+        output = pipe.run()
+        return output
 
-        for row in data:
-            # Compat layer: normally the envelope should just return the data
-            # directly, but older versions of Torchserve didn't have envelope.
-            image = row.get("data") or row.get("body")
-            if isinstance(image, str):
-                # if the image is a string of bytesarray.
-                image = base64.b64decode(image)
+        ## Allocated a tensor instead of putting images in a list
+        # batch_size = len(data)
+        # images = torch.empty(batch_size, 3, 224, 224)
 
-            # If the image is sent as bytesarray
-            if isinstance(image, (bytearray, bytes)):
-                image = Image.open(io.BytesIO(image))
-                image = self.image_processing(image)
-            else:
-                # if the image is a list
-                image = torch.FloatTensor(image)
+        # for i in range(len(data)):
+        #     row = data[i]
+        #     image = image_decoder(row)
+        #     # image = image.resize((256,256))
+        #     # image.crop((16,16,240,240))
+        #     # image = self.image_processing(image)
+        #     images[i] = image
+        
+        # return images
 
-            images.append(image)
+if __name__ == "__main__":
+    handler = VisionHandler()
+    data = [torch.randn(3,224), torch.randn(3,224)]
+    output = handler.preprocess(data)
+    print(output)
 
-        return torch.stack(images).to(self.device)
-
-    def get_insights(self, tensor_data, _, target=0):
-        print("input shape", tensor_data.shape)
-        return self.ig.attribute(tensor_data, target=target, n_steps=15).tolist()

--- a/ts/torch_handler/vision_handler.py
+++ b/ts/torch_handler/vision_handler.py
@@ -18,13 +18,27 @@ import nvidia.dali.types as types
 import nvidia.dali.fn as fn
 from nvidia.dali.plugin.pytorch import DALIGenericIterator
 
+
+### TOREMOVE: Notes to self
+###
+## There are a few things that make our image handlers slow
+## We stack tensors and pass them around in lists instead of creating a batched tensor
+# Indexing into it and then passing that whole tensor in one go
+## Any for loop in our handler code is code smell
+
+### DALI specific
+### We can build a DALI pipeline once in initialization and then pass in input tensors one by one in the same way that
+### https://github.com/triton-inference-server/dali_backend/blob/main/client/dali_grpc_client.py
+### DALI seems to not mind manually reading input images as lists :?
+
+
 @pipeline_def(num_threads=4, device_id=0, batch_size=1) #batch_size = 128
 def get_dali_pipeline(data):
 
     for images in data:
-        images = fn.decoders.image(images)
+        images = fn.decoders.image(images) # This is a CPU only operation
         images = fn.resize(images, resize_x=256, resize_y=256)
-        images = fn.decoders.image_random_crop(images, device="mixed", output_type=types.RGB)
+        images = fn.decoders.image_random_crop(images, output_type=types.RGB)
         images = fn.crop_mirror_normalize(images,
                                         mean=[0.485 * 255,0.456 * 255,0.406 * 255],
                                         std=[0.229 * 255,0.224 * 255,0.225 * 255],
@@ -35,6 +49,14 @@ class VisionHandler(BaseHandler, ABC):
     """
     Base class for all vision handlers
     """
+
+    def initialize(self, data):
+        pipe = get_dali_pipeline(data)
+        # print(data)
+        pipe.build()
+        output = pipe.run()
+        return output
+
     def preprocess(self, data):
         """The preprocess function of MNIST program converts the input data to a float tensor
 
@@ -44,10 +66,9 @@ class VisionHandler(BaseHandler, ABC):
         Returns:
             list : The preprocess function returns the input image as a list of float tensors.
         """
-        pipe = get_dali_pipeline(data)
-        pipe.build()
-        output = pipe.run()
-        return output
+
+        images = self.initialize(data)
+        return images
 
         ## Allocated a tensor instead of putting images in a list
         # batch_size = len(data)
@@ -65,7 +86,7 @@ class VisionHandler(BaseHandler, ABC):
 
 if __name__ == "__main__":
     handler = VisionHandler()
-    data = [torch.randn(3,224), torch.randn(3,224)]
+    data = [torch.randn(3, 224, 224), torch.randn(3,224, 224)]
     output = handler.preprocess(data)
     print(output)
 


### PR DESCRIPTION
## Description

Unfortunately DALI bundles its image decoder function in their pipeline language so we can't just use a part of DALI.
Also DALI insists on reading images from disk directly (there are workarounds) but outputs of a pipeline can only be read by implementing a data loader. Overall I can't see us integrating DALI in a handler but it should be possible with a custom python backend. Parking this work for now until I hopefully find something simpler.

#1546 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update - will require documentation update to discuss how to pick optimal settings for DALI

## Feature/Issue validation/testing

Will use Li's benchmarking suite before and after this change for image models to decide whether to ship or not

- [ ] Test A
- [ ] Test B

- Logs

## Checklist:

- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Did you enable `pre-commit` to check and format your changes before pushing your changes?
