### PR TITLE
Update CI and docs to use java 17

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -25,22 +25,22 @@ jobs:
         with:
           python-version: 3.8
           architecture: x64
-      - name: Setup Java 11
+      - name: Setup Java 17
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: '17'
       - name: Checkout TorchServe
         uses: actions/checkout@v2
       - name: Install dependencies
         run: |
           python ts_scripts/install_dependencies.py --environment=dev
       - name: Torchserve Sanity
-        run: | 
+        run: |
           python torchserve_sanity.py
       - name: mvn install
         run: cd serving-sdk/ && mvn clean install -q && cd ../
-        
+
       # Any coverage.xml will be picked up by this step
       # Just make sure each coverage.xml is in a different folder
       - name: Upload codecov
@@ -49,5 +49,3 @@ jobs:
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           chmod +x codecov
           ./codecov
-
-

--- a/.github/workflows/ci_gpu.yml
+++ b/.github/workflows/ci_gpu.yml
@@ -11,7 +11,7 @@ on:
 concurrency:
   group: ci-gpu-${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_number || github.ref }}
   cancel-in-progress: true
-  
+
 jobs:
   ci-gpu:
     runs-on: [self-hosted, ci-gpu]
@@ -29,11 +29,11 @@ jobs:
         with:
           python-version: 3.8
           architecture: x64
-      - name: Setup Java 11
+      - name: Setup Java 17
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: '17'
       - name: Checkout TorchServe
         uses: actions/checkout@v2
       - name: Install dependencies
@@ -51,4 +51,3 @@ jobs:
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           chmod +x codecov
           ./codecov
-

--- a/.github/workflows/torchserve-nightly-build.yml
+++ b/.github/workflows/torchserve-nightly-build.yml
@@ -23,11 +23,11 @@ jobs:
         run: |
           python ts_scripts/install_dependencies.py --environment=dev
           pip install -e .
-      - name: Setup Java 11
+      - name: Setup Java 17
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: '17'
       - name: Build PyPI & conda nightly binaries
         run: python binaries/build.py --nightly
       - name: Push conda nightly binaries

--- a/benchmarks/jmeter.md
+++ b/benchmarks/jmeter.md
@@ -27,7 +27,7 @@ The benchmarking script requires the following to run:
 
 ### Windows
 
-For Windows, you should have python3 and java(OpenJDK-11) installed. You will need to install jmeter with plugins which can be accomplished by running `python windows_install_dependencies.py <Path to install jmeter>`. For example:
+For Windows, you should have python3 and java(OpenJDK-17) installed. You will need to install jmeter with plugins which can be accomplished by running `python windows_install_dependencies.py <Path to install jmeter>`. For example:
 ```bash
 python3 windows_install_dependencies.py "C:\\Program Files"
 ```
@@ -173,14 +173,14 @@ The benchmarks can be used in conjunction with standard profiling tools such as 
 Once you have stopped recording, you should be able to analyze the data. One useful section to examine is CPU views > Call Tree and CPU views > Hot Spots to see where the processor time is going.
 
 ## Backend
