### PR TITLE
fix: model status API for kserve

### DIFF
--- a/kubernetes/kserve/config.properties
+++ b/kubernetes/kserve/config.properties
@@ -11,5 +11,6 @@ metrics_format=prometheus
 NUM_WORKERS=1
 number_of_netty_threads=4
 job_queue_size=10
+load_models=all
 model_store=/home/model-server/shared/model-store
 model_snapshot={"name":"startup.cfg","modelCount":1,"models":{"mnist":{"1.0":{"defaultVersion":true,"marName":"mnist.mar","minWorkers":1,"maxWorkers":5,"batchSize":5,"maxBatchDelay":200,"responseTimeout":60}}}}

--- a/kubernetes/kserve/kserve_wrapper/TSModelRepository.py
+++ b/kubernetes/kserve/kserve_wrapper/TSModelRepository.py
@@ -1,14 +1,16 @@
 """ The repository to serve the Torchserve Models in the kserve side"""
 import logging
 from importlib.metadata import version
+
 import kserve
 
-if version('kserve') >= '0.8.0':
+if version("kserve") >= "0.8.0":
     from kserve.model_repository import ModelRepository as ModelRepository
 else:
     from kserve.kfmodel_repository import KFModelRepository as ModelRepository
 
 logging.basicConfig(level=kserve.constants.KSERVE_LOGLEVEL)
+
 
 class TSModelRepository(ModelRepository):
     """A repository of kserve KFModels
@@ -16,8 +18,8 @@ class TSModelRepository(ModelRepository):
         KFModelRepository (object): The parameters from the KFModelRepository is passed
         as inputs to the TSModel Repository.
     """
