### PR TITLE
Skip spellcheck if no changed files

### DIFF
--- a/ts_scripts/spellcheck.sh
+++ b/ts_scripts/spellcheck.sh
@@ -9,7 +9,12 @@ else
 fi
 
 sources_arg=""
-for src in $sources ;do
-        sources_arg+=" -S $src"
+for src in $sources; do
+        sources_arg="${sources_arg} -S $src"
 done
-pyspelling -c ts_scripts/spellcheck_conf/spellcheck.yaml --name Markdown $sources_arg
+
+if [ ! "$sources_arg" ]; then
+	echo "No files to spellcheck"
+else
+	pyspelling -c ts_scripts/spellcheck_conf/spellcheck.yaml --name Markdown $sources_arg
+fi


### PR DESCRIPTION
## Description

Skips spellcheck in CI if no changed files found

Please read our [CONTRIBUTING.md](https://github.com/pytorch/serve/blob/master/CONTRIBUTING.md) prior to creating your first pull request.

Please include a summary of the feature or issue being fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #1918

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

```
./ts_scripts/spellcheck.sh " "
++ sudo apt-get install aspell
Reading package lists... Done
Building dependency tree
Reading state information... Done
aspell is already the newest version (0.60.7~20110707-4ubuntu0.2).
The following packages were automatically installed and are no longer required:
  linux-aws-5.4-headers-5.4.0-1075 linux-aws-5.4-headers-5.4.0-1078 linux-aws-5.4-headers-5.4.0-1080 linux-aws-5.4-headers-5.4.0-1081 linux-aws-5.4-headers-5.4.0-1084 linux-aws-5.4-headers-5.4.0-1085 linux-headers-5.4.0-1085-aws
  linux-image-5.4.0-1085-aws linux-modules-5.4.0-1085-aws
Use 'sudo apt autoremove' to remove them.
0 upgraded, 0 newly installed, 0 to remove and 49 not upgraded.
++ [[ -z   ]]
++ sources=' '
++ sources_arg=
++ '[' '!' '' ']'
++ echo 'No files to spellcheck'
No files to spellcheck



./ts_scripts/spellcheck.sh CONTRIBUTING.md README.md
++ sudo apt-get install aspell
Reading package lists... Done
Building dependency tree
Reading state information... Done
aspell is already the newest version (0.60.7~20110707-4ubuntu0.2).
The following packages were automatically installed and are no longer required:
  linux-aws-5.4-headers-5.4.0-1075 linux-aws-5.4-headers-5.4.0-1078 linux-aws-5.4-headers-5.4.0-1080 linux-aws-5.4-headers-5.4.0-1081 linux-aws-5.4-headers-5.4.0-1084 linux-aws-5.4-headers-5.4.0-1085 linux-headers-5.4.0-1085-aws
  linux-image-5.4.0-1085-aws linux-modules-5.4.0-1085-aws
Use 'sudo apt autoremove' to remove them.
0 upgraded, 0 newly installed, 0 to remove and 49 not upgraded.
++ [[ -z CONTRIBUTING.md README.md ]]
++ sources='CONTRIBUTING.md README.md'
++ sources_arg=
++ for src in $sources
++ sources_arg=' -S CONTRIBUTING.md'
++ for src in $sources
++ sources_arg=' -S CONTRIBUTING.md -S README.md'
++ '[' '!' ' -S CONTRIBUTING.md -S README.md' ']'
++ pyspelling -c ts_scripts/spellcheck_conf/spellcheck.yaml --name Markdown -S CONTRIBUTING.md -S README.md
Spelling check passed :)
```


## Checklist:

- [X] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?