### PR TITLE
Make cpp backend compile under ubuntun 22.04 with gcc-9

### DIFF
--- a/cpp/src/backends/process/model_worker.cc
+++ b/cpp/src/backends/process/model_worker.cc
@@ -1,6 +1,13 @@
 #include "src/backends/process/model_worker.hh"
 
+namespace fs = std::filesystem;
+#if __cpp_lib_filesystem >= 201703
+namespace fs = std::filesystem;
+#elif __cpp_lib_experimental_filesystem >= 201406
 namespace fs = std::experimental::filesystem;
+#else
+#error require filesystem
+#endif
 
 namespace torchserve {
   void SocketServer::Initialize(

--- a/cpp/src/backends/process/model_worker.hh
+++ b/cpp/src/backends/process/model_worker.hh
@@ -3,7 +3,15 @@
 
 #include <arpa/inet.h>
 #include <cstdio>
+
+#if __has_include(<filesystem>)
+#include <filesystem>
+#elif __has_include(<experimental/filesystem>)
 #include <experimental/filesystem>
+#else
+#error require filesystem
+#endif
+
 #include <netinet/in.h>
 #include <string>
 #include <sys/socket.h>

--- a/cpp/test/utils/logging_test.cc
+++ b/cpp/test/utils/logging_test.cc
@@ -1,11 +1,26 @@
 #include <gtest/gtest.h>
+
+#if __has_include(<filesystem>)
+#include <filesystem>
+#elif __has_include(<experimental/filesystem>)
 #include <experimental/filesystem>
+#else
+#error require filesystem
+#endif
+
 #include <fmt/format.h>
 #include <fstream>
 
 #include "src/utils/logging.hh"
 
+namespace fs = std::filesystem;
+#if __cpp_lib_filesystem >= 201703
+namespace fs = std::filesystem;
+#elif __cpp_lib_experimental_filesystem >= 201406
 namespace fs = std::experimental::filesystem;
+#else
+#error require filesystem
+#endif
 
 namespace torchserve {
   void Cleanup(const std::string& logfile_path) {


### PR DESCRIPTION
## Description

This fixes compiling issue for distributions where std::filesystem was moved out of experimental. 

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Tests:
Run ./build.sh under Ubuntu 22.04 with gcc-9 installed
Output unit test:
```
torchserve_cpp build is complete. To run unit test:   ./_build/test/torchserve_cpp_test
Running main() from /home/ubuntu/serve/cpp/_build/_deps/googletest-src/googletest/src/gtest_main.cc
[==========] Running 20 tests from 6 test suites.
[----------] Global test environment set-up.
[----------] 1 test from BackendIntegTest
[ RUN      ] BackendIntegTest.TestOTFProtocolAndHandler
E1010 19:51:31.264867 148630 otf_message.cc:84] Invalid request_id received. Aborting inference request
[       OK ] BackendIntegTest.TestOTFProtocolAndHandler (99 ms)
[----------] 1 test from BackendIntegTest (99 ms total)

[----------] 8 tests from OTFMessageTest
[ RUN      ] OTFMessageTest.TestRetieveCmd
[       OK ] OTFMessageTest.TestRetieveCmd (0 ms)
[ RUN      ] OTFMessageTest.TestEncodeLoadModelResponse
[       OK ] OTFMessageTest.TestEncodeLoadModelResponse (0 ms)
[ RUN      ] OTFMessageTest.TestUTF8EncodeLoadModelResponse
[       OK ] OTFMessageTest.TestUTF8EncodeLoadModelResponse (0 ms)
[ RUN      ] OTFMessageTest.TestRetrieveMsgLoadGpu
[       OK ] OTFMessageTest.TestRetrieveMsgLoadGpu (0 ms)
[ RUN      ] OTFMessageTest.TestRetrieveMsgLoadNoGpu
[       OK ] OTFMessageTest.TestRetrieveMsgLoadNoGpu (0 ms)
[ RUN      ] OTFMessageTest.TestEncodeSuccessInferenceResponse
[       OK ] OTFMessageTest.TestEncodeSuccessInferenceResponse (0 ms)
[ RUN      ] OTFMessageTest.TestEncodeFailureInferenceResponse
E1010 19:51:31.338406 148630 otf_message_test.cc:151] result_size: 120
[       OK ] OTFMessageTest.TestEncodeFailureInferenceResponse (0 ms)
[ RUN      ] OTFMessageTest.TestRetrieveInferenceMsg
E1010 19:51:31.338544 148630 otf_message.cc:84] Invalid request_id received. Aborting inference request
[       OK ] OTFMessageTest.TestRetrieveInferenceMsg (0 ms)
[----------] 8 tests from OTFMessageTest (0 ms total)

[----------] 6 tests from TorchScriptedBackendTest
[ RUN      ] TorchScriptedBackendTest.TestLoadPredictBaseHandler
[       OK ] TorchScriptedBackendTest.TestLoadPredictBaseHandler (17 ms)
[ RUN      ] TorchScriptedBackendTest.TestLoadPredictMnistHandler
[       OK ] TorchScriptedBackendTest.TestLoadPredictMnistHandler (16 ms)
[ RUN      ] TorchScriptedBackendTest.TestBackendInitWrongModelDir
E1010 19:51:31.372742 148630 model_archive.cc:45] Failed to init Manifest from: test/resources/torchscript_model/mnist/MAR-INF/MANIFEST.json
[       OK ] TorchScriptedBackendTest.TestBackendInitWrongModelDir (0 ms)
[ RUN      ] TorchScriptedBackendTest.TestBackendInitWrongHandler
[       OK ] TorchScriptedBackendTest.TestBackendInitWrongHandler (1 ms)
[ RUN      ] TorchScriptedBackendTest.TestLoadModelFailure
E1010 19:51:31.377674 148630 base_handler.cc:18] loading the model: mnist_scripted_v2, device id: -1, error: Unrecognized data format
[       OK ] TorchScriptedBackendTest.TestLoadModelFailure (3 ms)
[ RUN      ] TorchScriptedBackendTest.TestLoadPredictMnistHandlerFailure
E1010 19:51:31.392688 148630 base_handler.cc:119] Failed to load tensor for request id: mnist_ts_0, c10 error: PytorchStreamReader failed reading zip archive: failed finding central directory
E1010 19:51:31.397619 148630 base_handler.cc:119] Failed to load tensor for request id: mnist_ts_1, c10 error: PytorchStreamReader failed reading zip archive: failed finding central directory
E1010 19:51:31.400008 148630 base_handler.hh:77] Failed to handle this batch
[       OK ] TorchScriptedBackendTest.TestLoadPredictMnistHandlerFailure (22 ms)
[----------] 6 tests from TorchScriptedBackendTest (61 ms total)

[----------] 1 test from DLLoaderTest
[ RUN      ] DLLoaderTest.TestGetInstance
[       OK ] DLLoaderTest.TestGetInstance (0 ms)
[----------] 1 test from DLLoaderTest (0 ms total)

[----------] 3 tests from LoggingTest
[ RUN      ] LoggingTest.TestIncorrectLogInitialization
[       OK ] LoggingTest.TestIncorrectLogInitialization (0 ms)
[ RUN      ] LoggingTest.TestJSONConfigLogInitialization
[       OK ] LoggingTest.TestJSONConfigLogInitialization (0 ms)
[ RUN      ] LoggingTest.TestFileLogInitialization
[       OK ] LoggingTest.TestFileLogInitialization (0 ms)
[----------] 3 tests from LoggingTest (1 ms total)

[----------] 1 test from ManifestTest
[ RUN      ] ManifestTest.TestInitialize
[       OK ] ManifestTest.TestInitialize (0 ms)
[----------] 1 test from ManifestTest (1 ms total)

[----------] Global test environment tear-down
[==========] 20 tests from 6 test suites ran. (164 ms total)
[  PASSED  ] 20 tests.
```

## Checklist:

- [X] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?