### PR TITLE
install torchserve from repository (pytorch/torchserve:0.5.3-cpu version mismatching issue)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -76,7 +76,7 @@ RUN python -m pip install --no-cache-dir captum torchtext
 
 COPY . tmp/serve
 
-RUN python -m pip install --no-cache-dir tmp/serve/ tmp/serve/model-archiver
+RUN python -m pip install --no-cache-dir tmp/serve/ tmp/serve/model-archiver tmp/serve/workflow-archiver
 
 # Final image for production
 FROM ${BASE_IMAGE} AS runtime-image

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,7 +39,8 @@ RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt \
     && rm -rf /var/lib/apt/lists/* \
     && cd /tmp \
     && curl -O https://bootstrap.pypa.io/get-pip.py \
-    && python3.8 get-pip.py
+    && python3.8 get-pip.py \
+    && rm -rf /tmp/*
 
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1 \ 
@@ -71,11 +72,11 @@ RUN TORCH_VER=$(curl --silent --location https://pypi.org/pypi/torch/json | pyth
     else \
         python -m pip install --no-cache-dir torch==$TORCH_VER+cpu torchvision==$TORCH_VISION_VER+cpu -f https://download.pytorch.org/whl/torch_stable.html; \
     fi
-RUN python -m pip install -U setuptools && python -m pip install --no-cache-dir captum torchtext torch-model-archiver
+RUN python -m pip install --no-cache-dir captum torchtext
 
 COPY . tmp/serve
 
-RUN python -m pip install tmp/serve/ && rm -r tmp/serve
+RUN python -m pip install --no-cache-dir tmp/serve/ tmp/serve/model-archiver
 
 # Final image for production
 FROM ${BASE_IMAGE} AS runtime-image
@@ -91,7 +92,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
     openjdk-11-jre-headless \
     build-essential \
     && rm -rf /var/lib/apt/lists/* \
-    && cd /tmp
+    && rm -rf /tmp/*
 
 RUN useradd -m model-server \
     && mkdir -p /home/model-server/tmp

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,7 +71,11 @@ RUN TORCH_VER=$(curl --silent --location https://pypi.org/pypi/torch/json | pyth
     else \
         python -m pip install --no-cache-dir torch==$TORCH_VER+cpu torchvision==$TORCH_VISION_VER+cpu -f https://download.pytorch.org/whl/torch_stable.html; \
     fi
-RUN python -m pip install -U setuptools && python -m pip install --no-cache-dir captum torchtext torchserve torch-model-archiver
+RUN python -m pip install -U setuptools && python -m pip install --no-cache-dir captum torchtext torch-model-archiver
+
+COPY . tmp/serve
+
+RUN python -m pip install tmp/serve/ && rm -r tmp/serve
 
 # Final image for production
 FROM ${BASE_IMAGE} AS runtime-image
@@ -96,12 +100,12 @@ COPY --chown=model-server --from=compile-image /home/venv /home/venv
 
 ENV PATH="/home/venv/bin:$PATH"
 
-COPY dockerd-entrypoint.sh /usr/local/bin/dockerd-entrypoint.sh
+COPY docker/dockerd-entrypoint.sh /usr/local/bin/dockerd-entrypoint.sh
 
 RUN chmod +x /usr/local/bin/dockerd-entrypoint.sh \
     && chown -R model-server /home/model-server
 
-COPY config.properties /home/model-server/config.properties
+COPY docker/config.properties /home/model-server/config.properties
 RUN mkdir /home/model-server/model-store && chown -R model-server /home/model-server/model-store
 
 EXPOSE 8080 8081 8082 7070 7071

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -108,7 +108,7 @@ fi
 
 if [ $BUILD_TYPE == "production" ]
 then
-  DOCKER_BUILDKIT=1 docker build --file Dockerfile --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg CUDA_VERSION=$CUDA_VERSION -t $DOCKER_TAG .
+  cd ../ && DOCKER_BUILDKIT=1 docker build --file docker/Dockerfile --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg CUDA_VERSION=$CUDA_VERSION -t $DOCKER_TAG .
 elif [ $BUILD_TYPE == "benchmark" ]
 then
   DOCKER_BUILDKIT=1 docker build --pull --no-cache --file Dockerfile.benchmark --build-arg USE_LOCAL_SERVE_FOLDER=$USE_LOCAL_SERVE_FOLDER --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg BRANCH_NAME=$BRANCH_NAME --build-arg CUDA_VERSION=$CUDA_VERSION --build-arg MACHINE_TYPE=$MACHINE -t $DOCKER_TAG .

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -108,7 +108,7 @@ fi
 
 if [ $BUILD_TYPE == "production" ]
 then
-  cd ../ && DOCKER_BUILDKIT=1 docker build --file docker/Dockerfile --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg CUDA_VERSION=$CUDA_VERSION -t $DOCKER_TAG .
+  DOCKER_BUILDKIT=1 docker build --file Dockerfile --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg CUDA_VERSION=$CUDA_VERSION -t $DOCKER_TAG ../
 elif [ $BUILD_TYPE == "benchmark" ]
 then
   DOCKER_BUILDKIT=1 docker build --pull --no-cache --file Dockerfile.benchmark --build-arg USE_LOCAL_SERVE_FOLDER=$USE_LOCAL_SERVE_FOLDER --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg BRANCH_NAME=$BRANCH_NAME --build-arg CUDA_VERSION=$CUDA_VERSION --build-arg MACHINE_TYPE=$MACHINE -t $DOCKER_TAG .


### PR DESCRIPTION
## Description

In the current implementation, at the time of `docker build`, a Docker image with the latest version of `torchserve` installed is created regardless of the version of the repository.

I change implementations to install `torchserve` from source.

Fixes https://github.com/pytorch/serve/issues/1736

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Feature/Issue validation/testing

Compare the expected torchserve version and torchserve version of docker images obtained using `pip list|grep "torchserve "|awk '{printf $2}'`.


## Checklist:

- [x] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?