### PR TITLE
Trigger Benchmark using Keyword in PR

### DIFF
--- a/.github/workflows/benchmark_nightly_cpu.yml
+++ b/.github/workflows/benchmark_nightly_cpu.yml
@@ -4,10 +4,13 @@ on:
   # run every day at 2:15am
   schedule:
     - cron:  '15 02 * * *'
+  pull_request:
+
 jobs:
   nightly:
+    if: ${{ (github.repository_owner == 'pytorch' && contains(github.event.pull_request.body, 'RUN_BENCHMARK')) || github.event_name  == 'schedule' }}
     runs-on: [self-hosted, cpu]
-    timeout-minutes: 1320 
+    timeout-minutes: 1320
     steps:
       - name: Clean up previous run
         run: |
@@ -34,7 +37,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: nightly cpu artifact
-          path: /tmp/ts_benchmark 
+          path: /tmp/ts_benchmark
       - name: Open issue on failure
         if: ${{ failure() && github.event_name  == 'schedule' }}
         uses: rishabhgupta/git-action-issue@v2

--- a/.github/workflows/benchmark_nightly_gpu.yml
+++ b/.github/workflows/benchmark_nightly_gpu.yml
@@ -1,13 +1,17 @@
 name: Benchmark torchserve gpu nightly
 
+
 on:
   # run every day at 2:15am
   schedule:
     - cron:  '15 02 * * *'
+  pull_request:
+
 jobs:
   nightly:
+    if: ${{ (github.repository_owner == 'pytorch' && contains(github.event.pull_request.body, 'RUN_BENCHMARK')) || github.event_name  == 'schedule' }}
     runs-on: [self-hosted, gpu]
-    timeout-minutes: 1320 
+    timeout-minutes: 1320
     steps:
       - name: Clean up previous run
         run: |
@@ -34,7 +38,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: nightly gpu artifact
-          path: /tmp/ts_benchmark 
+          path: /tmp/ts_benchmark
       - name: Open issue on failure
         if: ${{ failure() && github.event_name  == 'schedule' }}
         uses: rishabhgupta/git-action-issue@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Your contributions will fall into two categories:
           ```
     - Run Regression test `python test/regression_tests.py`
     - For running individual test suites refer [code_coverage](docs/code_coverage.md) documentation
-    - If you are updating an existing model make sure that performance hasn't degraded by running [benchmarks](https://github.com/pytorch/serve/tree/master/benchmarks) on the master branch and your branch and verify there is no performance regression
+    - If you are updating an existing model make sure that performance hasn't degraded by typing `RUN_BENCHMARK` in your PR description which will automatically trigger our comprehensive benchmarking suite
     - Run `ts_scripts/spellcheck.sh` to fix any typos in your documentation
     - For large changes make sure to run the [automated benchmark suite](https://github.com/pytorch/serve/tree/master/test/benchmark) which will run the apache bench tests on several configurations of CUDA and EC2 instances
     - If you need more context on a particular issue, please create raise a ticket on [`TorchServe` GH repo](https://github.com/pytorch/serve/issues/new/choose) or connect to [PyTorch's slack channel](https://pytorch.slack.com/)


### PR DESCRIPTION
This PR checks if the keyword at the top shows up anywhere in the PR description and if it does it triggers our benchmark suite. This is useful for times when you need to check if a given change improves performance or not without setting up a manual suite each time. Hopefully this will make it easier to easily measure and more quickly integrate performance related changes like #1631 and #1797 

Test is below

h/t @xuzhao9