### PR TITLE
Fix Windows Nightly Build

### DIFF
--- a/.github/workflows/torchserve-nightly-build.yml
+++ b/.github/workflows/torchserve-nightly-build.yml
@@ -2,6 +2,7 @@ name: Push torchserve nightly
 
 on:
   # run every day at 11:15am
+  push:
   schedule:
     - cron:  '15 11 * * *'
 jobs:

--- a/.github/workflows/torchserve-nightly-build.yml
+++ b/.github/workflows/torchserve-nightly-build.yml
@@ -2,7 +2,6 @@ name: Push torchserve nightly
 
 on:
   # run every day at 11:15am
-  push:
   schedule:
     - cron:  '15 11 * * *'
 jobs:

--- a/binaries/conda/build_packages.py
+++ b/binaries/conda/build_packages.py
@@ -132,7 +132,8 @@ def conda_build(
             output_dir = os.path.join(conda_build_dir, "output")
             cmd = f"{CONDA_BINARY} build --output-folder {output_dir} --python={pyv} {pkg}"
             print(f"## In directory: {os.getcwd()}; Executing command: {cmd}")
-            try_and_handle(cmd, dry_run)
+            if not dry_run:
+                os.system(cmd)
     return 0  # Used for sys.exit(0) --> to indicate successful system exit
 
 


### PR DESCRIPTION
Fixes #1821

## Problem

`subprocess.run()` has frequently given me issues on Windows so changing back a single line back to `os.system()`

## Test:

I temporarily enabled on push for nightly builds to test out on all 3 OSs at once

```
on:
  # run every day at 11:15am
  push:
  schedule:
    - cron:  '15 11 * * *'
jobs:
```

 https://github.com/pytorch/serve/runs/8090582952?check_suite_focus=true