### PR TITLE
Keep root dir for extra files when generating .mar file in model-archiver

### DIFF
--- a/examples/mar_extra_root/README.md
+++ b/examples/mar_extra_root/README.md
@@ -1,0 +1,149 @@
+# How to keep the original root directory of the extra files
+
+In this example, we show how to deal with the extra files that the structure is complicated or contain same repetitive file names.
+
+## Quick start
+
+1. *[Recommended]: For easy access, copy your extra files to one directory. Eg:*
+    ```shell
+    $ tree -L 3 examples/mar_extra_root
+    examples/mar_extra_root
+    ├── my_lib1
+    │   ├── my_file.py
+    │   └── my_module
+    │       └── my_file1.py
+    ├── my_lib2
+    │   ├── my_file.py
+    │   └── my_module
+    │       └── my_file1.py
+    └── ...
+    ```
+2. Check your handler file as [mnist_handler_extra.py](mnist_handler_extra.py);
+    ```python
+    from my_lib1.my_file import func as func1
+    from my_lib2.my_file import func as func2
+
+    func1()
+    func2()
+    ...
+    ```
+    **Note:** need to use absolute imports.
+
+3. Generate the .mar file:
+    ```shell
+    $ torch-model-archiver \
+        --model-name mnist \
+        --version 1.0 \
+        --model-file      examples/image_classifier/mnist/mnist.py \
+        --serialized-file examples/image_classifier/mnist/mnist_cnn.pt \
+        --handler         'examples/mar_extra_root/mnist_handler_extra.py' \
+        --extra-files     'examples/mar_extra_root/my_lib1,examples/mar_extra_root/my_lib2' \
+        --keep-extra-root
+    ```
+
+## Normal Mar file
+
+Usually we don't need to append extra files:
+```shell
+$ torch-model-archiver \
+  --model-name mnist \
+  --version 1.0 \
+  --model-file      examples/image_classifier/mnist/mnist.py \
+  --serialized-file examples/image_classifier/mnist/mnist_cnn.pt \
+  --handler         examples/image_classifier/mnist/mnist_handler.py
+```
+
+The structure of the mar file as follows:
+```shell
+$ unzip -l mnist.mar    
+Archive:  mnist.mar
+  Length      Date    Time    Name
+---------  ---------- -----   ----
+     1273  2022-06-19 01:57   mnist_handler.py
+  4800893  2022-06-19 01:57   mnist_cnn.pt
+      757  2022-06-19 01:57   mnist.py
+      265  2022-06-19 01:57   MAR-INF/MANIFEST.json
+---------                     -------
+  4803188                     4 files
+```
+
+
+### Without `--keep-extra-root` option
+
+Maybe it works:
+```shell
+$ torch-model-archiver \
+    --model-name mnist \
+    --version 1.0 \
+    --model-file      examples/image_classifier/mnist/mnist.py \
+    --serialized-file examples/image_classifier/mnist/mnist_cnn.pt \
+    --handler        'examples/mar_extra_root/mnist_handler_extra.py' \
+    --extra-files    'examples/mar_extra_root/my_lib1'
+```
+
+The structure of the mar file as follows:
+```shell
+$ unzip -l mnist.mar
+Archive:  mnist.mar
+  Length      Date    Time    Name
+---------  ---------- -----   ----
+     1376  2022-06-19 02:22   mnist_handler_extra.py
+  4800893  2022-06-19 02:22   mnist_cnn.pt
+       58  2022-06-19 01:32   my_file.py
+      757  2022-06-19 02:22   mnist.py
+       59  2022-06-19 01:32   my_module/my_file1.py
+      271  2022-06-19 02:22   MAR-INF/MANIFEST.json
+---------                     -------
+  4803414                     6 files
+```
+*Note: `my_lib1` has been dropped, `my_file.py` and `my_module/` are under the root dir.* 
+
+*Note: This mar file contains `mnist_handler_extra.py`, and it requires `my_lib2` dir to run.* 
+
+### Use `--keep-extra-root` option
+
+Somtimes we don't want to break the existing structure in extra files. Then work with the `--keep-extra-root`.
+
+```shell
+$ torch-model-archiver \
+    --model-name mnist \
+    --version 1.0 \
+    --model-file      examples/image_classifier/mnist/mnist.py \
+    --serialized-file examples/image_classifier/mnist/mnist_cnn.pt \
+    --handler         'examples/mar_extra_root/mnist_handler_extra.py' \
+    --extra-files     'examples/mar_extra_root/my_lib1,examples/mar_extra_root/my_lib2' \
+    --keep-extra-root
+```
+
+```shell
+$ unzip -l mnist.mar
+Archive:  mnist.mar
+  Length      Date    Time    Name
+---------  ---------- -----   ----
+     1376  2022-06-19 02:06   mnist_handler_extra.py
+  4800893  2022-06-19 02:06   mnist_cnn.pt
+      757  2022-06-19 02:06   mnist.py
+       58  2022-06-19 01:32   my_lib2/my_file.py
+       59  2022-06-19 01:32   my_lib2/my_module/my_file1.py
+       58  2022-06-19 01:32   my_lib1/my_file.py
+       59  2022-06-19 01:32   my_lib1/my_module/my_file1.py
+      271  2022-06-19 02:06   MAR-INF/MANIFEST.json
+---------                     -------
+  4803531                     8 files
+```
+
+**WARN!** If we don't modify files and run command with `my_lib1` and `my_lib2`, error may occur:
+```shell
+$ torch-model-archiver \
+    --model-name mnist \
+    --version 1.0 \
+    --model-file      examples/image_classifier/mnist/mnist.py \
+    --serialized-file examples/image_classifier/mnist/mnist_cnn.pt \
+    --handler         examples/mar_extra_root/mnist_handler_extra.py \
+    --extra-files     'examples/mar_extra_root/my_lib1,examples/mar_extra_root/my_lib2'
+...
+FileExistsError: [Errno 17] File exists: '/tmp/mnist/my_module'
+```
+## Refer
+
+- [MNIST](https://github.com/pytorch/serve/blob/master/examples/image_classifier/mnist/README.md).

--- a/examples/mar_extra_root/mnist_handler_extra.py
+++ b/examples/mar_extra_root/mnist_handler_extra.py
@@ -1,0 +1,44 @@
+from torchvision import transforms
+from ts.torch_handler.image_classifier import ImageClassifier
+from torch.profiler import ProfilerActivity
+
+
+from my_lib1.my_file import func as func1
+from my_lib2.my_file import func as func2
+
+func1()
+func2()
+
+
+class MNISTDigitClassifier(ImageClassifier):
+    """
+    MNISTDigitClassifier handler class. This handler extends class ImageClassifier from image_classifier.py, a
+    default handler. This handler takes an image and returns the number in that image.
+
+    Here method postprocess() has been overridden while others are reused from parent class.
+    """
+
+    image_processing = transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Normalize((0.1307,), (0.3081,))
+    ])
+
+    def __init__(self):
+        super(MNISTDigitClassifier, self).__init__()
+        self.profiler_args = {
+            "activities" : [ProfilerActivity.CPU],
+            "record_shapes": True,
+        }
+
+
+    def postprocess(self, data):
+        """The post process of MNIST converts the predicted output response to a label.
+
+        Args:
+            data (list): The predicted output from the Inference with probabilities is passed
+            to the post-process function
+        Returns:
+            list : A list of dictionaries with predictions and explanations is returned
+        """
+        return data.argmax(1).tolist()
+        

