### PR TITLE
Logging error when benchmark script fails

### DIFF
--- a/benchmarks/benchmark-ab.py
+++ b/benchmarks/benchmark-ab.py
@@ -565,7 +565,7 @@ def extract_errors(data, pattern):
     for line in data:
         if pattern.search(line):
             print(line)
-    assert ()
+    raise Exception("Error while running Benchmark")
 
 
 def generate_latency_graph():

--- a/benchmarks/benchmark-ab.py
+++ b/benchmarks/benchmark-ab.py
@@ -550,7 +550,22 @@ def extract_entity(data, pattern, index, delim=" "):
     for line in data:
         if pattern.search(line):
             return line.split(delim)[index].strip()
+
+    # If code execution reaches here, there is some error
+    with open(execution_params["metric_log"]) as f:
+        data = f.readlines()
+    extract_errors(data, "Error")
+
     return None
+
+
+def extract_errors(data, pattern):
+
+    pattern = re.compile(pattern)
+    for line in data:
+        if pattern.search(line):
+            print(line)
+    assert ()
 
 
 def generate_latency_graph():


### PR DESCRIPTION
## Description

Nightly benchmark script has been failing on a regular basis .

Currently, from the logs its not clear why the failure happens.

Added logic to log the errors.

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Before change
```
Traceback (most recent call last):
  File "/home/ubuntu/serve/benchmarks/auto_benchmark.py", line 307, in <module>
    main()
  File "/home/ubuntu/serve/benchmarks/auto_benchmark.py", line 301, in main
    run_benchmark(bm_config)
  File "/home/ubuntu/serve/benchmarks/auto_benchmark.py", line 201, in run_benchmark
    gen_metrics_json.gen_metric(
  File "/home/ubuntu/serve/benchmarks/utils/gen_metrics_json.py", line 183, in gen_metric
    gen_metrics_from_csv(csv_dict, stats_metrics_file)
  File "/home/ubuntu/serve/benchmarks/utils/gen_metrics_json.py", line 109, in gen_metrics_from_csv
    "Value": float(v)})
ValueError: could not convert string to float: ''
```


- [ ] After Change
```
Saving benchmark results to /tmp
Warning: TorchServe is using non-default JVM parameters: -Xmx4g -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError

2023-02-13T20:28:43,127 [INFO ] W-9003-benchmark_1.0-stdout MODEL_LOG - torch.cuda.OutOfMemoryError: CUDA out of memory. Tried to allocate 314.00 MiB (GPU 0; 14.61 GiB total capacity; 894.51 MiB already allocated; 274.81 MiB free; 958.00 MiB reserved in total by PyTorch) If reserved memory is >> allocated memory try setting max_split_size_mb to avoid fragmentation.  See documentation for Memory Management and PYTORCH_CUDA_ALLOC_CONF

2023-02-13T20:28:43,140 [ERROR] W-9002-benchmark_1.0 org.pytorch.serve.wlm.BatchAggregator - Unexpected job in sendError(): b86aa0ed-d41f-4ed6-9562-b34313b49f88

2023-02-13T20:28:43,140 [ERROR] W-9002-benchmark_1.0 org.pytorch.serve.wlm.BatchAggregator - Unexpected job in sendError(): 232d9721-c98b-4fd6-9f43-724d24a9e379

```


## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?