### PR TITLE
Validate torchserve process in pid file before starting

### DIFF
--- a/ts/model_server.py
+++ b/ts/model_server.py
@@ -29,17 +29,13 @@ def start():
     if os.path.isfile(pid_file):
         with open(pid_file, "r") as f:
             pid = int(f.readline())
-
-            if pid:
-                try:
-                    process_from_pid_file = psutil.Process(pid)
-                    pid = (
-                        pid if TS_NAMESPACE in process_from_pid_file.cmdline() else None
-                    )
-                except psutil.Error:
-                    pid = None
-                    print("Removing orphan pid file.")
-                    os.remove(pid_file)
+            try:
+                process_from_pid_file = psutil.Process(pid)
+                pid = pid if TS_NAMESPACE in process_from_pid_file.cmdline() else None
+            except psutil.Error:
+                pid = None
+                print("Removing orphan pid file.")
+                os.remove(pid_file)
     # pylint: disable=too-many-nested-blocks
     if args.version:
         print("TorchServe Version is {}".format(__version__))


### PR DESCRIPTION
## Description

Fixes #1862 - There's an edge case where if `.model_server.pid` file is not deleted when torchserve stops abruptly and another process with same pid is started before torchserve is attempted to start again at which point it falsely assumes that the new pid of another process is torchserve process and exits with message `"TorchServe is already running, please use torchserve --stop to stop TorchServe."` This additional check validates that the process is actually a torchserve process and if not it will start torchserve. 
Testing:
* Usual path - verified that torchserve start and stop work as before
* Edge case path - manually changed the pid file to replace pid with another process and verified that torchserve started without complaining that torchserve is already running.