### PR TITLE
Disable Alert on Nightly GPU

### DIFF
--- a/.github/workflows/benchmark_nightly_gpu.yml
+++ b/.github/workflows/benchmark_nightly_gpu.yml
@@ -43,11 +43,3 @@ jobs:
         with:
           name: nightly gpu artifact
           path: /tmp/ts_benchmark
-      - name: Open issue on failure
-        if: ${{ failure() && github.event_name  == 'schedule' }}
-        uses: dacbd/create-issue-action@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          title: Nightly GPU benchmark failed
-          body:  Commit ${{ github.sha }} daily scheduled [CI run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) failed, please check why
-          assignees: ''


### PR DESCRIPTION
We're ignoring the errors so it's not useful to keep having them

Should open a separate issue to figure out why this job is flaky