### PR TITLE
Support array of parameters

### DIFF
--- a/ts/service.py
+++ b/ts/service.py
@@ -64,8 +64,25 @@ class Service(object):
             model_in = dict()
             # Parameter level headers are updated here. multipart/form-data can have multiple headers.
             for parameter in parameters:
-                model_in.update({parameter["name"]: parameter["value"]})
-                model_in_headers.update({parameter["name"]: {"content-type": parameter["contentType"]}})
+                parameter_name = parameter["name"]
+                if parameter_name.endswith("[]"):
+                    parameter_name = parameter_name[:len(parameter_name) - 2]
+                if parameter_name in model_in:
+                    parameter_value = model_in[parameter_name]
+                    if not isinstance(parameter_value, list):
+                        parameter_value = [parameter_value]
+                    parameter_value.append(parameter["value"])
+
+                    content_types = model_in_headers[parameter_name]['content-type']
+                    if not isinstance(content_types, list):
+                        content_types = [content_types]
+                    content_types.append(parameter["contentType"])
+                    header_value = {"content-type": content_types}
+                else:
+                    parameter_value = parameter["value"]
+                    header_value = {"content-type": parameter["contentType"]}
+                model_in.update({parameter_name: parameter_value})
+                model_in_headers.update({parameter_name: header_value})
 
             # Request level headers are populated here
             if request_batch.get("headers") is not None:

--- a/ts/tests/unit_tests/test_worker_service.py
+++ b/ts/tests/unit_tests/test_worker_service.py
@@ -19,6 +19,18 @@ class TestService:
             {"name": "xyz", "value": "abc", "contentType": "text/csv"}
         ], "data": b""}
     ]
+    data_array1 = [
+        {"requestId": b"123", "parameters": [
+            {"name": "xyz", "value": "abc1", "contentType": "text/plain"},
+            {"name": "xyz", "value": "abc2", "contentType": "text/csv"}
+        ], "data": b""}
+    ]
+    data_array2 = [
+        {"requestId": b"123", "parameters": [
+            {"name": "xyz[]", "value": "abc1", "contentType": "text/plain"},
+            {"name": "xyz[]", "value": "abc2", "contentType": "text/csv"}
+        ], "data": b""}
+    ]
 
     @pytest.fixture()
     def service(self, mocker):
@@ -40,6 +52,18 @@ class TestService:
         headers, input_batch, req_to_id_map = service.retrieve_data_for_inference(self.data)
         assert headers[0].get_request_property("xyz").get("content-type") == "text/csv"
         assert input_batch[0] == {"xyz": "abc"}
+        assert req_to_id_map == {0: "123"}
+
+    def test_array_req1(self, service):
+        headers, input_batch, req_to_id_map = service.retrieve_data_for_inference(self.data_array1)
+        assert headers[0].get_request_property("xyz").get("content-type") == ["text/plain", "text/csv"]
+        assert input_batch[0] == {"xyz": ["abc1", "abc2"]}
+        assert req_to_id_map == {0: "123"}
+
+    def test_array_req2(self, service):
+        headers, input_batch, req_to_id_map = service.retrieve_data_for_inference(self.data_array2)
+        assert headers[0].get_request_property("xyz").get("content-type") == ["text/plain", "text/csv"]
+        assert input_batch[0] == {"xyz": ["abc1", "abc2"]}
         assert req_to_id_map == {0: "123"}
 
 


### PR DESCRIPTION
## Description

Supports array of parameters. It might be useful in cases where the model might expect a list of images, instead of a single image. It could also be used to control batching manually.

Fixes #1536 (Potentially/Partially ?)

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

Technically it doesn't break any API/interface. The service would behave differently if someone uses array parameters in requests.

## Feature/Issue validation/testing

Added unit test validating the expected request formats.

## Checklist:

- [x] Did you have fun?
- [x] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?