--- a/examples/mar_extra_root/my_lib1/my_file.py
+++ b/examples/mar_extra_root/my_lib1/my_file.py
@@ -1,0 +1,2 @@
+def func():
+    print('my_lib1/my_file.py')

--- a/examples/mar_extra_root/my_lib1/my_module/my_file1.py
+++ b/examples/mar_extra_root/my_lib1/my_module/my_file1.py
@@ -1,0 +1,2 @@
+def func1():
+    print('my_lib1/my_module/my_file1.py')

--- a/examples/mar_extra_root/my_lib2/my_file.py
+++ b/examples/mar_extra_root/my_lib2/my_file.py
@@ -1,0 +1,2 @@
+def func():
+    print('my_lib2/my_file.py')

--- a/examples/mar_extra_root/my_lib2/my_module/my_file1.py
+++ b/examples/mar_extra_root/my_lib2/my_module/my_file1.py
@@ -1,0 +1,2 @@
+def func1():
+    print('my_lib2/my_module/my_file1.py')

--- a/model-archiver/model_archiver/arg_parser.py
+++ b/model-archiver/model_archiver/arg_parser.py
@@ -96,6 +96,12 @@ class ArgParser(object):
                                         'This is the default archiving format. Models archived in this format\n'
                                         'will be readily hostable on native TorchServe.\n')
 
