### PR TITLE
Remove Relative Imports in handlers

### DIFF
--- a/ts/torch_handler/base_handler.py
+++ b/ts/torch_handler/base_handler.py
@@ -4,16 +4,18 @@ Also, provides handle method per torch serve custom model specification
 """
 
 import abc
+import importlib.util
 import logging
 import os
-import importlib.util
 import time
+
 import torch
 from pkg_resources import packaging
-from ..utils.util import list_classes_from_module, load_label_mapping
+
+from ts.utils.util import list_classes_from_module, load_label_mapping
 
 if packaging.version.parse(torch.__version__) >= packaging.version.parse("1.8.1"):
-    from torch.profiler import profile, record_function, ProfilerActivity
+    from torch.profiler import ProfilerActivity, profile, record_function
 
     PROFILER_AVAILABLE = True
 else:

--- a/ts/torch_handler/image_classifier.py
+++ b/ts/torch_handler/image_classifier.py
@@ -5,8 +5,8 @@ import torch
 import torch.nn.functional as F
 from torchvision import transforms
 
-from .vision_handler import VisionHandler
-from ..utils.util  import map_class_to_label
+from ts.torch_handler.vision_handler import VisionHandler
+from ts.utils.util import map_class_to_label
 
 
 class ImageClassifier(VisionHandler):
@@ -18,13 +18,14 @@ class ImageClassifier(VisionHandler):
     topk = 5
     # These are the standard Imagenet dimensions
     # and statistics
-    image_processing = transforms.Compose([
-        transforms.Resize(256),
-        transforms.CenterCrop(224),
-        transforms.ToTensor(),
-        transforms.Normalize(mean=[0.485, 0.456, 0.406],
-                             std=[0.229, 0.224, 0.225])
-    ])
+    image_processing = transforms.Compose(
+        [
+            transforms.Resize(256),
+            transforms.CenterCrop(224),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+        ]
+    )
 
     def set_max_result_classes(self, topk):
         self.topk = topk

--- a/ts/torch_handler/image_segmenter.py
+++ b/ts/torch_handler/image_segmenter.py
@@ -3,7 +3,9 @@ Module for image segmentation default handler
 """
 import torch
 from torchvision import transforms as T
-from .vision_handler import VisionHandler
+
+from ts.torch_handler.vision_handler import VisionHandler
+
 
 class ImageSegmenter(VisionHandler):
     """
@@ -12,19 +14,19 @@ class ImageSegmenter(VisionHandler):
     where N - batch size, K - number of classes, H - height and W - width.
     """
 
-    image_processing = T.Compose([
-        T.Resize(256),
-        T.CenterCrop(224),
-        T.ToTensor(),
-        T.Normalize(
-            mean=[0.485, 0.456, 0.406],
-            std=[0.229, 0.224, 0.225]
-        )])
+    image_processing = T.Compose(
+        [
+            T.Resize(256),
+            T.CenterCrop(224),
+            T.ToTensor(),
+            T.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+        ]
+    )
 
     def postprocess(self, data):
         # Returning the class for every pixel makes the response size too big
         # (> 24mb). Instead, we'll only return the top class for each image
-        data = data['out']
+        data = data["out"]
         data = torch.nn.functional.softmax(data, dim=1)
         data = torch.max(data, dim=1)
         data = torch.stack([data.indices.type(data.values.dtype), data.values], dim=3)

--- a/ts/torch_handler/object_detector.py
+++ b/ts/torch_handler/object_detector.py
@@ -2,11 +2,12 @@
 Module for object detection default handler
 """
 import torch
-from torchvision import transforms
-from torchvision import __version__ as torchvision_version
 from packaging import version
-from .vision_handler import VisionHandler
-from ..utils.util import map_class_to_label
+from torchvision import __version__ as torchvision_version
+from torchvision import transforms
+
+from ts.torch_handler.vision_handler import VisionHandler
+from ts.utils.util import map_class_to_label
 
 
 class ObjectDetector(VisionHandler):

--- a/ts/torch_handler/text_classifier.py
+++ b/ts/torch_handler/text_classifier.py
@@ -5,14 +5,17 @@ Module for text classification default handler
 DOES NOT SUPPORT BATCH!
 """
 import logging
+
 import torch
 import torch.nn.functional as F
-from torchtext.data.utils import ngrams_iterator
 from captum.attr import TokenReferenceBase
-from .text_handler import TextHandler
-from ..utils.util import map_class_to_label
+from torchtext.data.utils import ngrams_iterator
+
+from ts.torch_handler.text_handler import TextHandler
+from ts.utils.util import map_class_to_label
 
 logger = logging.getLogger(__name__)
