### PR TITLE
Update Dockerfile.dev to install gnupg before calling apt-key del 7fa2af80 (fix: #2075)

### DIFF
--- a/kubernetes/kserve/Dockerfile.dev
+++ b/kubernetes/kserve/Dockerfile.dev
@@ -20,13 +20,17 @@ ARG MACHINE_TYPE=cpu
 ARG BRANCH_NAME_KF=master
 ENV PYTHONUNBUFFERED TRUE
 
+RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt \
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+  gnupg
+
 # Workaround from https://github.com/NVIDIA/nvidia-docker/issues/1632
 RUN apt-key del 7fa2af80
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu2004/x86_64/7fa2af80.pub
 
 RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt \
-  apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
   fakeroot \
   ca-certificates \


### PR DESCRIPTION
## Description

Please read our [CONTRIBUTING.md](https://github.com/pytorch/serve/blob/master/CONTRIBUTING.md) prior to creating your first pull request.

Please include a summary of the feature or issue being fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #2075

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] `DOCKER_BUILDKIT=1 docker build -f Dockerfile.dev -t pytorch/torchserve-kfs:latest-dev .` now can run without any error. 
Logs:
```bash
❯ DOCKER_BUILDKIT=1 docker build -f Dockerfile.dev -t pytorch/torchserve-kfs:latest-dev .
[+] Building 514.7s (14/17)                                                                                                                            
 => [compile-image 1/9] FROM docker.io/library/ubuntu:20.04@sha256:0e0402cd13f68137edb0266e1d2c682f217814420f2d43d300ed8f65479b14fb               0.0s
 => CACHED [compile-image 2/9] RUN cp /etc/apt/sources.list /etc/apt/sources.list.bak                                                             0.0s
 => CACHED [compile-image 3/9] RUN sed -i "s@\(archive\|security\|ports\).ubuntu.com@mirrors.tuna.tsinghua.edu.cn@g" /etc/apt/sources.list        0.0s
 => CACHED [compile-image 4/9] RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt   apt-get update &&   DEBIAN_FRONTEND=noninteractive apt-  0.0s
 => CACHED [compile-image 5/9] RUN apt-key del 7fa2af80                                                                                           0.0s
 => CACHED [compile-image 6/9] RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.  0.0s
 => CACHED [compile-image 7/9] RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu2004/x86_  0.0s
 => CACHED [compile-image 8/9] RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt   DEBIAN_FRONTEND=noninteractive apt-get install --no-ins  0.0s
 => CACHED [compile-image 9/9] RUN python -m pip install -U pip setuptools    
```

## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?