### PR TITLE
update java version to 17 on macOS

### DIFF
--- a/ts_scripts/install_dependencies.py
+++ b/ts_scripts/install_dependencies.py
@@ -128,12 +128,7 @@ class Darwin(Common):
             out = get_brew_version()
             if out == "N/A":
                 sys.exit("**Error: Homebrew not installed...")
-
-            os.system("brew tap AdoptOpenJDK/openjdk")
-            if out >= "2.7":
-                os.system("brew install --cask adoptopenjdk11")
-            else:
-                os.system("brew cask install adoptopenjdk11")
+            os.system("brew install openjdk@17")
 
     def install_nodejs(self):
         os.system("brew unlink node")

--- a/ts_scripts/install_utils
+++ b/ts_scripts/install_utils
@@ -14,11 +14,10 @@ install_java_deps()
 {
   set +e
   JAVA_VERSION=$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1)
-	if [ "$JAVA_VERSION" != "11" ]
+	if [ "$JAVA_VERSION" != "17" ]
   then
     if [[ "$OSTYPE" == "darwin"* ]]; then
-      brew tap AdoptOpenJDK/openjdk
-      brew cask install adoptopenjdk11
+      brew install openjdk@17
     else
       sudo apt-get install -y openjdk-17-jdk
     fi


### PR DESCRIPTION
## Description

Update macOS java version to jdk 17. Previously, jdk11 from [adoptopen](https://adoptopenjdk.net/) was being used which does not have jdk17. Using [jdk17](https://formulae.brew.sh/formula/openjdk@17) from https://openjdk.org/ which is also consistent with Ubuntu.

Fixes #(issue)
Parent task : https://github.com/pytorch/serve/issues/1619
Sub task: https://github.com/pytorch/serve/issues/1731

## Feature/Issue validation/testing

- [x]  torchserve_sanity.py
[torchserve_sanity.log](https://github.com/pytorch/serve/files/9129133/torchserve_sanity.log)

- [x] regression_tests.log
[regression_tests.log](https://github.com/pytorch/serve/files/9129135/regression_tests.log)

- [x] sample load inference requests
[jdk17_mac_cpu_load_infer.log](https://github.com/pytorch/serve/files/9152264/jdk17_mac_cpu_load_infer.log)
```
(ts_py_env) nalrohit@147dda6964dd torchserve % java -version
openjdk version "17.0.3" 2022-04-19
OpenJDK Runtime Environment Homebrew (build 17.0.3+0)
OpenJDK 64-Bit Server VM Homebrew (build 17.0.3+0, mixed mode, sharing)
(ts_py_env) nalrohit@147dda6964dd torchserve % curl -X POST  "http://localhost:8081/models?url=densenet161.mar&initial_workers=1"
{
  "status": "Model \"densenet161\" Version: 1.0 registered with 1 initial workers"
}
(ts_py_env) nalrohit@147dda6964dd torchserve % curl http://localhost:8080/predictions/densenet161 -T kitten_small.jpg            
{
  "tabby": 0.4781668484210968,
  "lynx": 0.20013417303562164,
  "tiger_cat": 0.16822926700115204,
  "tiger": 0.061912767589092255,
  "Egyptian_cat": 0.05113610625267029
}%                                                                                                                                    
(ts_py_env) nalrohit@147dda6964dd torchserve % torchserve --stop
TorchServe has stopped.
```


