### PR TITLE
Update ubuntu docker version

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-20.04, macOS-latest, windows-latest]
     steps:
       - name: Setup Python 3.8
         uses: actions/setup-python@v2
@@ -49,7 +49,7 @@ jobs:
       # Any coverage.xml will be picked up by this step
       # Just make sure each coverage.xml is in a different folder
       - name: Upload codecov
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-20.04'
         run : |
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           chmod +x codecov

--- a/.github/workflows/doc-automation.yml
+++ b/.github/workflows/doc-automation.yml
@@ -4,7 +4,7 @@ on:
       - master
 jobs:
   build_docs_job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Setup Python 3.8
       uses: actions/setup-python@v2

--- a/.github/workflows/docker-nightly-build.yml
+++ b/.github/workflows/docker-nightly-build.yml
@@ -6,7 +6,7 @@ on:
     - cron:  '15 11 * * *'
 jobs:
   nightly:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Setup Python 3.8
         uses: actions/setup-python@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Lint changed files
     steps:
       - uses: actions/checkout@v3
@@ -50,7 +50,7 @@ jobs:
           echo "pre-commit install"
           echo "pre-commit will lint your code for you, so git add and commit those new changes and this check should become green"
   spellcheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/official_release.yml
+++ b/.github/workflows/official_release.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-20.04, macOS-latest, windows-latest]
     steps:
       - name: Setup Conda
         uses: s-weigand/setup-conda@v1
@@ -41,21 +41,21 @@ jobs:
       - name: Push PyPI binaries
         env:
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-20.04'
         run: python binaries/upload.py --upload-pypi-packages
       - name: Login to Docker
         env:
           DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-20.04'
         run: docker login --username pytorchbot --password "$DOCKER_PASSWORD"
       - name: Build & Upload pytorch/torchserve Docker images
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-20.04'
         run: |
           cd docker
           python build_upload_release.py
           cd ..
       - name: Build & Upload pytorch/torchserve-kfs Docker images
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-20.04'
         run: |
           cd kubernetes/kserve
           python build_upload_release.py

--- a/.github/workflows/torchserve-nightly-build.yml
+++ b/.github/workflows/torchserve-nightly-build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-20.04, macOS-latest, windows-latest]
     steps:
       - name: Setup Conda
         uses: s-weigand/setup-conda@v1
