### PR TITLE
add workaround solution in gpu regression test

### DIFF
--- a/test/buildspec_gpu.yml
+++ b/test/buildspec_gpu.yml
@@ -8,13 +8,13 @@ phases:
       python: 3.8
     commands:
       # Workaround from https://github.com/NVIDIA/nvidia-docker/issues/1632
-      - apt-get update
-      - apt-get install sudo -y
       - apt-get install wget
       - apt-key del 7fa2af80
       - wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
       - dpkg -i cuda-keyring_1.0-1_all.deb
       - apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
+      - apt-get update
+      - apt-get install sudo -y
       - curl -O https://bootstrap.pypa.io/get-pip.py && python get-pip.py
       - update-alternatives --install /usr/local/bin/pip pip /usr/local/bin/pip3 1
       - python ts_scripts/install_dependencies.py --cuda=cu102 --environment=dev

--- a/test/buildspec_gpu.yml
+++ b/test/buildspec_gpu.yml
@@ -7,6 +7,7 @@ phases:
     runtime-versions:
       python: 3.8
     commands:
+      # Workaround from https://github.com/NVIDIA/nvidia-docker/issues/1632
       - apt-key del 7fa2af80
       - apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
       - apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu2004/x86_64/7fa2af80.pub

--- a/test/buildspec_gpu.yml
+++ b/test/buildspec_gpu.yml
@@ -7,6 +7,9 @@ phases:
     runtime-versions:
       python: 3.8
     commands:
+      - apt-key del 7fa2af80
+      - apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
+      - apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu2004/x86_64/7fa2af80.pub
       - apt-get update
       - apt-get install sudo -y
       - curl -O https://bootstrap.pypa.io/get-pip.py && python get-pip.py

--- a/test/buildspec_gpu.yml
+++ b/test/buildspec_gpu.yml
@@ -8,12 +8,13 @@ phases:
       python: 3.8
     commands:
       # Workaround from https://github.com/NVIDIA/nvidia-docker/issues/1632
+      - apt-get update
+      - apt-get install sudo -y
+      - apt-get install wget
       - apt-key del 7fa2af80
       - wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
       - dpkg -i cuda-keyring_1.0-1_all.deb
       - apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
-      - apt-get update
-      - apt-get install sudo -y
       - curl -O https://bootstrap.pypa.io/get-pip.py && python get-pip.py
       - update-alternatives --install /usr/local/bin/pip pip /usr/local/bin/pip3 1
       - python ts_scripts/install_dependencies.py --cuda=cu102 --environment=dev

--- a/test/buildspec_gpu.yml
+++ b/test/buildspec_gpu.yml
@@ -9,8 +9,9 @@ phases:
     commands:
       # Workaround from https://github.com/NVIDIA/nvidia-docker/issues/1632
       - apt-key del 7fa2af80
+      - wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
+      - dpkg -i cuda-keyring_1.0-1_all.deb
       - apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
-      - apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu2004/x86_64/7fa2af80.pub
       - apt-get update
       - apt-get install sudo -y
       - curl -O https://bootstrap.pypa.io/get-pip.py && python get-pip.py


### PR DESCRIPTION
## Description

Please include a summary of the feature or issue being fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

[Nvidia error](https://github.com/NVIDIA/nvidia-docker/issues/1631) caused gpu regression test fail to download cuda.
```
Reading package lists…
W: GPG error: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64 InRelease: The following signatures couldn’t be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC
E: The repository ‘https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64 InRelease’ is no longer signed.
```
Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the tests [UT/IT] that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

<img width="1202" alt="Screen Shot 2022-05-24 at 10 49 04 AM" src="https://user-images.githubusercontent.com/23464292/170099992-9732b59e-8ea4-4522-b44d-abfbb151cf1d.png">

## Checklist:

- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Did you enable `pre-commit` to check and format your changes before pushing your changes?
