### PR TITLE
For CUDA 11.1,  only 11.1.1 Nvidia Docker images are available.

### DIFF
--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -58,7 +58,7 @@ do
           shift
           ;;
         -lf|--use-local-serve-folder)
-          USE_LOCAL_SERVE_FOLDER=true        
+          USE_LOCAL_SERVE_FOLDER=true
           shift
           ;;
         -ipex|--build-with-ipex)
@@ -76,7 +76,7 @@ do
             BASE_IMAGE="nvidia/cuda:11.3.0-cudnn8-runtime-ubuntu18.04"
           elif [ $CUDA_VERSION == "cu111" ];
           then
-            BASE_IMAGE="nvidia/cuda:11.1-cudnn8-runtime-ubuntu18.04"
+            BASE_IMAGE="nvidia/cuda:11.1.1-cudnn8-runtime-ubuntu18.04"
           elif [ $CUDA_VERSION == "cu102" ];
           then
             BASE_IMAGE="nvidia/cuda:10.2-cudnn8-runtime-ubuntu18.04"
@@ -97,14 +97,14 @@ do
         -ub|--ubuntu)
           UBUNTU_VERSION="$2"
           if [[ $CUDA_VERSION == "cu116"  &&  $UBUNTU_VERSION == "ubuntu20.04" ]];
-          then 
+          then
             BASE_IMAGE="nvidia/cuda:11.6.0-cudnn8-runtime-ubuntu20.04"
           elif [[ $CUDA_VERSION == "cu113" && $UBUNTU_VERSION == "ubuntu20.04" ]];
-          then 
+          then
             BASE_IMAGE="nvidia/cuda:11.3.0-cudnn8-runtime-ubuntu20.04"
           elif [[ $CUDA_VERSION == "cu111" && $UBUNTU_VERSION == "ubuntu20.04" ]];
-          then 
-            BASE_IMAGE="nvidia/cuda:11.1.0-cudnn8-runtime-ubuntu20.04"
+          then
+            BASE_IMAGE="nvidia/cuda:11.1.1-cudnn8-runtime-ubuntu20.04"
           elif [[ $UBUNTU_VERSION == "ubuntu20.04" ]];
           then
             echo "Using CPU image"
@@ -113,7 +113,7 @@ do
             echo "Ubuntu and CUDA version combination is not supported"
             echo $UBUNTU_VERSION
             echo $CUDA_VERSION
-            exit 1 
+            exit 1
           fi
           shift
           ;;


### PR DESCRIPTION
## Description

For CUDA 11.1,  only 11.1.1 Nvidia Docker images are available. Updated the script accordingly

Fixes #([1929](https://github.com/pytorch/serve/issues/1929))

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [Logs](https://github.com/pytorch/serve/files/9889911/serve_issues1929_logs.txt)



## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?