### PR TITLE
debug standalone handler

### DIFF
--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -174,3 +174,5 @@ if __name__ == "__main__":
     x = handler.postprocess(x)
     print(x)
 ```
+
+And then you can just run `python base_handler.py`

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -116,7 +116,7 @@ Refer [default handlers](default_handlers.md#torchserve-default-inference-handle
 
 ### Is it possible to deploy Hugging Face models?
 Yes, you can deploy Hugging Face models using a custom handler.
-Refer [HuggingFace_Transformers](https://github.com/pytorch/serve/blob/master/examples/Huggingface_Transformers/README.md) for example. 
+Refer [HuggingFace_Transformers](https://github.com/pytorch/serve/blob/master/examples/Huggingface_Transformers/README.md) for example.
 
 ## Model-archiver
  Relevant documents
@@ -152,3 +152,25 @@ A mar file can be used either locally or be publicly available via http. An S3 U
 
 ### How to set a model's batch size on SageMaker?  Key parameters for TorchServe performance tuning.
 [TorchServe performance tuning example](https://github.com/lxning/torchserve_perf/blob/master/torchserve_perf.ipynb)
+
+### How to debug `Backend worker monitoring thread interrupted or backend worker process died`
+
+The easiest to debug this kind of issues is to look at the generated `logs/model_log.log` and see if there's anything suspicious there. Usually this is some bug in your `handler.py` code so you could in principle fix the bug, repackage into a new `.mar` file and try again but for interactive debugging this isn't ideal and instead we recommend you run handlers as standalone python files.
+
+For example let's say you wanted to run `ts/torch_handler/base_handler.py`, this is just a regular `python` file you can run it if you create a `if __name__ == "__main__"` function and this is often the fastest way to spot issues in your `handler.py` or run more extensive profiling to find issues with a slow model.
+
+So for example you would add the following code to `base_handler.py`
+
+```python
+# ...
+# Rest of handler code up here
+
+if __name__ == "__main__":
+    handler = BaseHandler()
+    handler.initialize()
+    x = torch.randn()
+    x = handler.preprocess(x)
+    x = handler.inference(x)
+    x = handler.postprocess(x)
+    print(x)
+```

--- a/ts/torch_handler/base_handler.py
+++ b/ts/torch_handler/base_handler.py
@@ -4,16 +4,18 @@ Also, provides handle method per torch serve custom model specification
 """
 
 import abc
+import importlib.util
 import logging
 import os
-import importlib.util
 import time
+
 import torch
 from pkg_resources import packaging
-from ..utils.util import list_classes_from_module, load_label_mapping
+
+from ts.utils.util import list_classes_from_module, load_label_mapping
 
 if packaging.version.parse(torch.__version__) >= packaging.version.parse("1.8.1"):
-    from torch.profiler import profile, record_function, ProfilerActivity
+    from torch.profiler import ProfilerActivity, profile, record_function
 
     PROFILER_AVAILABLE = True
 else:

--- a/ts/torch_handler/image_classifier.py
+++ b/ts/torch_handler/image_classifier.py
@@ -5,8 +5,8 @@ import torch
 import torch.nn.functional as F
 from torchvision import transforms
 
-from .vision_handler import VisionHandler
-from ..utils.util  import map_class_to_label
+from ts.torch_handler.vision_handler import VisionHandler
+from ts.utils.util import map_class_to_label
 
 
 class ImageClassifier(VisionHandler):
@@ -18,13 +18,14 @@ class ImageClassifier(VisionHandler):
     topk = 5
     # These are the standard Imagenet dimensions
     # and statistics
-    image_processing = transforms.Compose([
-        transforms.Resize(256),
-        transforms.CenterCrop(224),
-        transforms.ToTensor(),
-        transforms.Normalize(mean=[0.485, 0.456, 0.406],
-                             std=[0.229, 0.224, 0.225])
-    ])
+    image_processing = transforms.Compose(
+        [
+            transforms.Resize(256),
+            transforms.CenterCrop(224),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+        ]
+    )
 
     def set_max_result_classes(self, topk):
         self.topk = topk

--- a/ts/torch_handler/image_segmenter.py
+++ b/ts/torch_handler/image_segmenter.py
@@ -3,7 +3,9 @@ Module for image segmentation default handler
 """
 import torch
 from torchvision import transforms as T
-from .vision_handler import VisionHandler
+
+from ts.torch_handler.vision_handler import VisionHandler
+
 
 class ImageSegmenter(VisionHandler):
     """
@@ -12,19 +14,19 @@ class ImageSegmenter(VisionHandler):
     where N - batch size, K - number of classes, H - height and W - width.
     """
 
-    image_processing = T.Compose([
-        T.Resize(256),
-        T.CenterCrop(224),
-        T.ToTensor(),
-        T.Normalize(
-            mean=[0.485, 0.456, 0.406],
-            std=[0.229, 0.224, 0.225]
-        )])
+    image_processing = T.Compose(
+        [
+            T.Resize(256),
+            T.CenterCrop(224),
+            T.ToTensor(),
+            T.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+        ]
+    )
 
     def postprocess(self, data):
         # Returning the class for every pixel makes the response size too big
         # (> 24mb). Instead, we'll only return the top class for each image
-        data = data['out']
+        data = data["out"]
         data = torch.nn.functional.softmax(data, dim=1)
         data = torch.max(data, dim=1)
         data = torch.stack([data.indices.type(data.values.dtype), data.values], dim=3)

--- a/ts/torch_handler/object_detector.py
+++ b/ts/torch_handler/object_detector.py
@@ -2,11 +2,12 @@
 Module for object detection default handler
 """
 import torch
-from torchvision import transforms
-from torchvision import __version__ as torchvision_version
 from packaging import version
-from .vision_handler import VisionHandler
-from ..utils.util import map_class_to_label
+from torchvision import __version__ as torchvision_version
+from torchvision import transforms
+
+from ts.torch_handler.vision_handler import VisionHandler
+from ts.utils.util import map_class_to_label
 
 
 class ObjectDetector(VisionHandler):

--- a/ts/torch_handler/text_classifier.py
+++ b/ts/torch_handler/text_classifier.py
@@ -5,14 +5,17 @@ Module for text classification default handler
 DOES NOT SUPPORT BATCH!
 """
 import logging
+
 import torch
 import torch.nn.functional as F
-from torchtext.data.utils import ngrams_iterator
 from captum.attr import TokenReferenceBase
-from .text_handler import TextHandler
-from ..utils.util import map_class_to_label
+from torchtext.data.utils import ngrams_iterator
+
+from ts.torch_handler.text_handler import TextHandler
+from ts.utils.util import map_class_to_label
 
 logger = logging.getLogger(__name__)
+
 
 class TextClassifier(TextHandler):
     """
@@ -46,7 +49,7 @@ class TextClassifier(TextHandler):
         line = data[0]
         text = line.get("data") or line.get("body")
         if isinstance(text, (bytes, bytearray)):
-            text = text.decode('utf-8')
+            text = text.decode("utf-8")
 
         text = self._remove_html_tags(text)
         text = text.lower()
@@ -55,11 +58,8 @@ class TextClassifier(TextHandler):
         text = self._remove_punctuation(text)
         text = self._tokenize(text)
         text_tensor = torch.as_tensor(
-            [
-                self.source_vocab[token]
-                for token in ngrams_iterator(text, self.ngrams)
-            ],
-            device=self.device
+            [self.source_vocab[token] for token in ngrams_iterator(text, self.ngrams)],
+            device=self.device,
         )
         return text_tensor, text
 

--- a/ts/torch_handler/text_handler.py
+++ b/ts/torch_handler/text_handler.py
@@ -2,18 +2,20 @@
 Base module for all text based default handler.
 Contains various text based utility methods
 """
+import logging
 import os
 import re
-import logging
 import string
 import unicodedata
 from abc import ABC
+
 import torch
 import torch.nn.functional as F
-from torchtext.data.utils import get_tokenizer
 from captum.attr import LayerIntegratedGradients
-from .base_handler import BaseHandler
-from .contractions import CONTRACTION_MAP
+from torchtext.data.utils import get_tokenizer
+
+from ts.torch_handler.base_handler import BaseHandler
+from ts.utils.contractions import CONTRACTION_MAP
 
 logger = logging.getLogger(__name__)
 
@@ -45,13 +47,17 @@ class TextHandler(BaseHandler, ABC):
         """
         super().initialize(context)
         self.initialized = False
-        source_vocab = self.manifest['model']['sourceVocab'] if 'sourceVocab' in self.manifest['model'] else None
+        source_vocab = (
+            self.manifest["model"]["sourceVocab"]
+            if "sourceVocab" in self.manifest["model"]
+            else None
+        )
         if source_vocab:
             # Backward compatibility
             self.source_vocab = torch.load(source_vocab)
         else:
             self.source_vocab = torch.load(self.get_source_vocab_path(context))
-        #Captum initialization
+        # Captum initialization
         self.lig = LayerIntegratedGradients(self.model, self.model.embedding)
         self.initialized = True
 
@@ -63,8 +69,10 @@ class TextHandler(BaseHandler, ABC):
         if os.path.isfile(source_vocab_path):
             return source_vocab_path
         else:
-            raise Exception('Missing the source_vocab file. Refer default handler '
-                            'documentation for details on using text_handler.')
+            raise Exception(
+                "Missing the source_vocab file. Refer default handler "
+                "documentation for details on using text_handler."
+            )
 
     def _expand_contractions(self, text):
         """

--- a/ts/torch_handler/vision_handler.py
+++ b/ts/torch_handler/vision_handler.py
@@ -3,19 +3,22 @@
 """
 Base module for all vision handlers
 """
-from abc import ABC
-import io
 import base64
+import io
+from abc import ABC
+
 import torch
-from PIL import Image
 from captum.attr import IntegratedGradients
-from .base_handler import BaseHandler
+from PIL import Image
+
+from ts.torch_handler.base_handler import BaseHandler
 
 
 class VisionHandler(BaseHandler, ABC):
     """
     Base class for all vision handlers
     """
+
     def initialize(self, context):
         super().initialize(context)
         self.ig = IntegratedGradients(self.model)

--- a/ts/utils/contractions.py
+++ b/ts/utils/contractions.py
@@ -125,5 +125,5 @@ CONTRACTION_MAP = {
     "you'll": "you will",
     "you'll've": "you will have",
     "you're": "you are",
-    "you've": "you have"
+    "you've": "you have",
 }


### PR DESCRIPTION
## Description

This PR introduce the ability to debug standalone handlers, many customer issues are opened here which bugs in handler code instead of bugs in torchserve. The error message is scary looking and makes it seem like an internal torchserve failure `Backend worker monitoring thread interrupted or backend worker process died`

However because of the lengthy packaging and torchserve start process it makes interactive debugging a pain. 

Instead torchserve handlers are nothing but regular python files which can be run in the following way

```python
if __name__ == "__main__":
    handler = BaseHandler()
    handler.initialize()
    x = torch.randn()
    x = handler.preprocess(x)
    x = handler.inference(x)
    x = handler.postprocess(x)
    print(x)
```

However our handlers as is used relative imports which would make them fail unless they were called from a specific directory so we've replaced statements like `from ..utils.util import list_classes_from_module, load_label_mapping`

by 
`from ts.utils.util import list_classes_from_module, load_label_mapping` to make this work and we've added documentation to in `docs/FAQ.md` to describe this feature to users.

While I was here I also moved contractions to the `utils` folder since it's not a handler and remaining changes are done via `pre-commit`

Fixes #1538 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Feature/Issue validation/testing

CI is enough, because if this didn't work it would break all of CI


## Checklist:

- [x] Did you have fun?
- [x] Have you made corresponding changes to the documentation?