### PR TITLE
Reverted RUN_BENCHMARK revert

### DIFF
--- a/.github/workflows/benchmark_nightly_cpu.yml
+++ b/.github/workflows/benchmark_nightly_cpu.yml
@@ -1,9 +1,10 @@
 name: Benchmark torchserve cpu nightly
 
+on:
   # run every day at 2:15am
-schedule:
-  - cron:  '15 02 * * *'
-pull_request:
+  schedule:
+    - cron:  '15 02 * * *'
+  pull_request:
 
 jobs:
   nightly:

--- a/.github/workflows/benchmark_nightly_cpu.yml
+++ b/.github/workflows/benchmark_nightly_cpu.yml
@@ -1,12 +1,13 @@
 name: Benchmark torchserve cpu nightly
 
-on:
   # run every day at 2:15am
-  schedule:
-    - cron:  '15 02 * * *'
+schedule:
+  - cron:  '15 02 * * *'
+pull_request:
 
 jobs:
   nightly:
+    if: ${{ (github.repository_owner == 'pytorch' && contains(github.event.pull_request.body, 'RUN_BENCHMARK')) || github.event_name  == 'schedule' }}
     runs-on: [self-hosted, cpu]
     timeout-minutes: 1320
     steps:

--- a/.github/workflows/benchmark_nightly_gpu.yml
+++ b/.github/workflows/benchmark_nightly_gpu.yml
@@ -1,13 +1,13 @@
 name: Benchmark torchserve gpu nightly
 
-
 on:
-  # run every day at 2:15am
   schedule:
     - cron:  '15 02 * * *'
+  pull_request:
 
 jobs:
   nightly:
+    if: ${{ (github.repository_owner == 'pytorch' && contains(github.event.pull_request.body, 'RUN_BENCHMARK')) || github.event_name  == 'schedule' }}
     runs-on: [self-hosted, gpu]
     timeout-minutes: 1320
     steps:

--- a/benchmarks/benchmark-ab.py
+++ b/benchmarks/benchmark-ab.py
@@ -507,7 +507,7 @@ def generate_csv_output():
     artifacts["TS latency P90"] = extract_entity(data, "90%", -1)
     artifacts["TS latency P99"] = extract_entity(data, "99%", -1)
     artifacts["TS latency mean"] = extract_entity(data, "Time per request:.*mean\)", -3)
-    if isinstance(artifacts["TS failed requests"], type(None)):
+    if artifacts["TS failed requests"] in [None, "", 0]:
         artifacts["TS error rate"] = 0.0
     else:
         artifacts["TS error rate"] = (


### PR DESCRIPTION
## Description

Fixes #1834 

We had initially reverted the ability to run benchmarks with a keyword because we believed that it was causing issues when concurrent benchmarks were ran. I suspect that wasn't quite the problem so decided to retrigger benchmarks and fix the issue which I believe was using None when there were no failed requests. If the benchmark CI passes below then it means the fix worked but I do unfortunately need to wait 16h to confirm. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Feature/Issue validation/testing

Before: #1834 
After: benchmark CI signals below

The CI signals will also confirm whether the benchmark script is flaky, which we cannot afford because it's 16h long and too slow to rerun

