### PR TITLE
Changed os.system to subprocess.run

### DIFF
--- a/binaries/build.py
+++ b/binaries/build.py
@@ -1,6 +1,7 @@
 import argparse
 import glob
 import os
+import subprocess
 import sys
 
 # To help discover local modules
@@ -49,7 +50,7 @@ def build_dist_whl(args):
         print(f"## In directory: {os.getcwd()} | Executing command: {cur_wheel_cmd}")
 
         if not args.dry_run:
-            build_exit_code = os.system(cur_wheel_cmd)
+            build_exit_code = subprocess.run(cur_wheel_cmd)
             # If any one of the steps fail, exit with error
             if build_exit_code != 0:
                 sys.exit(f"## {binary} build Failed !")

--- a/binaries/conda/build_packages.py
+++ b/binaries/conda/build_packages.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import subprocess
 from datetime import date
 
 from ts_scripts.utils import try_and_handle
@@ -11,7 +12,7 @@ MINICONDA_DOWNLOAD_URL = (
 )
 CONDA_BINARY = (
     os.popen("which conda").read().strip()
-    if os.system(f"conda --version") == 0
+    if subprocess.run(f"conda --version") == 0
     else f"$HOME/miniconda/condabin/conda"
 )
 
@@ -37,7 +38,7 @@ def install_conda_build(dry_run):
     """
 
     # Check if conda binary already exists
-    exit_code = os.system(f"conda --version")
+    exit_code = subprocess.run(f"conda --version")
     if exit_code == 0:
         print(
             f"'conda' already present on the system. Proceeding without a fresh conda installation."
@@ -54,7 +55,7 @@ def install_miniconda(dry_run):
     """
 
     # Check if conda binary already exists
