### PR TITLE
Update java version to 17 on ubuntu

### DIFF
--- a/benchmarks/install_dependencies.sh
+++ b/benchmarks/install_dependencies.sh
@@ -13,7 +13,7 @@ sudo apt-get install -y \
         python3-dev \
         python-psutil \
         python3-pip \
-        openjdk-11-jdk \
+        openjdk-17-jdk \
         g++ \
         curl \
         vim \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,17 +2,17 @@
 #
 # This file can build images for cpu and gpu env. By default it builds image for CPU.
 # Use following option to build image for cuda/GPU: --build-arg BASE_IMAGE=nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04
-# Here is complete command for GPU/cuda - 
+# Here is complete command for GPU/cuda -
 # $ DOCKER_BUILDKIT=1 docker build --file Dockerfile --build-arg BASE_IMAGE=nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04 -t torchserve:latest .
 #
 # Following comments have been shamelessly copied from https://github.com/pytorch/pytorch/blob/master/Dockerfile
-# 
+#
 # NOTE: To build this you will need a docker version > 18.06 with
 #       experimental enabled and DOCKER_BUILDKIT=1
 #
 #       If you do not use buildkit you are not going to have a good time
 #
-#       For reference: 
+#       For reference:
 #           https://docs.docker.com/develop/develop-images/build_enhancements/
 
 
@@ -42,7 +42,7 @@ RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt \
     && python3.8 get-pip.py
 
 
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1 \ 
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1 \
     && update-alternatives --install /usr/local/bin/pip pip /usr/local/bin/pip3.8 1
 
 RUN python3.8 -m venv /home/venv
@@ -84,6 +84,8 @@ RUN --mount=type=cache,target=/var/cache/apt \
     python3.8 \
     python3.8-distutils \
     python3.8-dev \
