### PR TITLE
Install gnupg2 for Ubuntu 22.04

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,6 +23,7 @@ ARG BASE_IMAGE=ubuntu:18.04
 ENV PYTHONUNBUFFERED TRUE
 
 # Workaround from https://github.com/NVIDIA/nvidia-docker/issues/1632
+RUN apt-get update && apt-get install -y gnupg2
 RUN apt-key del 7fa2af80
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu2004/x86_64/7fa2af80.pub


### PR DESCRIPTION
## Description

This was a community contributed fix by @BeMarinoGit to make our `docker/build_image.sh` work on Ubuntu 22.04

Fixes #1646

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] Ubuntu 22.04 without fix (broken)
Logs for Test A

```
(serve) ubuntu@ip-172-31-18-239:~/serve/docker$ ./build_image.sh 
[+] Building 1.6s (8/25)                                                                                                                                                                                                                           
 => [internal] load build definition from Dockerfile                                                                                                                                                                                          0.0s
 => => transferring dockerfile: 4.83kB                                                                                                                                                                                                        0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                                                                                                               0.0s
 => resolve image config for docker.io/docker/dockerfile:experimental                                                                                                                                                                         0.6s
 => CACHED docker-image://docker.io/docker/dockerfile:experimental@sha256:600e5c62eedff338b3f7a0850beb7c05866e0ef27b2d2e8c02aa468e78496ff5                                                                                                    0.0s
 => [internal] load metadata for docker.io/library/ubuntu:18.04                                                                                                                                                                               0.4s
 => [internal] load build context                                                                                                                                                                                                             0.0s
 => => transferring context: 80B                                                                                                                                                                                                              0.0s
 => CACHED [compile-image  1/11] FROM docker.io/library/ubuntu:18.04@sha256:478caf1bec1afd54a58435ec681c8755883b7eb843a8630091890130b15a79af                                                                                                  0.0s
 => ERROR [compile-image  2/11] RUN apt-key del 7fa2af80                                                                                                                                                                                      0.4s
------                                                                                                                                                                                                                                             
 > [compile-image  2/11] RUN apt-key del 7fa2af80:
#9 0.355 E: gnupg, gnupg2 and gnupg1 do not seem to be installed, but one of them is required for this operation
------
executor failed running [/bin/sh -c apt-key del 7fa2af80]: exit code: 255
```

- [x] Ubuntu 22.04 with fix (works)
Logs for Test B

