### PR TITLE
Skip codecov on Mac and Windows

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -44,6 +44,7 @@ jobs:
       # Any coverage.xml will be picked up by this step
       # Just make sure each coverage.xml is in a different folder
       - name: Upload codecov
+        if: matrix.os == 'ubuntu-latest'
         run : |
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           chmod +x codecov


### PR DESCRIPTION
## Description
We only need to upload codecov for ubuntu for now so disabling mac and windows

Fixes #1757 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)