+        parser_export.add_argument('--keep-extra-root',
+                                   required=False,
+                                   action='store_true',
+                                   help='When the --keep-extra-root flags are specified, the directorys specified by\n'
+                                        '--extra-files will be copied from the root name or to drop the root name')
+
         parser_export.add_argument('-f', '--force',
                                    required=False,
                                    action='store_true',

--- a/model-archiver/model_archiver/model_packaging.py
+++ b/model-archiver/model_archiver/model_packaging.py
@@ -33,7 +33,8 @@ def package_model(args, manifest):
         artifact_files = {'model_file': model_file, 'serialized_file': serialized_file, 'handler': handler,
                           'extra_files': extra_files, 'requirements-file': requirements_file}
 
-        model_path = ModelExportUtils.copy_artifacts(model_name, **artifact_files)
+        model_path = ModelExportUtils.copy_artifacts(model_name, keep_extra_root=args.keep_extra_root,
+                                                     **artifact_files)
 
         # Step 2 : Zip 'em all up
         ModelExportUtils.archive(export_file_path, model_name, model_path, manifest, args.archive_format)


### PR DESCRIPTION
## Description

Please read our [CONTRIBUTING.md](https://github.com/pytorch/serve/blob/master/CONTRIBUTING.md) prior to creating your first pull request.

Please include a summary of the feature or issue being fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

- support to append sub dirs when generate a *.mar file, such as:
  ```shell
      project/
      ├── my_lib1
      │   ├── my_file.py
      │   └── my_module
      │       └── my_file1.py
      ├── handler.py
      ├── model.py
      ├── weights.pt
      └── ...
  ```
Fixes #1689 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation updated. see [README](https://github.com/csJoax/torchserve/blob/issue_1689/examples/mar_extra_root/README.md) in `examples/mar_extra_root/`.

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] Test A
```shell
$ torch-model-archiver \
    --model-name mnist \
    --version 1.0 \
    --model-file      examples/image_classifier/mnist/mnist.py \
    --serialized-file examples/image_classifier/mnist/mnist_cnn.pt \
    --handler        'examples/mar_extra_root/mnist_handler_extra.py' \
   --extra-files     'examples/mar_extra_root/my_lib1,examples/mar_extra_root/my_lib2' 
ERROR - Maybe running with `--keep-extra-root` or rename the files
Traceback (most recent call last):
  File "/opt/miniconda3/envs/torch/bin/torch-model-archiver", line 33, in <module>
    sys.exit(load_entry_point('torch-model-archiver', 'console_scripts', 'torch-model-archiver')())
  File "/home/joax/GitSpace/pytorch_serve/model-archiver/model_archiver/model_packaging.py", line 57, in generate_model_archive
    package_model(args, manifest=manifest)
  File "/home/joax/GitSpace/pytorch_serve/model-archiver/model_archiver/model_packaging.py", line 36, in package_model
    model_path = ModelExportUtils.copy_artifacts(model_name, keep_extra_root=args.keep_extra_root,
  File "/home/joax/GitSpace/pytorch_serve/model-archiver/model_archiver/model_packaging_utils.py", line 180, in copy_artifacts
    ModelExportUtils.__copy_dir(file, model_path, keep_extra_root)
  File "/home/joax/GitSpace/pytorch_serve/model-archiver/model_archiver/model_packaging_utils.py", line 146, in __copy_dir
    shutil.copytree(src, dst, False, None)
  File "/opt/miniconda3/envs/torch/lib/python3.9/shutil.py", line 565, in copytree
    return _copytree(entries=entries, src=src, dst=dst, symlinks=symlinks,
  File "/opt/miniconda3/envs/torch/lib/python3.9/shutil.py", line 466, in _copytree
    os.makedirs(dst, exist_ok=dirs_exist_ok)
  File "/opt/miniconda3/envs/torch/lib/python3.9/os.py", line 225, in makedirs
    mkdir(name, mode)
FileExistsError: [Errno 17] File exists: '/tmp/mnist/my_module'
```

- [x] Test B
```shell
$ torch-model-archiver \
    --model-name mnist \
    --version 1.0 \
    --model-file      examples/image_classifier/mnist/mnist.py \
    --serialized-file examples/image_classifier/mnist/mnist_cnn.pt \
    --handler         'examples/mar_extra_root/mnist_handler_extra.py' \
    --extra-files     'examples/mar_extra_root/my_lib1,examples/mar_extra_root/my_lib2' \
    --keep-extra-root
$ unzip -l mnist.mar
Archive:  mnist.mar
  Length      Date    Time    Name
---------  ---------- -----   ----
     1376  2022-06-19 02:06   mnist_handler_extra.py
  4800893  2022-06-19 02:06   mnist_cnn.pt
      757  2022-06-19 02:06   mnist.py
       58  2022-06-19 01:32   my_lib2/my_file.py
       59  2022-06-19 01:32   my_lib2/my_module/my_file1.py
       58  2022-06-19 01:32   my_lib1/my_file.py
       59  2022-06-19 01:32   my_lib1/my_module/my_file1.py
      271  2022-06-19 02:06   MAR-INF/MANIFEST.json
---------                     -------
  4803531                     8 files
```


## Checklist:

- [x] Did you have fun? 
- [x] Have you added tests that prove your fix is effective or that this feature works? Yes, see `examples/mar_extra_root/`
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation? Yes, see [README](https://github.com/csJoax/torchserve/blob/issue_1689/examples/mar_extra_root/README.md) in `examples/mar_extra_root/`