```
(serve) ubuntu@ip-172-31-18-239:~/serve/docker$ ./build_image.sh 
[+] Building 115.5s (27/27) FINISHED                                                                                                                                                                                                               
 => [internal] load build definition from Dockerfile                                                                                                                                                                                          0.0s
 => => transferring dockerfile: 38B                                                                                                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                             0.0s
 => => transferring context: 2B                                                                                                                                                                                                               0.0s
 => resolve image config for docker.io/docker/dockerfile:experimental                                                                                                                                                                         0.4s
 => CACHED docker-image://docker.io/docker/dockerfile:experimental@sha256:600e5c62eedff338b3f7a0850beb7c05866e0ef27b2d2e8c02aa468e78496ff5                                                                                                    0.0s
 => [internal] load metadata for docker.io/library/ubuntu:18.04                                                                                                                                                                               0.3s
 => CACHED [compile-image  1/12] FROM docker.io/library/ubuntu:18.04@sha256:478caf1bec1afd54a58435ec681c8755883b7eb843a8630091890130b15a79af                                                                                                  0.0s
 => [internal] load build context                                                                                                                                                                                                             0.0s
 => => transferring context: 80B                                                                                                                                                                                                              0.0s
 => CACHED [compile-image  2/12] RUN apt-get update && apt-get install -y gnupg2                                                                                                                                                              0.0s
 => CACHED [compile-image  3/12] RUN apt-key del 7fa2af80                                                                                                                                                                                     0.0s
 => CACHED [compile-image  4/12] RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub                                                                                         0.0s
 => CACHED [compile-image  5/12] RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu2004/x86_64/7fa2af80.pub                                                                             0.0s
 => [compile-image  6/12] RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt     apt-get update &&     apt remove python-pip  python3-pip &&     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y     ca-cert  49.1s
 => [runtime-image 2/9] RUN --mount=type=cache,target=/var/cache/apt     apt-get update &&     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y     python3.8     python3.8-distutils     python3.8-dev     openjd  49.1s
 => [compile-image  7/12] RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1     && update-alternatives --install /usr/local/bin/pip pip /usr/local/bin/pip3.8 1                                                   0.6s
 => [runtime-image 3/9] RUN useradd -m model-server     && mkdir -p /home/model-server/tmp                                                                                                                                                    0.8s
 => [compile-image  8/12] RUN python3.8 -m venv /home/venv                                                                                                                                                                                    2.1s
 => [compile-image  9/12] RUN python -m pip install -U pip setuptools                                                                                                                                                                         6.2s
 => [compile-image 10/12] RUN export USE_CUDA=1                                                                                                                                                                                               0.4s
 => [compile-image 11/12] RUN TORCH_VER=$(curl --silent --location https://pypi.org/pypi/torch/json | python -c "import sys, json, pkg_resources; releases = json.load(sys.stdin)['releases']; print(sorted(releases, key=pkg_resources.par  24.8s
 => [compile-image 12/12] RUN python -m pip install -U setuptools && python -m pip install --no-cache-dir captum torchtext torchserve torch-model-archiver                                                                                   14.1s
 => [runtime-image 4/9] COPY --chown=model-server --from=compile-image /home/venv /home/venv                                                                                                                                                  5.9s
 => [runtime-image 5/9] COPY dockerd-entrypoint.sh /usr/local/bin/dockerd-entrypoint.sh                                                                                                                                                       0.0s
 => [runtime-image 6/9] RUN chmod +x /usr/local/bin/dockerd-entrypoint.sh     && chown -R model-server /home/model-server                                                                                                                     0.3s
 => [runtime-image 7/9] COPY config.properties /home/model-server/config.properties                                                                                                                                                           0.1s
 => [runtime-image 8/9] RUN mkdir /home/model-server/model-store && chown -R model-server /home/model-server/model-store                                                                                                                      0.4s
 => [runtime-image 9/9] WORKDIR /home/model-server                                                                                                                                                                                            0.1s
 => exporting to image                                                                                                                                                                                                                        6.4s
 => => exporting layers                                                                                                                                                                                                                       6.4s
 => => writing image sha256:495d5766106b00c7ecc2ba4d9d77e6315d29099e14f9102786fa49091ac97dd4                                                                                                                                                  0.0s
 => => naming to docker.io/pytorch/torchserve:latest-cpu  
```