-The benchmarks can also be used to analyze the backend performance using cProfile. To benchmark a backend code, 
+The benchmarks can also be used to analyze the backend performance using cProfile. To benchmark a backend code,
 
 1. Install Torchserve
 
     Using local TorchServe instance:
 
     * Install TorchServe using the [install guide](../README.md#install-torchserve-and-torch-model-archiver)
-    
+
     By using external docker container for TorchServe:
 
     * Create a [docker container for TorchServe](../docker/README.md).
@@ -204,7 +204,7 @@ The benchmarks can also be used to analyze the backend performance using cProfil
     ```
 
 4. Visualize SnakeViz results.
- 
+
     To visualize the profiling data using `snakeviz` use following commands:
 
     ```bash
@@ -213,4 +213,4 @@ The benchmarks can also be used to analyze the backend performance using cProfil
     ```
     ![](snake_viz.png)
 
-    It should start up a web server on your machine and automatically open the page. Note that tha above command will fail if executed on a server where no browser is installed. The backend profiling should generate a visualization similar to the pic shown above. 
+    It should start up a web server on your machine and automatically open the page. Note that tha above command will fail if executed on a server where no browser is installed. The backend profiling should generate a visualization similar to the pic shown above.

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -16,7 +16,7 @@ Refer [configuration.md](https://github.com/pytorch/serve/blob/master/docs/confi
 Relevant issues: [[542](https://github.com/pytorch/serve/issues/542)]
 
 #### "java.lang.NoSuchMethodError" when starting Torchserve.[[473](https://github.com/pytorch/serve/issues/473)]
-This error usually occurs when Java 11 is not installed or used. Java 11 is required by Torchserve and older java versions are not supported.
+This error usually occurs when Java 17 is not installed or used. Java 17 is required by Torchserve and older java versions are not supported.
 
 Relevant issues: [[#473](https://github.com/pytorch/serve/issues/473)]
 
@@ -35,7 +35,7 @@ Relevant issues: [[#335](https://github.com/pytorch/serve/issues/335)]
 
 ###  Snapshot related issues
 #### How to disable Snapshot feature?
-By default, the snapshot feature is enabled. To disable snapshot feature start torchserve using --ncs flag or specify config file using --ts-config path/to/config 
+By default, the snapshot feature is enabled. To disable snapshot feature start torchserve using --ncs flag or specify config file using --ts-config path/to/config
 Relevant issues:[[#383](https://github.com/pytorch/serve/issues/383), [#512](https://github.com/pytorch/serve/issues/512)]
 
 #### Torchserve stopped after restart with "InvalidSnapshotException" exception.
@@ -77,7 +77,7 @@ Relevant issues: [[#566](https://github.com/pytorch/serve/issues/566)]
 You can provide a requirements.txt while creating a mar file using "--requirements-file/ -r" flag. You can refer to the [waveglow text-to-speech-synthesizer](https://github.com/pytorch/serve/tree/master/examples/text_to_speech_synthesizer) example
 
 -   [waveglow mar creation script](https://github.com/pytorch/serve/blob/master/examples/text_to_speech_synthesizer/create_mar.sh)
--   [waveglow handler](https://github.com/pytorch/serve/blob/master/examples/text_to_speech_synthesizer/waveglow_handler.py#L57)
+-   [waveglow handler](https://github.com/pytorch/serve/blob/2d9c7ccc316f592374943a1963c1057bbe232c9e/examples/text_to_speech_synthesizer/waveglow_handler.py#L49)
 
 Relevant issues: [[#566](https://github.com/pytorch/serve/issues/566)]
 Refer [Torch model archiver cli](https://github.com/pytorch/serve/blob/master/model-archiver/README.md#torch-model-archiver-command-line-interface) for more details.

--- a/docs/torchserve_on_win_native.md
+++ b/docs/torchserve_on_win_native.md
@@ -13,17 +13,17 @@
  - The instruction given here will use anaconda Powershell terminal to install torchserve
  - Install Anaconda as given [here](https://docs.anaconda.com/anaconda/install/windows/)
  - Install Git as given [here](https://github.com/git-for-windows/git/releases/download/v2.28.0.windows.1/Git-2.28.0-64-bit.exe)
- - Install openjdk11
-    - Download [openjdk11](https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_windows-x64_bin.zip)
+ - Install openjdk17
+    - Download [openjdk17](https://download.oracle.com/java/17/archive/jdk-17.0.3_windows-x64_bin.zip)
     - Unzip and edit/add environment variables i.e. PATH and JAVA_HOME
     e.g.
-    - Using command line `unzip openjdk-11*_bin.zip` or using GUI interface
-    - Edit system or user profile environment variable `PATH` value and append path `<your-openjdk11-path>\bin` to it
+    - Using command line `unzip jdk-17.0.3_windows-x64_bin.zip` or using GUI interface
+    - Edit system or user profile environment variable `PATH` value and append path `<your-openjdk17-path>\bin` to it
  - Install nodejs
     - Download [nodejs](https://nodejs.org/dist/v14.15.1/node-v14.15.1-x64.msi)
     - Post installation make sure nodejs and npm node modules binaries are present in PATH environment variable.
-    - You may have to re-start windows if your 'Anaconda Powershell Prompt' (APP) is not able to detect npm or nodejs commands 
-    
+    - You may have to re-start windows if your 'Anaconda Powershell Prompt' (APP) is not able to detect npm or nodejs commands
+
 ## Install from binaries
 
 NOTE At present, wheels for windows are not available on PyPi. However following steps can also be used if you have prebuilt torchserve wheel for windows.
@@ -38,29 +38,29 @@ NOTE At present, wheels for windows are not available on PyPi. However following
     - `pip install torchserve torch-model-archiver`
  - Start torchserve `torchserve.exe --start --model-store <path-to-model-store>`
  - For next steps refer [Serving a model](../README.md#serve-a-model)
-    
+
 ## Install from source
 
- - Ensure that system or user profile environment variable name `JAVA_HOME` with value as `<your-openjdk11-path>` path is present.
+ - Ensure that system or user profile environment variable name `JAVA_HOME` with value as `<your-openjdk17-path>` path is present.
  - Install [Microsoft Visual C++ Redistributable for Visual Studio 2015, 2017 and 2019](https://support.microsoft.com/en-in/help/2977003/the-latest-supported-visual-c-downloads)
- 
+
    NOTE ensure that you have restarted system after install above Visual C++ components
  - Ensure that 'nvidia-smi.exe' is available in `Path` environment variable. Usually, it should be available under `<your_install_drive>\Program Files\NVIDIA Corporation\NVSMI`
    e.g. C:\Program Files\NVIDIA Corporation\NVSMI, add this path to `Path` env variable
  - Start 'Anaconda Powershell Prompt' (APP) as Admin User i.e. By right click on APP and run following commands
  - `git clone https://github.com/pytorch/serve.git`
  - `pip install click`
- - `cd serve`  
- 
+ - `cd serve`
+
     #### For production usage, use commands below:
     - `python .\ts_scripts\install_dependencies.py --environment=prod`
-    - `python .\ts_scripts\install_from_src.py`  
- 
-    #### For development purposes, use commands below: 
+    - `python .\ts_scripts\install_from_src.py`
+
+    #### For development purposes, use commands below:
     If you plan to develop with TorchServe and change some source code, commands below will help.
     The install_dependencies script installs few extra dependencies which are needed for development and testing.
     - `python .\ts_scripts\install_dependencies.py --environment=dev`
-    - `python .\ts_scripts\install_from_src.py`  
+    - `python .\ts_scripts\install_from_src.py`
 
 ## Troubleshooting
  - If you are building from source then you may have to change the port number for inference, management and metrics apis as specified in `frontend/server/src/test/resources/config.properties`,

--- a/docs/torchserve_on_wsl.md
+++ b/docs/torchserve_on_wsl.md
@@ -12,7 +12,7 @@
 
  - [Windows Subsystem for Linux Installation Guide for Windows 10](https://docs.microsoft.com/en-us/windows/wsl/install-win10)
  - [Windows Subsystem for Linux Installation Guide for Windows Server 2019](https://docs.microsoft.com/en-us/windows/wsl/install-on-server)
- 
+
 
 ## Install from binaries
 
@@ -24,10 +24,10 @@ echo 'export PATH=$HOME/.local/bin:$PATH' >> ~/.bashrc
 source ~/.bashrc
 ```
 
-1. Install JDK 11
+1. Install JDK 17
 
 ```bash
-sudo apt-get install openjdk-11-jdk
+sudo apt-get install openjdk-17-jdk
 ```
 
 1. Install Dependencies


### PR DESCRIPTION
## Description

Update CI and docs to use java 17

Fixes #(issue)
https://github.com/pytorch/serve/issues/1619

## Feature/Issue validation/testing

- For Windows jdk upgrade, ran torchserve sanity tests.
[torchserve_sanity_jdk17.log](https://github.com/pytorch/serve/files/9185053/torchserve_sanity_jdk17.log)

- Sample load infer requests.
[load_infer_jdk17_win.txt](https://github.com/pytorch/serve/files/9185196/load_infer_jdk17_win.txt)
commands ran
```
C:\Users\Administrator\Documents\torchserve> java --version
java 17.0.3.1 2022-04-22 LTS
Java(TM) SE Runtime Environment (build 17.0.3.1+2-LTS-6)
Java HotSpot(TM) 64-Bit Server VM (build 17.0.3.1+2-LTS-6, mixed mode, sharing)
C:\Users\Administrator\Documents\torchserve> curl "http://localhost:8081/models"
{
  "models": []
}
C:\Users\Administrator\Documents\torchserve> curl -X POST  "http://localhost:8081/models?url=squeezenet1_1.mar&initial_workers=1"
{
  "status": "Model \"squeezenet1_1\" Version: 1.0 registered with 1 initial workers"
}
C:\Users\Administrator\Documents\torchserve> curl http://localhost:8080/predictions/squeezenet1_1 -T kitten_small.jpg
{
  "lynx": 0.5455784201622009,
  "tabby": 0.2794168293476105,
  "Egyptian_cat": 0.10391931980848312,
  "tiger_cat": 0.062633216381073,
  "leopard": 0.005019133910536766
}
C:\Users\Administrator\Documents\torchserve>
```


## Checklist:

- [x] Did you have fun?
- [x] Have you made corresponding changes to the documentation?