### PR TITLE
Clarify Kserve api in Readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Refer to [torchserve docker](docker/README.md) for details.
   * [Kubeflow](https://v0-5.kubeflow.org/docs/components/pytorchserving/)
   * [MLflow](https://github.com/mlflow/mlflow-torchserve)
   * [Sagemaker](https://aws.amazon.com/blogs/machine-learning/serving-pytorch-models-in-production-with-the-amazon-sagemaker-native-torchserve-integration/)
-  * [Kserve](https://kserve.github.io/website/modelserving/v1beta1/torchserve/) (Supports both v1 and v2 api)
+  * [Kserve](https://kserve.github.io/website/modelserving/v1beta1/torchserve/): Supports both v1 and v2 API
   * [Vertex AI](https://cloud.google.com/blog/topics/developers-practitioners/pytorch-google-cloud-how-deploy-pytorch-models-vertex-ai)
 * Export your model for optimized inference. Torchscript out of the box, [ORT](https://discuss.pytorch.org/t/deploying-onnx-model-with-torchserve/97725/2), [IPEX](https://github.com/pytorch/serve/tree/master/examples/intel_extension_for_pytorch), [TensorRT](https://github.com/pytorch/serve/issues/1243), [FasterTransformer](https://github.com/pytorch/serve/tree/master/examples/FasterTransformer_HuggingFace_Bert)
 * [Performance Guide](docs/performance_guide.md): builtin support to optimize, benchmark and profile PyTorch and TorchServe performance

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Refer to [torchserve docker](docker/README.md) for details.
   * [Kubeflow](https://v0-5.kubeflow.org/docs/components/pytorchserving/)
   * [MLflow](https://github.com/mlflow/mlflow-torchserve)
   * [Sagemaker](https://aws.amazon.com/blogs/machine-learning/serving-pytorch-models-in-production-with-the-amazon-sagemaker-native-torchserve-integration/)
-  * [Kserve](https://kserve.github.io/website/modelserving/v1beta1/torchserve/): Supports both v1 and v2 API
+  * [Kserve](https://kserve.github.io/website/0.8/modelserving/v1beta1/torchserve/): Supports both v1 and v2 API
   * [Vertex AI](https://cloud.google.com/blog/topics/developers-practitioners/pytorch-google-cloud-how-deploy-pytorch-models-vertex-ai)
 * Export your model for optimized inference. Torchscript out of the box, [ORT](https://discuss.pytorch.org/t/deploying-onnx-model-with-torchserve/97725/2), [IPEX](https://github.com/pytorch/serve/tree/master/examples/intel_extension_for_pytorch), [TensorRT](https://github.com/pytorch/serve/issues/1243), [FasterTransformer](https://github.com/pytorch/serve/tree/master/examples/FasterTransformer_HuggingFace_Bert)
 * [Performance Guide](docs/performance_guide.md): builtin support to optimize, benchmark and profile PyTorch and TorchServe performance

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Refer to [torchserve docker](docker/README.md) for details.
   * [Kubeflow](https://v0-5.kubeflow.org/docs/components/pytorchserving/)
   * [MLflow](https://github.com/mlflow/mlflow-torchserve)
   * [Sagemaker](https://aws.amazon.com/blogs/machine-learning/serving-pytorch-models-in-production-with-the-amazon-sagemaker-native-torchserve-integration/)
-  * [Kserve](https://kserve.github.io/website/modelserving/v1beta1/torchserve/)
+  * [Kserve](https://kserve.github.io/website/modelserving/v1beta1/torchserve/) (Supports both v1 and v2 api)
   * [Vertex AI](https://cloud.google.com/blog/topics/developers-practitioners/pytorch-google-cloud-how-deploy-pytorch-models-vertex-ai)
 * Export your model for optimized inference. Torchscript out of the box, [ORT](https://discuss.pytorch.org/t/deploying-onnx-model-with-torchserve/97725/2), [IPEX](https://github.com/pytorch/serve/tree/master/examples/intel_extension_for_pytorch), [TensorRT](https://github.com/pytorch/serve/issues/1243), [FasterTransformer](https://github.com/pytorch/serve/tree/master/examples/FasterTransformer_HuggingFace_Bert)
 * [Performance Guide](docs/performance_guide.md): builtin support to optimize, benchmark and profile PyTorch and TorchServe performance

--- a/docs/management_api.md
+++ b/docs/management_api.md
@@ -13,8 +13,7 @@ The Management API listens on port 8081 and is only accessible from localhost by
 
 Similar to the [Inference API](inference_api.md), the Management API provides a [API description](#api-description) to describe management APIs with the OpenAPI 3.0 specification.
 
-Alternatively if you want to use KServe, TorchServe  supports both v1 and v2 api. For more details please look into this [README.md](../kubernetes/kserve/README.md).
-
+Alternatively, if you want to use KServe, TorchServe supports both v1 and v2 API. For more details please look into this [kserve/README.md](https://github.com/pytorch/serve/tree/master/kubernetes/kserve)
 ## Register a model
 
 This API follows the [ManagementAPIsService.RegisterModel](https://github.com/pytorch/serve/blob/master/frontend/server/src/main/resources/proto/management.proto) gRPC API.

--- a/docs/management_api.md
+++ b/docs/management_api.md
@@ -13,6 +13,8 @@ The Management API listens on port 8081 and is only accessible from localhost by
 
 Similar to the [Inference API](inference_api.md), the Management API provides a [API description](#api-description) to describe management APIs with the OpenAPI 3.0 specification.
 
+Alternatively if you want to use KServe, TorchServe  supports both v1 and v2 api. For more details please look into this [README.md](../kubernetes/kserve/README.md).
+
 ## Register a model
 
 This API follows the [ManagementAPIsService.RegisterModel](https://github.com/pytorch/serve/blob/master/frontend/server/src/main/resources/proto/management.proto) gRPC API.

--- a/docs/management_api.md
+++ b/docs/management_api.md
@@ -13,7 +13,7 @@ The Management API listens on port 8081 and is only accessible from localhost by
 
 Similar to the [Inference API](inference_api.md), the Management API provides a [API description](#api-description) to describe management APIs with the OpenAPI 3.0 specification.
 
-Alternatively, if you want to use KServe, TorchServe supports both v1 and v2 API. For more details please look into this [kserve/README.md](https://github.com/pytorch/serve/tree/master/kubernetes/kserve)
+Alternatively, if you want to use KServe, TorchServe supports both v1 and v2 API. For more details please look into this [kserve documentation](https://github.com/pytorch/serve/tree/master/kubernetes/kserve)
 ## Register a model
 
 This API follows the [ManagementAPIsService.RegisterModel](https://github.com/pytorch/serve/blob/master/frontend/server/src/main/resources/proto/management.proto) gRPC API.


### PR DESCRIPTION
Clarify Kserve protocol versions supported in Readme.

## Description

Clarify Kserve protocol versions supported by torchserve, in Readme
Fixes #1721

## Type of change
- [x] This change requires a documentation update ( Readme)

## Feature/Issue validation/testing
Not applicable.

## Checklist:

- [x] Did you have fun?
- [x] Have you made corresponding changes to the documentation?

Please let me know if it needs to be rephrased or documented differently,
Thanks.