### PR TITLE
Use and link to correct paths

### DIFF
--- a/examples/image_classifier/mnist/README.md
+++ b/examples/image_classifier/mnist/README.md
@@ -1,44 +1,37 @@
 # Digit recognition model with MNIST dataset
 
-In this example, we show how to use a pre-trained custom MNIST model to performing real time Digit recognition with TorchServe.
+In this example, we show how to use a pre-trained custom MNIST model to perfor real-time digit recognition with TorchServe.
 
 The inference service would return the digit inferred by the model in the input image.
 
-We used the following pytorch example to train the basic MNIST model for digit recognition :
+We used the following pytorch example to train the basic MNIST model for digit recognition:
 https://github.com/pytorch/examples/tree/master/mnist
 
 # Objective
-1. Demonstrate how to package a custom trained model with custom handler into torch model archive (.mar) file
-2. Demonstrate how to create model handler code
-3. Demonstrate how to load model archive (.mar) file into TorchServe and run inference.
+1. Demonstrate how to package a custom trained model with custom handler into torch model archive (`.mar`) file.
+2. Demonstrate how to create model handler code.
+3. Demonstrate how to load model archive (`.mar`) file into TorchServe and run inference..
 
 # Serve a custom model on TorchServe
 
-Run the commands given in following steps from the parent directory of the root of the repository. For example, if you cloned the repository into /home/my_path/serve, run the steps from /home/my_path
+Run the commands given in following steps from the root of this repository. For example, if you cloned the repository into `/home/user/serve`, first run `cd /home/user/serve` and then the individual commands.
 
- * Step - 1: Create a new model architecture file which contains model class extended from torch.nn.modules. In this example we have created [mnist model file](mnist.py).
- * Step - 2: Train a MNIST digit recognition model using https://github.com/pytorch/examples/blob/master/mnist/main.py and save the state dict of model. We have added the pre-created [state dict](mnist_cnn.pt) of this model.
- * Step - 3: Write a custom handler to run the inference on your model. In this example, we have added a [custom_handler](mnist_handler.py) which runs the inference on the input greyscale images using the above model and recognizes the digit in the image.
- * Step - 4: Create a torch model archive using the torch-model-archiver utility to archive the above files.
- 
+ * Step - 1: Create a file that defines the model architecture as a class that extends `torch.nn.Module`. Our example: [`mnist.py`](./mnist.py).
+ * Step - 2: Train a MNIST digit recognition model following https://github.com/pytorch/examples/blob/master/mnist/main.py and save the state dict of model. Our example: [`mnist_cnn.pt`](./mnist_cnn.pt)
+ * Step - 3: Write a custom handler to run the inference on your model. Our example: [`mnist_handler.py`](./mnist_handler.py) 
+ * Step - 4: Create a torch model archive using the torch-model-archiver utility to archive the above files:
     ```bash
     torch-model-archiver --model-name mnist --version 1.0 --model-file examples/image_classifier/mnist/mnist.py --serialized-file examples/image_classifier/mnist/mnist_cnn.pt --handler  examples/image_classifier/mnist/mnist_handler.py
     ```
-   
-  Step 5 is optional. Perform this step to use pytorch profiler
-       
-  * Step - 5: To enable pytorch profiler, set the following environment variable.
-  
-        ```
-        export ENABLE_TORCH_PROFILER=true
-        ```
-   
- * Step - 6: Register the model on TorchServe using the above model archive file and run digit recognition inference
-   
+  * Step - 5: To enable pytorch profiler, set the following environment variable. *This is optional*
+    ```bash
+    export ENABLE_TORCH_PROFILER=true
+    ```
+ * Step - 6: Register the model on TorchServe using the above model archive file and run digit recognition inference:
     ```bash
     mkdir model_store
     mv mnist.mar model_store/
-    torchserve --start --model-store model_store --models mnist=mnist.mar --ts-config config.properties
+    torchserve --start --model-store model_store --models mnist=mnist.mar --ts-config examples/image_classifier/mnist/config.properties
     curl http://127.0.0.1:8080/predictions/mnist -T examples/image_classifier/mnist/test_data/0.png
     ```
 


### PR DESCRIPTION
Although, according to a statement towards the beginning of the tutorial, paths were supposed to relative to the repository's root's parent, most were actually relative to the repository's root. The path to the configuration file only contained the filename.

Please note that this commit and pull request only pertain to a single text file. No code changes, no tests, no nothin'.