### PR TITLE
Temporarily reverting PR 1798 

### DIFF
--- a/.github/workflows/benchmark_nightly_cpu.yml
+++ b/.github/workflows/benchmark_nightly_cpu.yml
@@ -4,11 +4,9 @@ on:
   # run every day at 2:15am
   schedule:
     - cron:  '15 02 * * *'
-  pull_request:
 
 jobs:
   nightly:
-    if: ${{ (github.repository_owner == 'pytorch' && contains(github.event.pull_request.body, 'RUN_BENCHMARK')) || github.event_name  == 'schedule' }}
     runs-on: [self-hosted, cpu]
     timeout-minutes: 1320
     steps:

--- a/.github/workflows/benchmark_nightly_gpu.yml
+++ b/.github/workflows/benchmark_nightly_gpu.yml
@@ -5,11 +5,9 @@ on:
   # run every day at 2:15am
   schedule:
     - cron:  '15 02 * * *'
-  pull_request:
 
 jobs:
   nightly:
-    if: ${{ (github.repository_owner == 'pytorch' && contains(github.event.pull_request.body, 'RUN_BENCHMARK')) || github.event_name  == 'schedule' }}
     runs-on: [self-hosted, gpu]
     timeout-minutes: 1320
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Your contributions will fall into two categories:
           ```
     - Run Regression test `python test/regression_tests.py`
     - For running individual test suites refer [code_coverage](docs/code_coverage.md) documentation
-    - If you are updating an existing model make sure that performance hasn't degraded by typing `RUN_BENCHMARK` in your PR description which will automatically trigger our comprehensive benchmarking suite
+    - If you are updating an existing model make sure that performance hasn't degraded by typing running [benchmarks](https://github.com/pytorch/serve/tree/master/benchmarks) on the master branch and your branch and verify there is no performance regression
     - Run `ts_scripts/spellcheck.sh` to fix any typos in your documentation
     - For large changes make sure to run the [automated benchmark suite](https://github.com/pytorch/serve/tree/master/test/benchmark) which will run the apache bench tests on several configurations of CUDA and EC2 instances
     - If you need more context on a particular issue, please create raise a ticket on [`TorchServe` GH repo](https://github.com/pytorch/serve/issues/new/choose) or connect to [PyTorch's slack channel](https://pytorch.slack.com/)

--- a/benchmarks/benchmark-ab.py
+++ b/benchmarks/benchmark-ab.py
@@ -398,7 +398,9 @@ def prepare_common_dependency():
         execution_params["config_properties"],
         os.path.join(execution_params["tmp_dir"], "benchmark", "conf"),
     )
-    shutil.copyfile(input, os.path.join(execution_params["tmp_dir"], "benchmark", "input"))
+    shutil.copyfile(
+        input, os.path.join(execution_params["tmp_dir"], "benchmark", "input")
+    )
 
 
 def getAPIS():
@@ -505,11 +507,16 @@ def generate_csv_output():
     artifacts["TS latency P90"] = extract_entity(data, "90%", -1)
     artifacts["TS latency P99"] = extract_entity(data, "99%", -1)
     artifacts["TS latency mean"] = extract_entity(data, "Time per request:.*mean\)", -3)
-    artifacts["TS error rate"] = (
-        int(artifacts["TS failed requests"]) / execution_params["requests"] * 100
-    )
+    if isinstance(artifacts["TS failed requests"], type(None)):
+        artifacts["TS error rate"] = None
+    else:
+        artifacts["TS error rate"] = (
+            int(artifacts["TS failed requests"]) / execution_params["requests"] * 100
+        )
 
-    with open(os.path.join(execution_params["tmp_dir"], "benchmark", "predict.txt")) as f:
+    with open(
+        os.path.join(execution_params["tmp_dir"], "benchmark", "predict.txt")
+    ) as f:
         lines = f.readlines()
         lines.sort(key=float)
         artifacts["Model_p50"] = lines[line50].strip()

--- a/benchmarks/benchmark-ab.py
+++ b/benchmarks/benchmark-ab.py
@@ -508,7 +508,7 @@ def generate_csv_output():
     artifacts["TS latency P99"] = extract_entity(data, "99%", -1)
     artifacts["TS latency mean"] = extract_entity(data, "Time per request:.*mean\)", -3)
     if isinstance(artifacts["TS failed requests"], type(None)):
-        artifacts["TS error rate"] = None
+        artifacts["TS error rate"] = 0.0
     else:
         artifacts["TS error rate"] = (
             int(artifacts["TS failed requests"]) / execution_params["requests"] * 100


### PR DESCRIPTION
## Description

There is a failure in BenchMark CI https://github.com/pytorch/serve/actions/runs/2908587948

This happened because multiple instances of benchmark CI runs were running concurrently after the commit in PR 1798

Fixes #(issue)

## Type of change

Run benchmark CI on nightly basis only.
Also, added a None type check to avoid a crash.

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)



## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ Yes] Have you made corresponding changes to the documentation?