### PR TITLE
Don't install IPEX on Mac to unblock CI

### DIFF
--- a/requirements/developer.txt
+++ b/requirements/developer.txt
@@ -1,5 +1,4 @@
 -r common.txt
-intel_extension_for_pytorch; sys_platform != 'win32'
 mock
 pytest
 pylint==2.6.0
@@ -14,3 +13,4 @@ pygit2==1.6.1
 pyspelling
 pre-commit
 twine
+intel_extension_for_pytorch; sys_platform != 'win32' and sys_platform != 'darwin'


### PR DESCRIPTION
Look at CI to see if this fix worked

## Description

When we merged the #1401 PR our Mac CI had bee flaky so we missed that `nvgpu` wouldn't be installed because no matching version of `ipex` would have been found for darwin.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] After this change
See Mac CI below 

- [x] Before this change
 https://github.com/pytorch/serve/runs/7419700493?check_suite_focus=true

```
Requirement already satisfied: numpy in /Users/runner/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages (from -r requirements/common.txt (line 9)) (1.23.1)
Collecting nvgpu
  Downloading nvgpu-0.9.0-py2.py3-none-any.whl (9.4 kB)
ERROR: Could not find a version that satisfies the requirement intel_extension_for_pytorch (from versions: none)
ERROR: No matching distribution found for intel_extension_for_pytorch
15s
Run python torchserve_sanity.py
Traceback (most recent call last):
  File "torchserve_sanity.py", line 5, in <module>
    from ts_scripts.sanity_utils import test_sanity
  File "/Users/runner/work/serve/serve/ts_scripts/sanity_utils.py", line 3, in <module>
    import nvgpu
ModuleNotFoundError: No module named 'nvgpu'
Error: Process completed with exit code [1](https://github.com/pytorch/serve/runs/7419700493?check_suite_focus=true#step:6:1).
```