- [x] Ubuntu 18.04 with fix (No impact)
```
(serve) ubuntu@ip-172-31-16-198:~/serve/docker$ ./build_image.sh 
[+] Building 145.5s (29/29) FINISHED                                                                                                                                                             
 => [internal] load build definition from Dockerfile                                                                                                                                        0.0s
 => => transferring dockerfile: 4.88kB                                                                                                                                                      0.0s
 => [internal] load .dockerignore                                                                                                                                                           0.0s
 => => transferring context: 2B                                                                                                                                                             0.0s
 => resolve image config for docker.io/docker/dockerfile:experimental                                                                                                                       0.8s
 => [auth] docker/dockerfile:pull token for registry-1.docker.io                                                                                                                            0.0s
 => CACHED docker-image://docker.io/docker/dockerfile:experimental@sha256:600e5c62eedff338b3f7a0850beb7c05866e0ef27b2d2e8c02aa468e78496ff5                                                  0.0s
 => [internal] load metadata for docker.io/library/ubuntu:18.04                                                                                                                             0.9s
 => [auth] library/ubuntu:pull token for registry-1.docker.io                                                                                                                               0.0s
 => [internal] load build context                                                                                                                                                           0.0s
 => => transferring context: 541B                                                                                                                                                           0.0s
 => [runtime-image 1/9] FROM docker.io/library/ubuntu:18.04@sha256:478caf1bec1afd54a58435ec681c8755883b7eb843a8630091890130b15a79af                                                         1.3s
 => => resolve docker.io/library/ubuntu:18.04@sha256:478caf1bec1afd54a58435ec681c8755883b7eb843a8630091890130b15a79af                                                                       0.0s
 => => sha256:478caf1bec1afd54a58435ec681c8755883b7eb843a8630091890130b15a79af 1.41kB / 1.41kB                                                                                              0.0s
 => => sha256:8da4e9509bfe5e09df6502e7a8e93c63e4d0d9dbaa9f92d7d767f96d6c20a78a 529B / 529B                                                                                                  0.0s
 => => sha256:ad080923604aa54962e903125cd9a860605c111bc45afc7d491cd8c77dccc13b 1.46kB / 1.46kB                                                                                              0.0s
 => => sha256:09db6f815738b9c8f25420c47e093f89abaabaa653f9678587b57e8f4400b5ff 26.71MB / 26.71MB                                                                                            0.4s
 => => extracting sha256:09db6f815738b9c8f25420c47e093f89abaabaa653f9678587b57e8f4400b5ff                                                                                                   0.7s
 => [compile-image  2/12] RUN apt-get update && apt-get install -y gnupg2                                                                                                                  11.7s
 => [runtime-image 2/9] RUN --mount=type=cache,target=/var/cache/apt     apt-get update &&     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y     python3.8     49.1s
 => [compile-image  3/12] RUN apt-key del 7fa2af80                                                                                                                                          0.7s
 => [compile-image  4/12] RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub                                              0.6s
 => [compile-image  5/12] RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu2004/x86_64/7fa2af80.pub                                  0.6s
 => [compile-image  6/12] RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt     apt-get update &&     apt remove python-pip  python3-pip &&     DEBIAN_FRONTEND=noninteractive apt-  57.3s
 => [runtime-image 3/9] RUN useradd -m model-server     && mkdir -p /home/model-server/tmp                                                                                                  0.5s
 => [compile-image  7/12] RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1     && update-alternatives --install /usr/local/bin/pip pip /usr/local/bin/pip3.8   0.4s
 => [compile-image  8/12] RUN python3.8 -m venv /home/venv                                                                                                                                  2.0s
 => [compile-image  9/12] RUN python -m pip install -U pip setuptools                                                                                                                       5.7s
 => [compile-image 10/12] RUN export USE_CUDA=1                                                                                                                                             0.4s
 => [compile-image 11/12] RUN TORCH_VER=$(curl --silent --location https://pypi.org/pypi/torch/json | python -c "import sys, json, pkg_resources; releases = json.load(sys.stdin)['releas  31.8s
 => [compile-image 12/12] RUN python -m pip install -U setuptools && python -m pip install --no-cache-dir captum torchtext torchserve torch-model-archiver                                 11.6s
 => [runtime-image 4/9] COPY --chown=model-server --from=compile-image /home/venv /home/venv                                                                                                8.1s
 => [runtime-image 5/9] COPY dockerd-entrypoint.sh /usr/local/bin/dockerd-entrypoint.sh                                                                                                     0.0s
 => [runtime-image 6/9] RUN chmod +x /usr/local/bin/dockerd-entrypoint.sh     && chown -R model-server /home/model-server                                                                   0.3s
 => [runtime-image 7/9] COPY config.properties /home/model-server/config.properties                                                                                                         0.0s
 => [runtime-image 8/9] RUN mkdir /home/model-server/model-store && chown -R model-server /home/model-server/model-store                                                                    0.4s
 => [runtime-image 9/9] WORKDIR /home/model-server                                                                                                                                          0.0s
 => exporting to image                                                                                                                                                                      6.2s
 => => exporting layers                                                                                                                                                                     6.2s
 => => writing image sha256:9d883fb497a7761c84d67d475ca2768fba8e0b6cac51cf9c04bf10bfe25949ac                                                                                                0.0s
 => => naming to docker.io/pytorch/torchserve:latest-cpu   
```

## Checklist:

- [x] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?