### PR TITLE
Wildcard search in model_archiver --extra-files 

### DIFF
--- a/model-archiver/model_archiver/model_packaging_utils.py
+++ b/model-archiver/model_archiver/model_packaging_utils.py
@@ -2,6 +2,7 @@
 Helper utils for Model Export tool
 """
 
+import glob
 import logging
 import os
 import re
@@ -156,20 +157,20 @@ class ModelExportUtils(object):
                         path = (path.split(":")[0] if ":" in path else path) + ".py"
 
                 if file_type == "extra_files":
-                    for file in path.split(","):
-                        file = file.strip()
-                        if os.path.isfile(file):
-                            shutil.copy2(file, model_path)
-                        elif os.path.isdir(file) and file != model_path:
-                            for item in os.listdir(file):
-                                src = os.path.join(file, item)
-                                dst = os.path.join(model_path, item)
-                                if os.path.isfile(src):
-                                    shutil.copy2(src, dst)
-                                elif os.path.isdir(src):
-                                    shutil.copytree(src, dst, False, None)
-                        else:
-                            raise ValueError(f"Invalid extra file given {file}")
+                    for path_or_wildcard in path.split(","):
+                        for file in glob.glob(path_or_wildcard.strip()):
+                            if os.path.isfile(file):
+                                shutil.copy2(file, model_path)
+                            elif os.path.isdir(file) and file != model_path:
+                                for item in os.listdir(file):
+                                    src = os.path.join(file, item)
+                                    dst = os.path.join(model_path, item)
+                                    if os.path.isfile(src):
+                                        shutil.copy2(src, dst)
+                                    elif os.path.isdir(src):
+                                        shutil.copytree(src, dst, False, None)
+                            else:
+                                raise ValueError(f"Invalid extra file given {file}")
                 else:
                     shutil.copy(path, model_path)
 


### PR DESCRIPTION
## Description

Fixes #2111 (Feature request)

**Implementation of wildcard filepaths for the model_archiver**

**Motivation**
"Large Language Models like Bloom, for example, consist of hundreds of sharded model files. Integrating all the model files as extra-files parameters is a cumbersome process. Wildcard support would help to solve this quickly."

**Implementation**
The change uses the same logic as before for how the extra_files are passed to the model archiver, but now also allows for passing wildcard paths like. /project/models/**.bin using the glob python module.

This does not require any new dependencies, but an update to the documentation is needed to inform about the new feature.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Feature/Issue validation/testing

Running torchserve_sanity.py passes with no issues. The model_archiver PyTests already require the model_archiver to function properly. I did not add any new test to assert the wildcard functionality is operating as expected. Should I?

## Checklist:

- [x] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?