### PR TITLE
Add argparse for grpc script

### DIFF
--- a/docs/grpc_api.md
+++ b/docs/grpc_api.md
@@ -28,7 +28,7 @@ Run following commands to Register, run inference and unregister, densenet161 mo
  - [Install TorchServe](../README.md)
 
  - Clone serve repo to run this example
- 
+
 ```bash
 git clone https://github.com/pytorch/serve
 cd serve
@@ -43,24 +43,24 @@ pip install -U grpcio protobuf grpcio-tools
  - Start torchServe
 
 ```bash
-mkdir model_store
-torchserve --start 
+mkdir models
+torchserve --start --model-store models/
 ```
 
  - Generate python gRPC client stub using the proto files
- 
+
 ```bash
 python -m grpc_tools.protoc --proto_path=frontend/server/src/main/resources/proto/ --python_out=ts_scripts --grpc_python_out=ts_scripts frontend/server/src/main/resources/proto/inference.proto frontend/server/src/main/resources/proto/management.proto
 ```
 
  - Register densenet161 model
- 
+
 ```bash
 python ts_scripts/torchserve_grpc_client.py register densenet161
 ```
 
- - Run inference using 
- 
+ - Run inference using
+
 ```bash
 python ts_scripts/torchserve_grpc_client.py infer densenet161 examples/image_classifier/kitten.jpg
 ```

--- a/ts_scripts/torchserve_grpc_client.py
+++ b/ts_scripts/torchserve_grpc_client.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
     )
 
     parser = argparse.ArgumentParser(
-        description="Torch Serve gRPC client",
+        description="TorchServe gRPC client",
         formatter_class=argparse.RawTextHelpFormatter,
     )
     subparsers = parser.add_subparsers(help="Action", dest="action")

--- a/ts_scripts/torchserve_grpc_client.py
+++ b/ts_scripts/torchserve_grpc_client.py
@@ -1,34 +1,35 @@
+import argparse
+
 import grpc
 import inference_pb2
 import inference_pb2_grpc
 import management_pb2
 import management_pb2_grpc
-import sys
 
 
 def get_inference_stub():
-    channel = grpc.insecure_channel('localhost:7070')
+    channel = grpc.insecure_channel("localhost:7070")
     stub = inference_pb2_grpc.InferenceAPIsServiceStub(channel)
     return stub
 
 
 def get_management_stub():
-    channel = grpc.insecure_channel('localhost:7071')
+    channel = grpc.insecure_channel("localhost:7071")
     stub = management_pb2_grpc.ManagementAPIsServiceStub(channel)
     return stub
 
 
 def infer(stub, model_name, model_input):
-    with open(model_input, 'rb') as f:
+    with open(model_input, "rb") as f:
         data = f.read()
 
-    input_data = {'data': data}
+    input_data = {"data": data}
     response = stub.Predictions(
-        inference_pb2.PredictionsRequest(model_name=model_name,
-                                         input=input_data))
+        inference_pb2.PredictionsRequest(model_name=model_name, input=input_data)
+    )
 
     try:
-        prediction = response.prediction.decode('utf-8')
+        prediction = response.prediction.decode("utf-8")
         print(prediction)
     except grpc.RpcError as e:
         exit(1)
@@ -37,23 +38,23 @@ def infer(stub, model_name, model_input):
 def register(stub, model_name, mar_set_str):
     mar_set = set()
     if mar_set_str:
-        mar_set = set(mar_set_str.split(','))
+        mar_set = set(mar_set_str.split(","))
     marfile = f"{model_name}.mar"
     print(f"## Check {marfile} in mar_set :", mar_set)
     if marfile not in mar_set:
         marfile = "https://torchserve.s3.amazonaws.com/mar_files/{}.mar".format(
-            model_name)
+            model_name
+        )
 
-    print(f"## Register marfile:{marfile}\n")
+    print(f"## Register marfile: {marfile}\n")
     params = {
-        'url': marfile,
-        'initial_workers': 1,
-        'synchronous': True,
-        'model_name': model_name
+        "url": marfile,
+        "initial_workers": 1,
+        "synchronous": True,
+        "model_name": model_name,
     }
     try:
-        response = stub.RegisterModel(
-            management_pb2.RegisterModelRequest(**params))
+        response = stub.RegisterModel(management_pb2.RegisterModelRequest(**params))
         print(f"Model {model_name} registered successfully")
     except grpc.RpcError as e:
         print(f"Failed to register model {model_name}.")
@@ -64,7 +65,8 @@ def register(stub, model_name, mar_set_str):
 def unregister(stub, model_name):
     try:
         response = stub.UnregisterModel(
-            management_pb2.UnregisterModelRequest(model_name=model_name))
+            management_pb2.UnregisterModelRequest(model_name=model_name)
+        )
         print(f"Model {model_name} unregistered successfully")
     except grpc.RpcError as e:
         print(f"Failed to unregister model {model_name}.")
@@ -72,17 +74,47 @@ def unregister(stub, model_name):
         exit(1)
 
 
-if __name__ == '__main__':
-    # args:
-    # 1-> api name [infer, register, unregister]
-    # 2-> model name
-    # 3-> model input for prediction
-    args = sys.argv[1:]
-    if args[0] == "infer":
-        infer(get_inference_stub(), args[1], args[2])
-    else:
-        api = globals()[args[0]]
-        if args[0] == "register":
-            api(get_management_stub(), args[1], args[2])
-        else:
-            api(get_management_stub(), args[1])
+if __name__ == "__main__":
+
+    parent_parser = argparse.ArgumentParser(add_help=False)
+    parent_parser.add_argument(
+        "model_name",
+        type=str,
+        default=None,
+        help="Name of the model used.",
+    )
+
+    parser = argparse.ArgumentParser(
+        description="Torch Serve gRPC client",
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(help="Action", dest="action")
+
+    A_parser = subparsers.add_parser("infer", parents=[parent_parser], add_help=False)
+    B_parser = subparsers.add_parser(
+        "register", parents=[parent_parser], add_help=False
+    )
+    C_parser = subparsers.add_parser(
+        "unregister", parents=[parent_parser], add_help=False
+    )
+
+    A_parser.add_argument(
+        "model_input", type=str, default=None, help="Input for model for inferencing."
+    )
+
+    B_parser.add_argument(
+        "mar_set",
+        type=str,
+        default=None,
+        nargs="?",
+        help="Comma separated list of mar models to be loaded using [model_name=]model_location format.",
+    )
+
+    args = parser.parse_args()
+
+    if args.action == "infer":
+        infer(get_inference_stub(), args.model_name, args.model_input)
+    elif args.action == "register":
+        register(get_management_stub(), args.model_name, args.mar_set)
+    elif args.action == "unregister":
+        unregister(get_management_stub(), args.model_name)

--- a/ts_scripts/torchserve_grpc_client.py
+++ b/ts_scripts/torchserve_grpc_client.py
@@ -90,19 +90,21 @@ if __name__ == "__main__":
     )
     subparsers = parser.add_subparsers(help="Action", dest="action")
 
-    A_parser = subparsers.add_parser("infer", parents=[parent_parser], add_help=False)
-    B_parser = subparsers.add_parser(
+    infer_action_parser = subparsers.add_parser(
+        "infer", parents=[parent_parser], add_help=False
+    )
+    register_action_parser = subparsers.add_parser(
         "register", parents=[parent_parser], add_help=False
     )
-    C_parser = subparsers.add_parser(
+    unregister_action_parser = subparsers.add_parser(
         "unregister", parents=[parent_parser], add_help=False
     )
 
-    A_parser.add_argument(
+    infer_action_parser.add_argument(
         "model_input", type=str, default=None, help="Input for model for inferencing."
     )
 
-    B_parser.add_argument(
+    register_action_parser.add_argument(
         "mar_set",
         type=str,
         default=None,


### PR DESCRIPTION
## Description

Fixes #1852

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Feature/Issue validation/testing

I'm not able to register the `densenet161` model.  

When I run:

```python
python ts_scripts/torchserve_grpc_client.py register densenet161
```

I get: 

```
ModuleNotFoundError: No module named 'image_classifier'
````

Maybe related to #966. Is the handler in the mar ok? Can anybody help me on this error?


## Checklist:

- [x] Introduce argparse for command line args parsing
- [x] Ability to register the model