@@ -38,7 +38,7 @@ jobs:
         env:
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         # skip pushing PyPI nightly binaries for macOS & windows as the binaries have the same name
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-20.04'
         run: python binaries/upload.py --upload-pypi-packages
       - name: Open issue on failure
         if: ${{ failure() && github.event_name  == 'schedule' }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,10 +16,10 @@
 #           https://docs.docker.com/develop/develop-images/build_enhancements/
 
 
-ARG BASE_IMAGE=ubuntu:18.04
+ARG BASE_IMAGE=ubuntu:20.04
 
 FROM ${BASE_IMAGE} AS compile-image
-ARG BASE_IMAGE=ubuntu:18.04
+ARG BASE_IMAGE=ubuntu:20.04
 ENV PYTHONUNBUFFERED TRUE
 
 RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt \

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -10,7 +10,7 @@
 #       For reference: 
 #           https://docs.docker.com/develop/develop-images/build_enhancements/
 
-ARG BASE_IMAGE=ubuntu:18.04
+ARG BASE_IMAGE=ubuntu:20.04
 ARG BUILD_TYPE=dev
 FROM ${BASE_IMAGE} AS compile-image
 

--- a/docker/Dockerfile.neuron.dev
+++ b/docker/Dockerfile.neuron.dev
@@ -15,7 +15,7 @@
 #       For reference:
 #           https://docs.docker.com/develop/develop-images/build_enhancements/
 
-ARG BASE_IMAGE=ubuntu:18.04
+ARG BASE_IMAGE=ubuntu:20.04
 ARG BUILD_TYPE=dev
 FROM ${BASE_IMAGE} AS compile-image
 

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -5,10 +5,10 @@ BRANCH_NAME="master"
 DOCKER_TAG="pytorch/torchserve:latest-cpu"
 BUILD_TYPE="production"
 DOCKER_FILE="Dockerfile"
-BASE_IMAGE="ubuntu:18.04"
+BASE_IMAGE="ubuntu:20.04"
 CUSTOM_TAG=false
 CUDA_VERSION=""
-UBUNTU_VERSION="ubuntu:18.04"
+UBUNTU_VERSION="ubuntu:20.04"
 USE_LOCAL_SERVE_FOLDER=false
 BUILD_WITH_IPEX=false
 
@@ -22,7 +22,7 @@ do
           echo "-g, --gpu specify to use gpu"
           echo "-bt, --buildtype specify to created image for codebuild. Possible values: production, dev, codebuild."
           echo "-cv, --cudaversion specify to cuda version to use"
-          echo "-ub, --ubuntu specify ubuntu version. Possible values: ubuntu:18.04, ubuntu 20.04"
+          echo "-ub, --ubuntu specify ubuntu version. Possible values: ubuntu:20.04, ubuntu 22.04"
           echo "-t, --tag specify tag name for docker image"
           echo "-lf, --use-local-serve-folder specify this option for the benchmark image if the current 'serve' folder should be used during automated benchmarks"
           echo "-ipex, --build-with-ipex specify to build with intel_extension_for_pytorch"

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -22,7 +22,7 @@ do
           echo "-g, --gpu specify to use gpu"
           echo "-bt, --buildtype specify to created image for codebuild. Possible values: production, dev, codebuild."
           echo "-cv, --cudaversion specify to cuda version to use"
-          echo "-ub, --ubuntu specify ubuntu version. Possible values: ubuntu:20.04, ubuntu 22.04"
+          echo "-ub, --ubuntu specify ubuntu version. Possible values: ubuntu:20.04"
           echo "-t, --tag specify tag name for docker image"
           echo "-lf, --use-local-serve-folder specify this option for the benchmark image if the current 'serve' folder should be used during automated benchmarks"
           echo "-ipex, --build-with-ipex specify to build with intel_extension_for_pytorch"

--- a/kubernetes/kserve/Dockerfile.dev
+++ b/kubernetes/kserve/Dockerfile.dev
@@ -10,7 +10,7 @@
 #       For reference:
 #           https://docs.docker.com/develop/develop-images/build_enhancements
 
-ARG BASE_IMAGE=ubuntu:18.04
+ARG BASE_IMAGE=ubuntu:20.04
 ARG BUILD_TYPE=dev
 FROM ${BASE_IMAGE} AS compile-image
 


### PR DESCRIPTION
## Description

Update default from Ubuntu 18.04 to Ubuntu 20.04 (LTS).

Fixes #1889 

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)


## Feature/Issue validation/testing

I need advice on how to test the different updates.

## Checklist

- [x] Should `20.04` be used [here](https://github.com/pytorch/serve/blob/master/.github/workflows/ci_cpu.yml#L21) instead of `latest` tag?
- [x] Should `20.04` be used [here](https://github.com/pytorch/serve/blob/master/.github/workflows/doc-automation.yml#L7) instead of `latest` tag? 
- [x] Should `20.04` be used [here](https://github.com/pytorch/serve/blob/master/.github/workflows/lint.yml#L13) instead of `latest` tag? 
- [x] Should `20.04` be used [here](https://github.com/pytorch/serve/blob/master/.github/workflows/official_release.yml#L16) instead of `latest` tag? 
- [x] Should `20.04` be used [here](https://github.com/pytorch/serve/blob/master/.github/workflows/torchserve-nightly-build.yml#L14) instead of `latest` tag? 
- [x] ~~[This](https://github.com/pytorch/serve/blob/master/docs/torchserve_on_wsl.md) guide refers to `18.04` version, should it be updated?~~
- [x] ~~[This](https://github.com/pytorch/serve/tree/master/examples/cloudformation) example uses `18.04` version~~
- [x] ~~In the [K8S](https://github.com/pytorch/serve/tree/master/kubernetes) folder there are some reference to `18.04` version~~

Edit after comments:
- [x] Update [script](https://github.com/pytorch/serve/blob/master/docker/build_image.sh#L97) where we should make 22.04 optional if people pass it in as an arg since 20.04 is now the default
- [x] Build the images and them by running an example inference, attach the log in the PR


