### PR TITLE
Pin markdown version to fix broken doc build

### DIFF
--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -1,3 +1,5 @@
+# cf. https://github.com/ryanfox/sphinx-markdown-tables/issues/36
+markdown<3.4.0
 sphinx==3.0.3
 recommonmark==0.6.0
 -e git+git://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme


### PR DESCRIPTION
## Description

Markdown 3.4 has made some breaking changes https://github.com/ryanfox/sphinx-markdown-tables/issues/36 which broke our doc build https://github.com/pytorch/serve/actions/workflows/doc-automation.yml so we right now we can't update our documentation

So suggestion for now is to pick an earlier version from https://github.com/ryanfox/sphinx-markdown-tables/issues/36

Fixes #1744 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Feature/Issue validation/testing

About 7 different people have confirmed this works for them https://github.com/ryanfox/sphinx-markdown-tables/issues/36


## Checklist:

- [x] Did you have fun?
- [x] Has code been commented, particularly in hard-to-understand areas?