-    def __init__(self, inference_address: str, management_address: str,
-                 model_dir: str):
+
+    def __init__(self, inference_address: str, management_address: str, model_dir: str):
         """The Inference Address, Management Address and the Model Directory from the kserve
         side is initialized here.
 

--- a/kubernetes/kserve/kserve_wrapper/TorchserveModel.py
+++ b/kubernetes/kserve/kserve_wrapper/TorchserveModel.py
@@ -126,6 +126,9 @@ class TorchserveModel(Model):
         return json.loads(response.body)
 
     def load(self) -> bool:
+        """This method validates model availabilty in the model directory
+        and sets ready flag to true.
+        """
         model_path = pathlib.Path(kserve.Storage.download(self.model_dir))
         paths = list(pathlib.Path(model_path).glob("*.mar"))
         existing_paths = [path for path in paths if path.exists()]

--- a/kubernetes/kserve/kserve_wrapper/TorchserveModel.py
+++ b/kubernetes/kserve/kserve_wrapper/TorchserveModel.py
@@ -1,15 +1,16 @@
 """ The torchserve side inference end-points request are handled to
     return a KServe side response """
 import json
-from typing import Dict
 import logging
 import pathlib
 from importlib.metadata import version
+from typing import Dict
+
 import kserve
 import tornado.web
-from kserve.model import ModelMissingError, InferenceError
+from kserve.model import ModelMissingError
 
-if version('kserve') >= '0.8.0':
+if version("kserve") >= "0.8.0":
     from kserve.model import Model as Model
 else:
     from kserve.kfmodel import KFModel as Model
@@ -126,12 +127,14 @@ class TorchserveModel(Model):
 
     def load(self) -> bool:
         model_path = pathlib.Path(kserve.Storage.download(self.model_dir))
-        paths = list(pathlib.Path(model_path).glob('*.mar'))
+        paths = list(pathlib.Path(model_path).glob("*.mar"))
         existing_paths = [path for path in paths if path.exists()]
         if len(existing_paths) == 0:
             raise ModelMissingError(model_path)
         elif len(existing_paths) > 1:
-            raise RuntimeError('More than one model file is detected, '
-                               f'Only one is allowed within model_dir: {existing_paths}')
+            raise RuntimeError(
+                "More than one model file is detected, "
+                f"Only one is allowed within model_dir: {existing_paths}"
+            )
         self.ready = True
         return self.ready

--- a/kubernetes/kserve/kserve_wrapper/TorchserveModel.py
+++ b/kubernetes/kserve/kserve_wrapper/TorchserveModel.py
@@ -125,8 +125,7 @@ class TorchserveModel(Model):
         return json.loads(response.body)
 
     def load(self) -> bool:
-        # model_path = pathlib.Path(kserve.Storage.download(self.model_dir))
-        model_path = '/home/ubuntu/models/model-store'
+        model_path = pathlib.Path(kserve.Storage.download(self.model_dir))
         paths = list(pathlib.Path(model_path).glob('*.mar'))
         existing_paths = [path for path in paths if path.exists()]
         if len(existing_paths) == 0:

--- a/kubernetes/kserve/kserve_wrapper/__main__.py
+++ b/kubernetes/kserve/kserve_wrapper/__main__.py
@@ -90,10 +90,11 @@ if __name__ == "__main__":
 
         model = TorchserveModel(model_name, inference_address,
                                 management_address, model_dir)
+        model.load()
         models.append(model)
+    registeredModels = TSModelRepository(inference_address, management_address, model_dir)
     ModelServer(
-        registered_models=TSModelRepository(inference_address,
-                                            management_address, model_dir),
+        registered_models=registeredModels,
         http_port=8080,
         grpc_port=7070,
     ).start(models)

--- a/kubernetes/kserve/kserve_wrapper/__main__.py
+++ b/kubernetes/kserve/kserve_wrapper/__main__.py
@@ -2,12 +2,12 @@
 import json
 import logging
 from importlib.metadata import version
-import kserve
 
+import kserve
 from TorchserveModel import TorchserveModel
 from TSModelRepository import TSModelRepository
 
-if version('kserve') >= '0.8.0':
+if version("kserve") >= "0.8.0":
     from kserve.model_server import ModelServer
 else:
     from kserve.kfserver import KFServer as ModelServer
@@ -74,25 +74,31 @@ def parse_config():
         model_store = DEFAULT_MODEL_STORE
     logging.info(
         "Wrapper : Model names %s, inference address %s, management address %s, model store %s",
-        model_names, inference_address, management_address, model_store)
+        model_names,
+        inference_address,
+        management_address,
+        model_store,
+    )
 
     return model_names, inference_address, management_address, model_store
 
 
 if __name__ == "__main__":
 
-    model_names, inference_address, management_address, model_dir = parse_config(
-    )
+    model_names, inference_address, management_address, model_dir = parse_config()
 
     models = []
 
     for model_name in model_names:
 
-        model = TorchserveModel(model_name, inference_address,
-                                management_address, model_dir)
+        model = TorchserveModel(
+            model_name, inference_address, management_address, model_dir
+        )
         model.load()
         models.append(model)
-    registeredModels = TSModelRepository(inference_address, management_address, model_dir)
+    registeredModels = TSModelRepository(
+        inference_address, management_address, model_dir
+    )
     ModelServer(
         registered_models=registeredModels,
         http_port=8080,

--- a/kubernetes/kserve/kserve_wrapper/__main__.py
+++ b/kubernetes/kserve/kserve_wrapper/__main__.py
@@ -94,6 +94,9 @@ if __name__ == "__main__":
         model = TorchserveModel(
             model_name, inference_address, management_address, model_dir
         )
+        # By default model.load() is called on first request. Enabling load all
+        # model in TS config.properties, all models are loaded at start and the
+        # below method sets status to true for the models.
         model.load()
         models.append(model)
     registeredModels = TSModelRepository(


### PR DESCRIPTION
Signed-off-by: jagadeesh <jagadeeshj@ideas2it.com>

## Description
fixes: [kserve/kserve-1915](https://github.com/kserve/kserve/issues/1915)

Issue: kserve model status API returns ready status only after a predict request as model is not loaded in startup.
Soln: Loads all TS models at start with `load_models` property and kserve load model method.

Gif of model status working after TS isvc deployment.
![output](https://user-images.githubusercontent.com/46392704/181746535-5b39f4c7-82c4-4b9a-80f3-6b01106b638a.gif)
[model-status.log](https://github.com/pytorch/serve/files/9270878/model-status.log)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B


## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?