### PR TITLE
update to latest version of jacoco

### DIFF
--- a/frontend/server/build.gradle
+++ b/frontend/server/build.gradle
@@ -11,6 +11,10 @@ dependencies {
     testImplementation "org.testng:testng:${testng_version}"
 }
 
+processResources.dependsOn('generateProto')
+processTestResources.dependsOn('generateTestProto')
+jar.dependsOn(':archive:jar')
+
 apply from: file("${project.rootProject.projectDir}/tools/gradle/proto.gradle")
 apply from: file("${project.rootProject.projectDir}/tools/gradle/launcher.gradle")
 

--- a/frontend/tools/gradle/check.gradle
+++ b/frontend/tools/gradle/check.gradle
@@ -35,7 +35,7 @@ tasks.withType(Checkstyle) {
 
 apply plugin: "jacoco"
 jacoco {
-    toolVersion = "0.8.5"
+    toolVersion = "0.8.8"
 }
 jacocoTestReport {
     group = "Reporting"

--- a/plugins/tools/gradle/check.gradle
+++ b/plugins/tools/gradle/check.gradle
@@ -33,7 +33,7 @@ tasks.withType(Checkstyle) {
 
 apply plugin: "jacoco"
 jacoco {
-    toolVersion = "0.8.5"
+    toolVersion = "0.8.8"
 }
 jacocoTestReport {
     group = "Reporting"


### PR DESCRIPTION
## Description

Updating to latest version of jacoco - 0.8.8 - https://www.eclemma.org/jacoco/ since there are codecov errors in ci log since jdk17 upgrade.

Ran `torchserve_sanity.py` locally and did not see the errors.

Also specified task dependencies to fix the warnings from gradle build.

e.g https://github.com/pytorch/serve/runs/7736904638?check_suite_focus=true
```> Task :server:processResources
Execution optimizations have been disabled for task ':server:processResources' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/home/runner/work/serve/serve/frontend/server/src/main/proto'. Reason: Task ':server:processResources' uses this output of task ':server:generateProto' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.3/userguide/validation_problems.html#implicit_dependency for more details about this problem.
  - Gradle detected a problem with the following location: '/home/runner/work/serve/serve/frontend/server/src/main/resources'. Reason: Task ':server:processResources' uses this output of task ':server:generateProto' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.3/userguide/validation_problems.html#implicit_dependency for more details about this problem.
  - Gradle detected a problem with the following location: '/home/runner/work/serve/serve/frontend/server/src/main/resources/proto'. Reason: Task ':server:processResources' uses this output of task ':server:generateProto' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.3/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```