+    # using openjdk-17-jdk due to circular dependency(ca-certificates) bug in openjdk-17-jre-headless debian package
+    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1009905
     openjdk-17-jdk \
     build-essential \
     && rm -rf /var/lib/apt/lists/* \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,7 @@ RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt \
     python3.8-distutils \
     python3.8-venv \
     python3-venv \
-    openjdk-11-jre-headless \
+    openjdk-17-jdk \
     curl \
     && rm -rf /var/lib/apt/lists/* \
     && cd /tmp \
@@ -84,7 +84,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
     python3.8 \
     python3.8-distutils \
     python3.8-dev \
-    openjdk-11-jre-headless \
+    openjdk-17-jdk \
     build-essential \
     && rm -rf /var/lib/apt/lists/* \
     && cd /tmp

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -40,7 +40,7 @@ RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt \
     python3.8-distutils \
    # python3-venv \
     build-essential \
-    openjdk-11-jdk \
+    openjdk-17-jdk \
     curl \
     vim \
     numactl \ 
@@ -84,10 +84,10 @@ CMD ["serve"]
 
 # Build CodeBuild Image
 FROM compile-image AS codebuild-image
-ENV JAVA_VERSION=11 \
-  JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64" \
-  JDK_HOME="/usr/lib/jvm/java-11-openjdk-amd64" \
-  JRE_HOME="/usr/lib/jvm/java-11-openjdk-amd64" \
+ENV JAVA_VERSION=17 \
+  JAVA_HOME="/usr/lib/jvm/java-17-openjdk-amd64" \
+  JDK_HOME="/usr/lib/jvm/java-17-openjdk-amd64" \
+  JRE_HOME="/usr/lib/jvm/java-17-openjdk-amd64" \
   ANT_VERSION=1.10.3 \
   MAVEN_HOME="/opt/maven" \
   MAVEN_VERSION=3.5.4 \

--- a/frontend/gradle/wrapper/gradle-wrapper.properties
+++ b/frontend/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/frontend/server/build.gradle
+++ b/frontend/server/build.gradle
@@ -19,6 +19,7 @@ jar {
         attributes 'Main-Class': 'org.pytorch.serve.ModelServer'
     }
     includeEmptyDirs = false
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     from configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
 
     exclude "META-INF/maven/**"

--- a/ts_scripts/install_dependencies.py
+++ b/ts_scripts/install_dependencies.py
@@ -1,7 +1,8 @@
+import argparse
 import os
 import platform
-import argparse
 import sys
+
 from print_env_info import run_and_parse_first_match
 
 REPO_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..")
@@ -10,11 +11,10 @@ sys.path.append(REPO_ROOT)
 from ts_scripts.utils import check_python_version
 
 
-class Common():
-
+class Common:
     def __init__(self):
         self.torch_stable_url = "https://download.pytorch.org/whl/torch_stable.html"
-        self.sudo_cmd = 'sudo '
+        self.sudo_cmd = "sudo "
 
     def install_java(self):
         pass
@@ -69,11 +69,10 @@ class Common():
 
 
 class Linux(Common):
-
     def __init__(self):
         super().__init__()
         # Skip 'sudo ' when the user is root
-        self.sudo_cmd = '' if os.geteuid() == 0 else self.sudo_cmd
+        self.sudo_cmd = "" if os.geteuid() == 0 else self.sudo_cmd
 
         if args.force:
             os.system(f"{self.sudo_cmd}apt-get update")
@@ -84,9 +83,10 @@ class Linux(Common):
 
     def install_nodejs(self):
         if os.system("node -v") != 0 or args.force:
-            os.system(f"{self.sudo_cmd}curl -sL https://deb.nodesource.com/setup_14.x | {self.sudo_cmd}bash -")
+            os.system(
+                f"{self.sudo_cmd}curl -sL https://deb.nodesource.com/setup_14.x | {self.sudo_cmd}bash -"
+            )
             os.system(f"{self.sudo_cmd}apt-get install -y nodejs")
-
 
     def install_wget(self):
         if os.system("wget --version") != 0 or args.force:
@@ -97,9 +97,7 @@ class Linux(Common):
             f"wget https://github.com/libgit2/libgit2/archive/refs/tags/v1.3.0.tar.gz -O libgit2-1.3.0.tar.gz"
         )
         os.system(f"tar xzf libgit2-1.3.0.tar.gz")
-        os.system(
-            f"cd libgit2-1.3.0 && cmake . && make && sudo make install && cd .."
-        )
+        os.system(f"cd libgit2-1.3.0 && cmake . && make && sudo make install && cd ..")
         os.system(f"rm -rf libgit2-1.3.0 && rm libgit2-1.3.0.tar.gz")
 
     def install_maven(self):
@@ -107,10 +105,9 @@ class Linux(Common):
 
 
 class Windows(Common):
-
     def __init__(self):
         super().__init__()
-        self.sudo_cmd = ''
+        self.sudo_cmd = ""
 
     def install_java(self):
         pass
@@ -123,7 +120,6 @@ class Windows(Common):
 
 
 class Darwin(Common):
-
     def __init__(self):
         super().__init__()
 
@@ -168,23 +164,39 @@ def install_dependencies(cuda_version=None):
     # Sequence of installation to be maintained
     system.install_java()
     requirements_file_path = "requirements/" + (
-        "production.txt" if args.environment == "prod" else "developer.txt")
+        "production.txt" if args.environment == "prod" else "developer.txt"
+    )
     system.install_python_packages(cuda_version, requirements_file_path)
 
 
 def get_brew_version():
-    """Returns `brew --version` output. """
+    """Returns `brew --version` output."""
 
-    return run_and_parse_first_match("brew --version", r'Homebrew (.*)')
+    return run_and_parse_first_match("brew --version", r"Homebrew (.*)")
 
 
 if __name__ == "__main__":
     check_python_version()
-    parser = argparse.ArgumentParser(description="Install various build and test dependencies of TorchServe")
-    parser.add_argument('--cuda', default=None, choices=['cu92', 'cu101', 'cu102', 'cu111', 'cu113'], help="CUDA version for torch")
-    parser.add_argument('--environment', default='prod', choices=['prod', 'dev'],
-                        help="environment(production or developer) on which dependencies will be installed")
-    parser.add_argument("--force", action='store_true', help="force reinstall dependencies wget, node, java and apt-update")
+    parser = argparse.ArgumentParser(
+        description="Install various build and test dependencies of TorchServe"
+    )
+    parser.add_argument(
+        "--cuda",
+        default=None,
+        choices=["cu92", "cu101", "cu102", "cu111", "cu113"],
+        help="CUDA version for torch",
+    )
+    parser.add_argument(
+        "--environment",
+        default="prod",
+        choices=["prod", "dev"],
+        help="environment(production or developer) on which dependencies will be installed",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="force reinstall dependencies wget, node, java and apt-update",
+    )
     args = parser.parse_args()
 
     install_dependencies(cuda_version=args.cuda)

--- a/ts_scripts/install_dependencies.py
+++ b/ts_scripts/install_dependencies.py
@@ -81,7 +81,7 @@ class Linux(Common):
 
     def install_java(self):
         if os.system("javac --version") != 0 or args.force:
-            os.system(f"{self.sudo_cmd}apt-get install -y openjdk-11-jdk")
+            os.system(f"{self.sudo_cmd}apt-get install -y openjdk-17-jdk")
 
     def install_nodejs(self):
         if os.system("node -v") != 0 or args.force:

--- a/ts_scripts/install_dependencies.py
+++ b/ts_scripts/install_dependencies.py
@@ -2,7 +2,6 @@ import os
 import platform
 import argparse
 import sys
-from pathlib import Path
 from print_env_info import run_and_parse_first_match
 
 REPO_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..")

--- a/ts_scripts/install_utils
+++ b/ts_scripts/install_utils
@@ -20,7 +20,7 @@ install_java_deps()
       brew tap AdoptOpenJDK/openjdk
       brew cask install adoptopenjdk11
     else
-      sudo apt-get install -y openjdk-11-jdk
+      sudo apt-get install -y openjdk-17-jdk
     fi
   fi
   set -e


### PR DESCRIPTION
## Description
Upgrades java version to 17 on ubuntu.

One notable change is that `openjdk-17-jdk` instead of just headless package due to circular dependency issue with`ca-certificate-java` package. https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1009905. This increased docker image size by ~200MB.

Docker images sizes:
```
ubuntu@ip-172-31-37-107:~/torchserve$ docker images
REPOSITORY             TAG              IMAGE ID       CREATED       SIZE
pytorch/torchserve     prod-cpu-jdk17   1cabb0c21a26   11 days ago   1.98GB
pytorch/torchserve     prod-gpu-jdk11   c507dc722994   11 days ago   7.56GB
pytorch/torchserve     prod-cpu-jdk11   f77c9b66469c   12 days ago   1.54GB
pytorch/torchserve     dev-gpu-jdk11    cd68df3b8f75   12 days ago   10.5GB
pytorch/torchserve     prod-gpu-jdk17   8a0adb614cae   12 days ago   8GB
pytorch/torchserve     dev-gpu-jdk17    2fee84b17735   13 days ago   10.6GB
```


Fixes #(issue)    
https://github.com/pytorch/serve/issues/1619
sub task - https://github.com/pytorch/serve/issues/1730

## Feature/Issue validation/testing

- [x] torchserve_sanity.py
- [x] tests/regression_tests.py
- [x]  performance test resu
- [x] CPU prod docker log -  [jdk17_cpu_load_infer.log](https://github.com/pytorch/serve/files/9144812/jdk17_cpu_load_infer.log)
- [x] GPU prod docker log - [jdk17_gpu_load_infer.log](https://github.com/pytorch/serve/files/9144815/jdk17_gpu_load_infer.log)
- [x] GPU devo docker log - [jdk17_dev_gpu_load_infer.log](https://github.com/pytorch/serve/files/9144821/jdk17_dev_gpu_load_infer.log)

Test commands ran for above docker tests - [test_commands.log](https://github.com/pytorch/serve/files/9144826/test_commands.log)
