### PR TITLE
Downgrade CI to ubuntu 18.04 

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macOS-latest]
+        os: [ubuntu-18.04, macOS-latest]
     steps:
       - name: Setup Python 3.8
         uses: actions/setup-python@v4


### PR DESCRIPTION

## Description

Downgrading CI to use ubuntu 18.04 as Ubuntu 20.04 CI has been flaky. 

- Upgrading to 22.04 did not resolve the issue

Fixes #([issue](https://github.com/pytorch/serve/issues/2053))

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


## Feature/Issue validation/testing

CI with 18.04 was reliable




## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?