### PR TITLE
Enable batch processing in scriptable tokenizer example

### DIFF
--- a/examples/text_classification_with_scriptable_tokenizer/handler.py
+++ b/examples/text_classification_with_scriptable_tokenizer/handler.py
@@ -1,6 +1,5 @@
 """
 Module for text classification with scriptable tokenizer
-DOES NOT SUPPORT BATCH!
 """
 import logging
 from abc import ABC
@@ -51,18 +50,19 @@ class CustomTextClassifier(BaseHandler, ABC):
 
         # Compat layer: normally the envelope should just return the data
         # directly, but older versions of Torchserve didn't have envelope.
-        # Processing only the first input, not handling batch inference
 
-        line = data[0]
-        text = line.get("data") or line.get("body")
-        # Decode text if not a str but bytes or bytearray
-        if isinstance(text, (bytes, bytearray)):
-            text = text.decode("utf-8")
+        text_batch = []
+        for line in data:
+            text = line.get("data") or line.get("body")
+            # Decode text if not a str but bytes or bytearray
+            if isinstance(text, (bytes, bytearray)):
+                text = text.decode("utf-8")
 
-        text = remove_html_tags(text)
-        text = text.lower()
+            text = remove_html_tags(text)
+            text = text.lower()
+            text_batch.append(text)
 
-        return text
+        return text_batch
 
     def inference(self, data, *args, **kwargs):
         """The Inference Request is made through this function and the user

--- a/examples/text_classification_with_scriptable_tokenizer/script_tokenizer_and_model.py
+++ b/examples/text_classification_with_scriptable_tokenizer/script_tokenizer_and_model.py
@@ -76,7 +76,7 @@ def main(args):
     model = XLMR_BASE_ENCODER.get_model(head=classifier_head)
 
     # Load trained parameters and load them into the model
-    model.load_state_dict(torch.load(args.input_file))
+    model.load_state_dict(torch.load(args.input_file, map_location=torch.device("cpu")))
 
     # Chain the tokenizer, the adapter and the model
     combi_model = T.Sequential(
@@ -88,7 +88,7 @@ def main(args):
     combi_model.eval()
 
     # Make sure to move the model to CPU to avoid placement error during loading
-    combi_model.to("cpu")
+    combi_model.to(torch.device("cpu"))
 
     combi_model_jit = torch.jit.script(combi_model)
 


### PR DESCRIPTION
## Description

Enables the processing of multiple examples in one batch for the scriptable tokenizer example:
serve/examples/text_classification_with_scriptable_tokenizer

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [X] Test A
```
cd serve/examples/text_classification_with_scriptable_tokenizer
wget https://bert-mar-file.s3.us-west-2.amazonaws.com/text_classification_with_scriptable_tokenizer/model.pt

python script_tokenizer_and_model.py model.pt model_jit.pt

# add print of model input and output in handler.py for test

torch-model-archiver --model-name scriptable_tokenizer --version 1.0 --serialized-file model_jit.pt --handler handler.py --extra-files "index_to_name.json"

mkdir model_store
mv scriptable_tokenizer.mar model_store/

torchserve --start --model-store model_store –ncs

curl -v -X POST "http://localhost:8081/models?initial_workers=1&url=scriptable_tokenizer.mar&batch_size=8"

curl http://127.0.0.1:8080/predictions/scriptable_tokenizer -T sample_text.txt& curl http://127.0.0.1:8080/predictions/scriptable_tokenizer -T sample_text.txt&
```

Logs for Test A
```
2023-02-15T06:17:58,582 [WARN ] W-9000-scriptable_tokenizer_1.0-stderr MODEL_LOG -   data = F.softmax(data)
2023-02-15T06:17:58,582 [INFO ] W-9000-scriptable_tokenizer_1.0-stdout MODEL_LOG - ["the rock is destined to be the 21st century 's new `` conan '' and that he 's going to make a splash even greater than arnold schwar
zenegger , jean-claud van damme or steven segal .\n", "the rock is destined to be the 21st century 's new `` conan '' and that he 's going to make a splash even greater than arnold schwarzenegger , jean-claud van damm
e or steven segal .\n"]
2023-02-15T06:17:58,583 [INFO ] W-9000-scriptable_tokenizer_1.0-stdout MODEL_LOG - tensor([[-4.2065,  4.3875],
2023-02-15T06:17:58,583 [INFO ] W-9000-scriptable_tokenizer_1.0-stdout MODEL_LOG -         [-4.2065,  4.3875]])
2023-02-15T06:17:58,583 [INFO ] W-9000-scriptable_tokenizer_1.0 org.pytorch.serve.wlm.WorkerThread - Backend response time: 2782
```

- [ ] Test B
Logs for Test B


## Checklist:

- [X] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?