### PR TITLE
wip add pip cache

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           python-version: 3.8
           architecture: x64
+          cache: pip
+          cache-dependency-path: '**/requirements/requirements*.txt'
+
       - name: Setup Java 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -20,6 +20,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
+      - name: Checkout TorchServe
+        uses: actions/checkout@v2
       - name: Setup Python 3.8
         uses: actions/setup-python@v2
         with:
@@ -33,8 +35,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
-      - name: Checkout TorchServe
-        uses: actions/checkout@v2
+
       - name: Install dependencies
         run: |
           python ts_scripts/install_dependencies.py --environment=dev

--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: 3.8
           architecture: x64
           cache: pip
-          cache-dependency-path: '**/requirements/requirements*.txt'
+          cache-dependency-path: '**/requirements/*.txt'
 
       - name: Setup Java 17
         uses: actions/setup-java@v3

--- a/.github/workflows/ci_gpu.yml
+++ b/.github/workflows/ci_gpu.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: 3.8
           architecture: x64
           cache: pip
-          cache-dependency-path: '**/requirements/requirements*.txt'
+          cache-dependency-path: '**/requirements/*.txt'
 
       - name: Setup Java 17
         uses: actions/setup-java@v3

--- a/.github/workflows/ci_gpu.yml
+++ b/.github/workflows/ci_gpu.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           python-version: 3.8
           architecture: x64
+          cache: pip
+          cache-dependency-path: '**/requirements/requirements*.txt'
+
       - name: Setup Java 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/ci_gpu.yml
+++ b/.github/workflows/ci_gpu.yml
@@ -24,6 +24,9 @@ jobs:
           cd ..
           pwd
           rm -rf _tool
+      - name: Checkout TorchServe
+        uses: actions/checkout@v2
+
       - name: Setup Python 3.8
         uses: actions/setup-python@v2
         with:
@@ -36,9 +39,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '17'
-      - name: Checkout TorchServe
-        uses: actions/checkout@v2
+          java-version: '17'          
       - name: Install dependencies
         run: |
           python ts_scripts/install_dependencies.py --environment=dev --cuda=cu102


### PR DESCRIPTION
wip to reduce CI time

Baseline `install_dependencies.py`
* On Ubuntu: 3min
* On Mac: 6 min
* On Windows: 6 min
* On GPU: 12 min

After adding pip cache