+
 
 class TextClassifier(TextHandler):
     """
@@ -46,7 +49,7 @@ class TextClassifier(TextHandler):
         line = data[0]
         text = line.get("data") or line.get("body")
         if isinstance(text, (bytes, bytearray)):
-            text = text.decode('utf-8')
+            text = text.decode("utf-8")
 
         text = self._remove_html_tags(text)
         text = text.lower()
@@ -55,11 +58,8 @@ class TextClassifier(TextHandler):
         text = self._remove_punctuation(text)
         text = self._tokenize(text)
         text_tensor = torch.as_tensor(
-            [
-                self.source_vocab[token]
-                for token in ngrams_iterator(text, self.ngrams)
-            ],
-            device=self.device
+            [self.source_vocab[token] for token in ngrams_iterator(text, self.ngrams)],
+            device=self.device,
         )
         return text_tensor, text
 

--- a/ts/torch_handler/text_handler.py
+++ b/ts/torch_handler/text_handler.py
@@ -2,18 +2,20 @@
 Base module for all text based default handler.
 Contains various text based utility methods
 """
+import logging
 import os
 import re
-import logging
 import string
 import unicodedata
 from abc import ABC
+
 import torch
 import torch.nn.functional as F
-from torchtext.data.utils import get_tokenizer
 from captum.attr import LayerIntegratedGradients
-from .base_handler import BaseHandler
-from .contractions import CONTRACTION_MAP
+from torchtext.data.utils import get_tokenizer
+
+from ts.torch_handler.base_handler import BaseHandler
+from ts.torch_handler.utils.contractions import CONTRACTION_MAP
 
 logger = logging.getLogger(__name__)
 
@@ -45,13 +47,17 @@ class TextHandler(BaseHandler, ABC):
         """
         super().initialize(context)
         self.initialized = False
-        source_vocab = self.manifest['model']['sourceVocab'] if 'sourceVocab' in self.manifest['model'] else None
+        source_vocab = (
+            self.manifest["model"]["sourceVocab"]
+            if "sourceVocab" in self.manifest["model"]
+            else None
+        )
         if source_vocab:
             # Backward compatibility
             self.source_vocab = torch.load(source_vocab)
         else:
             self.source_vocab = torch.load(self.get_source_vocab_path(context))
-        #Captum initialization
+        # Captum initialization
         self.lig = LayerIntegratedGradients(self.model, self.model.embedding)
         self.initialized = True
 
@@ -63,8 +69,10 @@ class TextHandler(BaseHandler, ABC):
         if os.path.isfile(source_vocab_path):
             return source_vocab_path
         else:
-            raise Exception('Missing the source_vocab file. Refer default handler '
-                            'documentation for details on using text_handler.')
+            raise Exception(
+                "Missing the source_vocab file. Refer default handler "
+                "documentation for details on using text_handler."
+            )
 
     def _expand_contractions(self, text):
         """

--- a/ts/torch_handler/utils/contractions.py
+++ b/ts/torch_handler/utils/contractions.py
@@ -125,5 +125,5 @@ CONTRACTION_MAP = {
     "you'll": "you will",
     "you'll've": "you will have",
     "you're": "you are",
-    "you've": "you have"
+    "you've": "you have",
 }

--- a/ts/torch_handler/vision_handler.py
+++ b/ts/torch_handler/vision_handler.py
@@ -3,19 +3,22 @@
 """
 Base module for all vision handlers
 """
-from abc import ABC
-import io
 import base64
+import io
+from abc import ABC
+
 import torch
-from PIL import Image
 from captum.attr import IntegratedGradients
-from .base_handler import BaseHandler
+from PIL import Image
+
+from ts.torch_handler.base_handler import BaseHandler
 
 
 class VisionHandler(BaseHandler, ABC):
     """
     Base class for all vision handlers
     """
+
     def initialize(self, context):
         super().initialize(context)
         self.ig = IntegratedGradients(self.model)


### PR DESCRIPTION
## Description

Our existing handler files use relative imports which break in two situations
* #1661 
* #1682 

More information on why this is a bad pattern here https://stackoverflow.com/a/14132912

We can fix this by removing relative imports and instead importing `from ts` - there is no functional change in this PR. For example


```python
# before
from ..utils.util import list_classes_from_module, load_label_mapping

# after
from ts.utils.util import list_classes_from_module, load_label_mapping
```

This change is unrelated to #1709, that PR fixes bugs for path calculation with `os.path.join()` which is multiplatform instead of `/` which doesn't work on Windows.

## Tests

Regression tests are failing: https://gist.github.com/msaroufim/610d3f0a4c1de14abef4de9aeffd01a6
CI is also failing: see below 

Very interesting, I would have expected this change to be harmless