### PR TITLE
fix describe worker state wrong

### DIFF
--- a/frontend/server/src/main/java/org/pytorch/serve/util/ApiUtils.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/ApiUtils.java
@@ -377,7 +377,8 @@ public final class ApiUtils {
         for (WorkerThread worker : workers) {
             String workerId = worker.getWorkerId();
             long startTime = worker.getStartTime();
-            boolean isRunning = worker.isRunning() && worker.getState() == WorkerState.WORKER_MODEL_LOADED;
+            boolean isRunning =
+                    worker.isRunning() && worker.getState() == WorkerState.WORKER_MODEL_LOADED;
             int gpuId = worker.getGpuId();
             long memory = worker.getMemory();
             int pid = worker.getPid();

--- a/frontend/server/src/main/java/org/pytorch/serve/util/ApiUtils.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/ApiUtils.java
@@ -35,6 +35,7 @@ import org.pytorch.serve.util.messages.WorkerCommands;
 import org.pytorch.serve.wlm.Model;
 import org.pytorch.serve.wlm.ModelManager;
 import org.pytorch.serve.wlm.ModelVersionedRefs;
+import org.pytorch.serve.wlm.WorkerState;
 import org.pytorch.serve.wlm.WorkerThread;
 
 public final class ApiUtils {
@@ -376,7 +377,7 @@ public final class ApiUtils {
         for (WorkerThread worker : workers) {
             String workerId = worker.getWorkerId();
             long startTime = worker.getStartTime();
-            boolean isRunning = worker.isRunning();
+            boolean isRunning = worker.isRunning() && worker.getState() == WorkerState.WORKER_MODEL_LOADED;
             int gpuId = worker.getGpuId();
             long memory = worker.getMemory();
             int pid = worker.getPid();


### PR DESCRIPTION
## Description

Please read our [CONTRIBUTING.md](https://github.com/pytorch/serve/blob/master/CONTRIBUTING.md) prior to creating your first pull request.

Please include a summary of the feature or issue being fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #(issue)
#1679 

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Before 
Logs for Before: get "ready" even model is still in loading mode
 curl http://localhost:8081/models/deeplabv3_resnet101_scripted
[
  {
    "modelName": "deeplabv3_resnet101_scripted",
    "modelVersion": "1.0",
    "modelUrl": "deeplabv3_resnet_101_scripted.mar",
    "runtime": "python",
    "minWorkers": 12,
    "maxWorkers": 12,
    "batchSize": 1,
    "maxBatchDelay": 100,
    "loadedAtStartup": true,
    "workers": [
      {
        "id": "9000",
        "startTime": "2022-06-09T19:44:57.371Z",
        "status": "READY",
        "memoryUsage": 0,
        "pid": -1,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9001",
        "startTime": "2022-06-09T19:44:57.372Z",
        "status": "READY",
        "memoryUsage": 0,
        "pid": -1,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9002",
        "startTime": "2022-06-09T19:44:57.372Z",
        "status": "READY",
        "memoryUsage": 0,
        "pid": -1,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9003",
        "startTime": "2022-06-09T19:44:57.373Z",
        "status": "READY",
        "memoryUsage": 0,
        "pid": -1,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9004",
        "startTime": "2022-06-09T19:44:57.373Z",
        "status": "READY",
        "memoryUsage": 0,
        "pid": -1,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9005",
        "startTime": "2022-06-09T19:44:57.373Z",
        "status": "READY",
        "memoryUsage": 0,
        "pid": -1,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9006",
        "startTime": "2022-06-09T19:44:57.373Z",
        "status": "READY",
        "memoryUsage": 0,
        "pid": -1,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9007",
      {
        "id": "9008",
        "startTime": "2022-06-09T19:44:57.374Z",
        "status": "READY",
        "memoryUsage": 0,
        "pid": -1,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9009",
        "startTime": "2022-06-09T19:44:57.375Z",
        "status": "READY",
        "memoryUsage": 0,
        "pid": -1,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9010",
        "startTime": "2022-06-09T19:44:57.375Z",
        "status": "READY",
        "memoryUsage": 0,
        "pid": -1,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9011",
        "startTime": "2022-06-09T19:44:57.375Z",
        "status": "READY",
        "memoryUsage": 0,
        "pid": -1,
        "gpu": false,
        "gpuUsage": "N/A"
      }
    ]
  }
]

- [ ] fixing
Logs for fixing: status changing from "unloading" to "ready" 
curl http://localhost:8081/models/deeplabv3_resnet101_scripted
[
  {
    "modelName": "deeplabv3_resnet101_scripted",
    "modelVersion": "1.0",
    "modelUrl": "deeplabv3_resnet_101_scripted.mar",
    "runtime": "python",
    "minWorkers": 12,
    "maxWorkers": 12,
    "batchSize": 1,
    "maxBatchDelay": 100,
    "loadedAtStartup": true,
    "workers": [
      {
        "id": "9000",
        "startTime": "2022-06-09T19:52:52.438Z",
        "status": "UNLOADING",
        "memoryUsage": 0,
        "pid": 3885,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9001",
        "startTime": "2022-06-09T19:52:52.440Z",
        "status": "UNLOADING",
        "memoryUsage": 0,
        "pid": 3886,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9002",
        "startTime": "2022-06-09T19:52:52.440Z",
        "status": "UNLOADING",
        "memoryUsage": 0,
        "pid": 3882,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9003",
        "startTime": "2022-06-09T19:52:52.441Z",
        "status": "UNLOADING",
        "memoryUsage": 0,
        "pid": 3884,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9004",
        "startTime": "2022-06-09T19:52:52.441Z",
        "status": "UNLOADING",
        "memoryUsage": 0,
        "pid": 3881,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9005",
        "startTime": "2022-06-09T19:52:52.441Z",
        "status": "UNLOADING",
        "memoryUsage": 0,
        "pid": 3880,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9006",
        "startTime": "2022-06-09T19:52:52.441Z",
        "status": "UNLOADING",
        "memoryUsage": 0,
        "pid": 3879,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9007",
        "startTime": "2022-06-09T19:52:52.441Z",
        "status": "UNLOADING",
        "memoryUsage": 0,
        "pid": 3887,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9008",
        "startTime": "2022-06-09T19:52:52.442Z",
        "status": "UNLOADING",
        "memoryUsage": 0,
        "pid": 3888,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9009",
        "startTime": "2022-06-09T19:52:52.442Z",
        "status": "UNLOADING",
        "memoryUsage": 0,
        "pid": 3889,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9010",
        "startTime": "2022-06-09T19:52:52.442Z",
        "status": "UNLOADING",
        "memoryUsage": 0,
        "pid": 3890,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9011",
        "startTime": "2022-06-09T19:52:52.443Z",
        "status": "UNLOADING",
        "memoryUsage": 0,
        "pid": 3883,
        "gpu": false,
        "gpuUsage": "N/A"
      }
    ]
  }
]

curl http://localhost:8081/models/deeplabv3_resnet101_scripted
[
  {
    "modelName": "deeplabv3_resnet101_scripted",
    "modelVersion": "1.0",
    "modelUrl": "deeplabv3_resnet_101_scripted.mar",
    "runtime": "python",
    "minWorkers": 12,
    "maxWorkers": 12,
    "batchSize": 1,
    "maxBatchDelay": 100,
    "loadedAtStartup": true,
    "workers": [
      {
        "id": "9000",
        "startTime": "2022-06-09T19:52:52.438Z",
        "status": "READY",
        "memoryUsage": 0,
        "pid": 3885,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9001",
        "startTime": "2022-06-09T19:52:52.440Z",
        "status": "READY",
        "memoryUsage": 0,
        "pid": 3886,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9002",
        "startTime": "2022-06-09T19:52:52.440Z",
        "status": "READY",
        "memoryUsage": 0,
        "pid": 3882,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9003",
        "startTime": "2022-06-09T19:52:52.441Z",
        "status": "READY",
        "memoryUsage": 0,
        "pid": 3884,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9004",
        "startTime": "2022-06-09T19:52:52.441Z",
        "status": "READY",
        "memoryUsage": 0,
        "pid": 3881,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9005",
        "startTime": "2022-06-09T19:52:52.441Z",
        "status": "READY",
        "memoryUsage": 0,
        "pid": 3880,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9006",
        "startTime": "2022-06-09T19:52:52.441Z",
        "status": "READY",
        "memoryUsage": 0,
        "pid": 3879,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9007",
        "startTime": "2022-06-09T19:52:52.441Z",
        "status": "READY",
        "memoryUsage": 0,
        "pid": 3887,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9008",
        "startTime": "2022-06-09T19:52:52.442Z",
        "status": "READY",
        "memoryUsage": 0,
        "pid": 3888,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9009",
        "startTime": "2022-06-09T19:52:52.442Z",
        "status": "READY",
        "memoryUsage": 0,
        "pid": 3889,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9010",
        "startTime": "2022-06-09T19:52:52.442Z",
        "status": "READY",
        "memoryUsage": 0,
        "pid": 3890,
        "gpu": false,
        "gpuUsage": "N/A"
      },
      {
        "id": "9011",
        "startTime": "2022-06-09T19:52:52.443Z",
        "status": "READY",
        "memoryUsage": 0,
        "pid": 3883,
        "gpu": false,
        "gpuUsage": "N/A"
      }
    ]
  }
]
## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?