-    exit_code = os.system(f"conda --version")
+    exit_code = subprocess.run(f"conda --version")
     if exit_code == 0:
         print(
             f"'conda' already present on the system. Proceeding without a fresh minconda installation."
@@ -133,7 +134,7 @@ def conda_build(
             cmd = f"{CONDA_BINARY} build --output-folder {output_dir} --python={pyv} {pkg}"
             print(f"## In directory: {os.getcwd()}; Executing command: {cmd}")
             if not dry_run:
-                os.system(cmd)
+                subprocess.run(cmd)
     return 0  # Used for sys.exit(0) --> to indicate successful system exit
 
 

--- a/binaries/install.py
+++ b/binaries/install.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 import glob
 
@@ -15,14 +16,14 @@ def install():
         channel_dir = os.path.abspath(os.path.join(REPO_ROOT, "binaries", "conda", "output"))
         conda_cmd = f"conda install --channel {channel_dir} -y torchserve torch-model-archiver"
         print(f"## In directory: {os.getcwd()} | Executing command: {conda_cmd}")
-        install_exit_code = os.system(conda_cmd)
+        install_exit_code = subprocess.run(conda_cmd)
     else:
         print("## Using pip to install torchserve and torch-model-archiver")
         ts_wheel = glob.glob(os.path.join(REPO_ROOT, "dist", "*.whl"))[0]
         ma_wheel = glob.glob(os.path.join(REPO_ROOT, "model-archiver", "dist", "*.whl"))[0]
         pip_cmd = f"pip install {ts_wheel} {ma_wheel}"
         print(f"## In directory: {os.getcwd()} | Executing command: {pip_cmd}")
-        install_exit_code = os.system(pip_cmd)
+        install_exit_code = subprocess.run(pip_cmd)
 
     if install_exit_code != 0:
         sys.exit("## Torchserve \ Model archiver Installation Failed !")

--- a/binaries/upload.py
+++ b/binaries/upload.py
@@ -2,6 +2,7 @@
 import argparse
 import glob
 import os
+import subprocess
 import sys
 
 # To help discover local modules
@@ -45,7 +46,7 @@ def upload_conda_packages(args, PACKAGES, CONDA_PACKAGES_PATH):
             ):
                 print(f"Uploading to anaconda package: {name}")
                 anaconda_upload_command = f"anaconda upload {file_path} --force"
-                exit_code = os.system(anaconda_upload_command)
+                exit_code = subprocess.run(anaconda_upload_command)
                 if exit_code != 0:
                     print(f"Anaconda package upload failed for package {name}")
                     return exit_code

--- a/examples/MMF-activity-recognition/Generting_Charades_action_lables.py
+++ b/examples/MMF-activity-recognition/Generting_Charades_action_lables.py
@@ -1,12 +1,11 @@
-import sys
-import os
+import subprocess
 import pandas as pd
 from pathlib import Path
 
-os.system('wget https://ai2-public-datasets.s3-us-west-2.amazonaws.com/charades/Charades_v1_480.zip')
-os.system('wget https://ai2-public-datasets.s3-us-west-2.amazonaws.com/charades/Charades.zip')
-os.system('unzip Charades_v1_480.zip')
-os.system('unzip Charades.zip')
+subprocess.run('wget https://ai2-public-datasets.s3-us-west-2.amazonaws.com/charades/Charades_v1_480.zip')
+subprocess.run('wget https://ai2-public-datasets.s3-us-west-2.amazonaws.com/charades/Charades.zip')
+subprocess.run('unzip Charades_v1_480.zip')
+subprocess.run('unzip Charades.zip')
 
 def make_charades_df(csv_path, video_dir, classes_file):
     # load the csv

--- a/examples/torchrec_dlrm/create_dlrm_mar.py
+++ b/examples/torchrec_dlrm/create_dlrm_mar.py
@@ -2,8 +2,7 @@
 This script creates a DLRM model and packs it into a TorchServe mar file
 """
 
-import os
-
+import subprocess
 import torch
 from dlrm_factory import DLRMFactory
 
@@ -32,7 +31,7 @@ def main():
     ]
 
     print("Archiving model into dlrm.mar")
-    os.system(" ".join(cmd))
+    subprocess.run(" ".join(cmd))
     print("Done")
 
 

--- a/test/pytest/test_handler.py
+++ b/test/pytest/test_handler.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import requests
 import json
 import logging
@@ -261,7 +262,7 @@ def test_MMF_activity_recognition_model_register_and_inference_on_valid_model():
 
     test_utils.start_torchserve(snapshot_file = snapshot_file_tf)
     test_utils.register_model('MMF_activity_recognition_v2', 'https://torchserve.pytorch.org/mar_files/MMF_activity_recognition_v2.mar')
-    os.system('wget https://mmfartifacts.s3-us-west-2.amazonaws.com/372CC.mp4 -P ../../examples/MMF-activity-recognition')
+    subprocess.run('wget https://mmfartifacts.s3-us-west-2.amazonaws.com/372CC.mp4 -P ../../examples/MMF-activity-recognition')
     input_json = "../../examples/MMF-activity-recognition/372CC.info.json"
     with open(input_json) as jsonfile:
         info = json.load(jsonfile)

--- a/ts_scripts/api_utils.py
+++ b/ts_scripts/api_utils.py
@@ -1,5 +1,6 @@
 import glob
 import os
+import subprocess
 import shutil
 import sys
 
@@ -109,7 +110,7 @@ def trigger_management_tests():
     ts.start_torchserve(ncs=True,
                         model_store=MODEL_STORE_DIR,
                         log_file=TS_CONSOLE_LOG_FILE)
-    EXIT_CODE = os.system(
+    EXIT_CODE = subprocess.run(
         f"newman run -e {POSTMAN_ENV_FILE} {POSTMAN_COLLECTION_MANAGEMENT} -d {POSTMAN_MANAGEMENT_DATA_FILE} -r cli,htmlextra --reporter-htmlextra-export {ARTIFACTS_MANAGEMENT_DIR}/{REPORT_FILE} --verbose"
     )
     ts.stop_torchserve()
@@ -123,7 +124,7 @@ def trigger_inference_tests():
     ts.start_torchserve(ncs=True,
                         model_store=MODEL_STORE_DIR,
                         log_file=TS_CONSOLE_LOG_FILE)
-    EXIT_CODE = os.system(
+    EXIT_CODE = subprocess.run(
         f"newman run -e {POSTMAN_ENV_FILE} {POSTMAN_COLLECTION_INFERENCE} -d {POSTMAN_INFERENCE_DATA_FILE} -r cli,htmlextra --reporter-htmlextra-export {ARTIFACTS_INFERENCE_DIR}/{REPORT_FILE} --verbose"
     )
     ts.stop_torchserve()
@@ -138,7 +139,7 @@ def trigger_workflow_tests():
                         model_store=MODEL_STORE_DIR,
                         workflow_store=MODEL_STORE_DIR,
                         log_file=TS_CONSOLE_LOG_FILE)
-    EXIT_CODE = os.system(
+    EXIT_CODE = subprocess.run(
         f"newman run -e {POSTMAN_ENV_FILE} {POSTMAN_COLLECTION_WORKFLOW} -d {POSTMAN_WORKFLOW_DATA_FILE} -r cli,htmlextra --reporter-htmlextra-export {ARTIFACTS_WORKFLOW_MANAGEMENT_DIR}/{REPORT_FILE} --verbose"
     )
     ts.stop_torchserve()
@@ -153,7 +154,7 @@ def trigger_workflow_inference_tests():
                         model_store=MODEL_STORE_DIR,
                         workflow_store=MODEL_STORE_DIR,
                         log_file=TS_CONSOLE_LOG_FILE)
-    EXIT_CODE = os.system(
+    EXIT_CODE = subprocess.run(
         f"newman run -e {POSTMAN_ENV_FILE} {POSTMAN_COLLECTION_WORKFLOW_INFERENCE} -d {POSTMAN_WORKFLOW_INFERENCE_DATA_FILE} -r cli,htmlextra --reporter-htmlextra-export {ARTIFACTS_WORKFLOW_INFERENCE_DIR}/{REPORT_FILE} --verbose"
     )
     ts.stop_torchserve()
@@ -168,7 +169,7 @@ def trigger_explanation_tests():
     ts.start_torchserve(ncs=True,
                         model_store=MODEL_STORE_DIR,
                         log_file=TS_CONSOLE_LOG_FILE)
-    EXIT_CODE = os.system(
+    EXIT_CODE = subprocess.run(
         f"newman run -e {POSTMAN_ENV_FILE} {POSTMAN_COLLECTION_EXPLANATION} -d {POSTMAN_EXPLANATION_DATA_FILE} -r cli,htmlextra --reporter-htmlextra-export {ARTIFACTS_INFERENCE_DIR}/{REPORT_FILE} --verbose"
     )
     ts.stop_torchserve()
@@ -189,7 +190,7 @@ def trigger_incr_timeout_inference_tests():
                         model_store=MODEL_STORE_DIR,
                         config_file="config.properties",
                         log_file=TS_CONSOLE_LOG_FILE)
-    EXIT_CODE = os.system(
+    EXIT_CODE = subprocess.run(
         f"newman run -e {POSTMAN_ENV_FILE} {POSTMAN_COLLECTION_INFERENCE} -d {POSTMAN_INCRSD_TIMEOUT_INFERENCE_DATA_FILE} -r cli,htmlextra --reporter-htmlextra-export {ARTIFACTS_INCRSD_TIMEOUT_INFERENCE_DIR}/{REPORT_FILE} --verbose"
     )
     ts.stop_torchserve()
@@ -206,7 +207,7 @@ def trigger_https_tests():
                         model_store=MODEL_STORE_DIR,
                         config_file=TS_CONFIG_FILE_HTTPS,
                         log_file=TS_CONSOLE_LOG_FILE)
-    EXIT_CODE = os.system(
+    EXIT_CODE = subprocess.run(
         f"newman run --insecure -e {POSTMAN_ENV_FILE} {POSTMAN_COLLECTION_HTTPS} -r cli,htmlextra --reporter-htmlextra-export {ARTIFACTS_HTTPS_DIR}/{REPORT_FILE} --verbose"
     )
     ts.stop_torchserve()
@@ -227,7 +228,7 @@ def trigger_management_tests_kf():
                         model_store=MODEL_STORE_DIR,
                         config_file="config.properties",
                         log_file=TS_CONSOLE_LOG_FILE)
-    EXIT_CODE = os.system(
+    EXIT_CODE = subprocess.run(
         f"newman run -e {POSTMAN_ENV_FILE} {POSTMAN_COLLECTION_MANAGEMENT} -d {POSTMAN_MANAGEMENT_DATA_FILE} -r cli,htmlextra --reporter-htmlextra-export {ARTIFACTS_MANAGEMENT_DIR_KF}/{REPORT_FILE} --verbose"
     )
     ts.stop_torchserve()
@@ -248,7 +249,7 @@ def trigger_inference_tests_kf():
                         model_store=MODEL_STORE_DIR,
                         config_file="config.properties",
                         log_file=TS_CONSOLE_LOG_FILE)
-    EXIT_CODE = os.system(
+    EXIT_CODE = subprocess.run(
         f"newman run -e {POSTMAN_ENV_FILE} {POSTMAN_COLLECTION_INFERENCE_KF} -d {POSTMAN_INFERENCE_DATA_FILE_KF} -r cli,htmlextra --reporter-htmlextra-export {ARTIFACTS_INFERENCE_DIR_KF}/{REPORT_FILE} --verbose"
     )
     ts.stop_torchserve()
@@ -264,7 +265,7 @@ def trigger_https_tests_kf():
                         model_store=MODEL_STORE_DIR,
                         config_file=TS_CONFIG_FILE_HTTPS_KF,
                         log_file=TS_CONSOLE_LOG_FILE)
-    EXIT_CODE = os.system(
+    EXIT_CODE = subprocess.run(
         f"newman run --insecure -e {POSTMAN_ENV_FILE} {POSTMAN_COLLECTION_HTTPS_KF} -r cli,htmlextra --reporter-htmlextra-export {ARTIFACTS_HTTPS_DIR_KF}/{REPORT_FILE} --verbose"
     )
     ts.stop_torchserve()
@@ -284,7 +285,7 @@ def trigger_inference_tests_kfv2():
                         model_store=MODEL_STORE_DIR,
                         config_file="config.properties",
                         log_file=TS_CONSOLE_LOG_FILE)
-    EXIT_CODE = os.system(
+    EXIT_CODE = subprocess.run(
         f"newman run -e {POSTMAN_ENV_FILE} {POSTMAN_COLLECTION_INFERENCE_KFV2} -d {POSTMAN_INFERENCE_DATA_FILE_KFV2} -r cli,htmlextra --reporter-htmlextra-export {ARTIFACTS_INFERENCE_DIR_KFV2}/{REPORT_FILE} --verbose"
     )
     ts.stop_torchserve()
@@ -300,7 +301,7 @@ def trigger_https_tests_kfv2():
                         model_store=MODEL_STORE_DIR,
                         config_file=TS_CONFIG_FILE_HTTPS_KFV2,
                         log_file=TS_CONSOLE_LOG_FILE)
-    EXIT_CODE = os.system(
+    EXIT_CODE = subprocess.run(
         f"newman run --insecure -e {POSTMAN_ENV_FILE} {POSTMAN_COLLECTION_HTTPS_KFV2} -r cli,htmlextra --reporter-htmlextra-export {ARTIFACTS_HTTPS_DIR_KFV2}/{REPORT_FILE} --verbose"
     )
     ts.stop_torchserve()

--- a/ts_scripts/backend_utils.py
+++ b/ts_scripts/backend_utils.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 
 
@@ -15,7 +16,7 @@ def test_torchserve():
 
     ts_test_cmd = f"python -m pytest --cov-report xml:{report_output_dir} --cov={coverage_dir} {test_dir}"
     print(f"## In directory: {os.getcwd()} | Executing command: {ts_test_cmd}")
-    ts_test_error_code = os.system(ts_test_cmd)
+    ts_test_error_code = subprocess.run(ts_test_cmd)
 
     if ts_test_error_code != 0:
         sys.exit("## TorchServe Pytests Failed !")

--- a/ts_scripts/frontend_utils.py
+++ b/ts_scripts/frontend_utils.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 
 
@@ -7,7 +8,7 @@ def test_frontend():
     frontend_gradlew_path = os.path.join("frontend", "gradlew")
     frontend_gradlew_cmd = f"{frontend_gradlew_path} -p frontend clean build"
     print(f"## In directory: {os.getcwd()} | Executing command: {frontend_gradlew_cmd}")
-    frontend_gradlew_exit_code = os.system(frontend_gradlew_cmd)
+    frontend_gradlew_exit_code = subprocess.run(frontend_gradlew_cmd)
 
     if frontend_gradlew_exit_code != 0:
         sys.exit("## Frontend Gradle Tests Failed !")

--- a/ts_scripts/install_dependencies.py
+++ b/ts_scripts/install_dependencies.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import subprocess
 import platform
 import sys
 
@@ -35,29 +36,29 @@ class Common:
                 )
                 sys.exit(1)
             else:
-                os.system(
+                subprocess.run(
                     f"{sys.executable} -m pip install -U -r requirements/torch_{cuda_version}_{platform.system().lower()}.txt"
                 )
         else:
-            os.system(
+            subprocess.run(
                 f"{sys.executable} -m pip install -U -r requirements/torch_{platform.system().lower()}.txt"
             )
 
     def install_python_packages(self, cuda_version, requirements_file_path):
         check = "where" if platform.system() == "Windows" else "which"
-        if os.system(f"{check} conda") == 0:
+        if subprocess.run(f"{check} conda") == 0:
             # conda install command should run before the pip install commands
             # as it may reinstall the packages with different versions
-            os.system("conda install -y conda-build")
+            subprocess.run("conda install -y conda-build")
 
         self.install_torch_packages(cuda_version)
-        os.system(f"{sys.executable} -m pip install -U pip setuptools")
+        subprocess.run(f"{sys.executable} -m pip install -U pip setuptools")
         # developer.txt also installs packages from common.txt
-        os.system(f"{sys.executable} -m pip install -U -r {requirements_file_path}")
+        subprocess.run(f"{sys.executable} -m pip install -U -r {requirements_file_path}")
         # If conda is available install conda-build package
 
     def install_node_packages(self):
-        os.system(
+        subprocess.run(
             f"{self.sudo_cmd}npm install -g newman newman-reporter-htmlextra markdown-link-check"
         )
 
@@ -75,30 +76,30 @@ class Linux(Common):
         self.sudo_cmd = "" if os.geteuid() == 0 else self.sudo_cmd
 
         if args.force:
-            os.system(f"{self.sudo_cmd}apt-get update")
+            subprocess.run(f"{self.sudo_cmd}apt-get update")
 
     def install_java(self):
-        if os.system("javac --version") != 0 or args.force:
-            os.system(f"{self.sudo_cmd}apt-get install -y openjdk-17-jdk")
+        if subprocess.run("javac --version") != 0 or args.force:
+            subprocess.run(f"{self.sudo_cmd}apt-get install -y openjdk-17-jdk")
 
     def install_nodejs(self):
-        if os.system("node -v") != 0 or args.force:
-            os.system(
+        if subprocess.run("node -v") != 0 or args.force:
+            subprocess.run(
                 f"{self.sudo_cmd}curl -sL https://deb.nodesource.com/setup_14.x | {self.sudo_cmd}bash -"
             )
-            os.system(f"{self.sudo_cmd}apt-get install -y nodejs")
+            subprocess.run(f"{self.sudo_cmd}apt-get install -y nodejs")
 
     def install_wget(self):
-        if os.system("wget --version") != 0 or args.force:
-            os.system(f"{self.sudo_cmd}apt-get install -y wget")
+        if subprocess.run("wget --version") != 0 or args.force:
+            subprocess.run(f"{self.sudo_cmd}apt-get install -y wget")
 
     def install_libgit2(self):
-        os.system(
+        subprocess.run(
             f"wget https://github.com/libgit2/libgit2/archive/refs/tags/v1.3.0.tar.gz -O libgit2-1.3.0.tar.gz"
         )
-        os.system(f"tar xzf libgit2-1.3.0.tar.gz")
-        os.system(f"cd libgit2-1.3.0 && cmake . && make && sudo make install && cd ..")
-        os.system(f"rm -rf libgit2-1.3.0 && rm libgit2-1.3.0.tar.gz")
+        subprocess.run(f"tar xzf libgit2-1.3.0.tar.gz")
+        subprocess.run(f"cd libgit2-1.3.0 && cmake . && make && sudo make install && cd ..")
+        subprocess.run(f"rm -rf libgit2-1.3.0 && rm libgit2-1.3.0.tar.gz")
 
 
 class Windows(Common):
@@ -121,23 +122,23 @@ class Darwin(Common):
         super().__init__()
 
     def install_java(self):
-        if os.system("javac -version") != 0 or args.force:
+        if subprocess.run("javac -version") != 0 or args.force:
             out = get_brew_version()
             if out == "N/A":
                 sys.exit("**Error: Homebrew not installed...")
-            os.system("brew install openjdk@17")
+            subprocess.run("brew install openjdk@17")
 
     def install_nodejs(self):
-        os.system("brew unlink node")
-        os.system("brew install node@14")
-        os.system("brew link --overwrite node@14")
+        subprocess.run("brew unlink node")
+        subprocess.run("brew install node@14")
+        subprocess.run("brew link --overwrite node@14")
 
     def install_node_packages(self):
-        os.system(f"{self.sudo_cmd} ./ts_scripts/mac_npm_deps")
+        subprocess.run(f"{self.sudo_cmd} ./ts_scripts/mac_npm_deps")
 
     def install_wget(self):
-        if os.system("wget --version") != 0 or args.force:
-            os.system("brew install wget")
+        if subprocess.run("wget --version") != 0 or args.force:
+            subprocess.run("brew install wget")
 
 
 def install_dependencies(cuda_version=None):

--- a/ts_scripts/install_from_src.py
+++ b/ts_scripts/install_from_src.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import subprocess
 import sys
 
 # To help discover local modules
@@ -18,7 +19,7 @@ def install_from_src(dev=False):
             else f"pip install --force-reinstall {binary}"
         )
         print(f"## In directory {os.getcwd()} | Executing command {cmd}")
-        os.system(cmd)
+        subprocess.run(cmd)
 
 
 if __name__ == "__main__":

--- a/ts_scripts/modelarchiver_utils.py
+++ b/ts_scripts/modelarchiver_utils.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 
 REPO_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..")
@@ -16,7 +17,7 @@ def test_modelarchiver():
 
     py_units_cmd = f"python -m pytest --cov-report xml:{report_output_dir} --cov={coverage_dir} {ut_dir}"
     print(f"## In directory: {os.getcwd()} | Executing command: {py_units_cmd}")
-    py_units_exit_code = os.system(py_units_cmd)
+    py_units_exit_code = subprocess.run(py_units_cmd)
 
     # Execute integration tests
     print("## Started model archiver pytests - integration tests")
@@ -25,7 +26,7 @@ def test_modelarchiver():
 
     py_integ_cmd = f"python -m pytest --cov-report xml:{report_output_dir} --cov={coverage_dir} {it_dir}"
     print(f"## In directory: {os.getcwd()} | Executing command: {py_integ_cmd}")
-    py_integ_exit_code = os.system(py_integ_cmd)
+    py_integ_exit_code = subprocess.run(py_integ_cmd)
 
     if py_units_exit_code != 0:
         sys.exit("## Model archiver Unit Pytests Failed !")

--- a/ts_scripts/regression_utils.py
+++ b/ts_scripts/regression_utils.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+import subprocess
 import sys
 import urllib.request
 from ts_scripts.shell_utils import rm_file
@@ -37,7 +38,7 @@ def generate_densenet_test_model_archive():
                 --handler {handler} \
                 --force"
     print(f"## In directory: {os.getcwd()} | Executing command: {cmd}")
-    sys_exit_code = os.system(cmd)
+    sys_exit_code = subprocess.run(cmd)
     os.remove(serialized_file_path)
     os.chdir(REPO_ROOT)
     return sys_exit_code
@@ -49,13 +50,13 @@ def run_pytest():
     cmd = "python -m grpc_tools.protoc --proto_path=../../frontend/server/src/main/resources/proto/" \
           " --python_out=. --grpc_python_out=. ../../frontend/server/src/main/resources/proto/inference.proto" \
           " ../../frontend/server/src/main/resources/proto/management.proto"
-    status = os.system(cmd)
+    status = subprocess.run(cmd)
     if status != 0:
         print("Could not generate gRPC client stubs")
         sys.exit(1)
     cmd = "python -m pytest -v ./"
     print(f"## In directory: {os.getcwd()} | Executing command: {cmd}")
-    status = os.system(cmd)
+    status = subprocess.run(cmd)
     rm_file('*_pb2*.py', True)
     return status
 

--- a/ts_scripts/sanity_utils.py
+++ b/ts_scripts/sanity_utils.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 import nvgpu
 import glob
@@ -19,7 +20,7 @@ def run_markdown_link_checker():
     for mdfile in glob.glob("**/*.md", recursive=True):
         cmd = f"markdown-link-check {mdfile} --config link_check_config.json"
         print(f"## In directory: {os.getcwd()} | Executing command: {cmd}")
-        status = os.system(cmd)
+        status = subprocess.run(cmd)
         if status != 0:
             print(f"## Broken links in file: {mdfile}")
             result = False
@@ -106,7 +107,7 @@ def test_sanity():
         mar_set_list_str = [str(s) for s in mg.mar_set]
         mar_set_str = ",".join(mar_set_list_str)
         register_model_grpc_cmd = f"python ts_scripts/torchserve_grpc_client.py register {model_name} {mar_set_str}"
-        status = os.system(register_model_grpc_cmd)
+        status = subprocess.run(register_model_grpc_cmd)
 
         if status != 0:
             print("## Failed to register model with torchserve")
@@ -116,7 +117,7 @@ def test_sanity():
 
         for input in model_inputs:
             infer_model_grpc_cmd = f"python ts_scripts/torchserve_grpc_client.py infer {model_name} {input}"
-            status = os.system(infer_model_grpc_cmd)
+            status = subprocess.run(infer_model_grpc_cmd)
             if status != 0:
                 print(f"## Failed to run inference on {model_name} model")
                 sys.exit(1)
@@ -124,7 +125,7 @@ def test_sanity():
                 print(f"## Successfully ran inference on {model_name} model.")
 
         unregister_model_grpc_cmd = f"python ts_scripts/torchserve_grpc_client.py unregister {model_name}"
-        status = os.system(unregister_model_grpc_cmd)
+        status = subprocess.run(unregister_model_grpc_cmd)
 
         if status != 0:
             print(f"## Failed to unregister {model_name}")

--- a/ts_scripts/tsutils.py
+++ b/ts_scripts/tsutils.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import platform
 import sys
 import time
@@ -43,7 +44,7 @@ def start_torchserve(
         print(f"## Console logs redirected to file: {log_file}")
         cmd += f" >> {log_file}"
     print(f"## In directory: {os.getcwd()} | Executing command: {cmd}")
-    status = os.system(cmd)
+    status = subprocess.run(cmd)
     if status == 0:
         print("## Successfully started TorchServe")
         time.sleep(wait_for)
@@ -57,7 +58,7 @@ def stop_torchserve(wait_for=10):
     print("## Stopping TorchServe")
     cmd = f"{torchserve_command[platform.system()]} --stop"
     print(f"## In directory: {os.getcwd()} | Executing command: {cmd}")
-    status = os.system(cmd)
+    status = subprocess.run(cmd)
     if status == 0:
         print("## Successfully stopped TorchServe")
         time.sleep(wait_for)
@@ -106,7 +107,7 @@ def generate_grpc_client_stubs():
     cmd = "python -m grpc_tools.protoc --proto_path=frontend/server/src/main/resources/proto/ --python_out=ts_scripts " \
           "--grpc_python_out=ts_scripts frontend/server/src/main/resources/proto/inference.proto " \
           "frontend/server/src/main/resources/proto/management.proto"
-    status = os.system(cmd)
+    status = subprocess.run(cmd)
     if status != 0:
         print("Could not generate gRPC client stubs")
         sys.exit(1)

--- a/ts_scripts/utils.py
+++ b/ts_scripts/utils.py
@@ -14,15 +14,15 @@ nvidia_smi_cmd = {
 
 
 def is_gpu_instance():
-    return True if os.system(nvidia_smi_cmd[platform.system()]) == 0 else False
+    return True if subprocess.run(nvidia_smi_cmd[platform.system()]) == 0 else False
 
 
 def is_conda_build_env():
-    return True if os.system("conda-build") == 0 else False
+    return True if subprocess.run("conda-build") == 0 else False
 
 
 def is_conda_env():
-    return True if os.system("conda") == 0 else False
+    return True if subprocess.run("conda") == 0 else False
 
 
 def check_python_version():

--- a/ts_scripts/workflow_archiver_utils.py
+++ b/ts_scripts/workflow_archiver_utils.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 
 REPO_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..")
@@ -15,7 +16,7 @@ def test_workflow_archiver():
     report_output_dir = os.path.join(ut_dir, "coverage.xml")
     py_units_cmd = f"python -m pytest --cov-report xml:{report_output_dir} --cov={coverage_dir} {ut_dir}"
     print(f"## In directory: {os.getcwd()} | Executing command: {py_units_cmd}")
-    py_units_exit_code = os.system(py_units_cmd)
+    py_units_exit_code = subprocess.run(py_units_cmd)
 
     # Execute integration tests
     print("## Started workflow archiver pytests - integration tests")
@@ -23,7 +24,7 @@ def test_workflow_archiver():
     report_output_dir = os.path.join(it_dir, "coverage.xml")
     py_integ_cmd = f"python -m pytest --cov-report xml:{report_output_dir} --cov={coverage_dir} {it_dir}"
     print(f"## In directory: {os.getcwd()} | Executing command: {py_integ_cmd}")
-    py_integ_exit_code = os.system(py_integ_cmd)
+    py_integ_exit_code = subprocess.run(py_integ_cmd)
 
     if py_units_exit_code != 0:
         sys.exit("## Workflow archiver Unit Pytests Failed !")


### PR DESCRIPTION
## Description
os.system() while popular is a problem call in python because it doesn't throw an error upon failing. This is why it's mostly recommended to use subprocess.run() as an alternative. 
This PR changes os.system to subprocess.run across the repo

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [X] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?