### PR TITLE
Fix TorchserveModel predict() and explain() methods to support latest kserve definitions

### DIFF
--- a/kubernetes/kserve/kserve_wrapper/TorchserveModel.py
+++ b/kubernetes/kserve/kserve_wrapper/TorchserveModel.py
@@ -3,7 +3,7 @@
 import orjson
 import logging
 import pathlib
-from typing import Dict
+from typing import Dict, Union
 
 import kserve
 import httpx
@@ -55,13 +55,13 @@ class TorchserveModel(Model):
         self.explainer_host = self.predictor_host
         logging.info("kfmodel Explain URL set to %s", self.explainer_host)
 
-    async def predict(self, payload: Dict, headers: Dict) -> Dict:
+    async def predict(self, payload: Union[Dict, InferRequest], headers: Dict) -> Dict:
         """The predict method is called when we hit the inference endpoint and handles
         the inference request and response from the Torchserve side and passes it on
         to the KServe side.
 
         Args:
-            payload (Dict): Input payload from the http client side.
+            payload (Dict|InferRequest): Input payload from the http client side.
             headers (Dict): Request headers.
 
         Raises:
@@ -125,8 +125,6 @@ class TorchserveModel(Model):
         """
         if self.explainer_host is None:
             raise NotImplementedError
-        if isinstance(payload, InferRequest):
-            payload = payload.to_rest()
         data = orjson.dumps(payload)
         logging.info("kfmodel explain request is %s", data)
         logging.info("EXPLAINER_HOST : %s", self.explainer_host)


### PR DESCRIPTION
## Description

The new predict definition takes 3 parameters - https://github.com/kserve/kserve/blob/15821f336336f73415a5da6968133c8b2b75c45d/python/kserve/kserve/model.py#L210

Fixes #(issue)
#2156

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Before Change

````
573666 root INFO [timing():49] kserve.io.kserve.protocol.rest.v2_endpoints.infer 0.0013496875762939453, ['http_status:500', 'http_method:POST', 'time:wall']
573666 root INFO [timing():49] kserve.io.kserve.protocol.rest.v2_endpoints.infer 0.0013029999999999986, ['http_status:500', 'http_method:POST', 'time:cpu']
573666 uvicorn.error ERROR [run_asgi():376] Exception in ASGI application
Traceback (most recent call last):
  File "/home/ubuntu/.local/lib/python3.10/site-packages/uvicorn/protocols/http/h11_impl.py", line 373, in run_asgi
    result = await app(self.scope, self.receive, self.send)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/uvicorn/middleware/proxy_headers.py", line 75, in __call__
    return await self.app(scope, receive, send)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/fastapi/applications.py", line 270, in __call__
    await super().__call__(scope, receive, send)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/starlette/applications.py", line 124, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/starlette/middleware/errors.py", line 184, in __call__
    raise exc
  File "/home/ubuntu/.local/lib/python3.10/site-packages/starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/timing_asgi/middleware.py", line 68, in __call__
    await self.app(scope, receive, send_wrapper)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/starlette/middleware/exceptions.py", line 79, in __call__
    raise exc
  File "/home/ubuntu/.local/lib/python3.10/site-packages/starlette/middleware/exceptions.py", line 68, in __call__
    await self.app(scope, receive, sender)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/fastapi/middleware/asyncexitstack.py", line 21, in __call__
    raise e
  File "/home/ubuntu/.local/lib/python3.10/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/starlette/routing.py", line 706, in __call__
    await route.handle(scope, receive, send)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/starlette/routing.py", line 276, in handle
    await self.app(scope, receive, send)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/starlette/routing.py", line 66, in app
    response = await func(request)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/fastapi/routing.py", line 235, in app
    raw_response = await run_endpoint_function(
  File "/home/ubuntu/.local/lib/python3.10/site-packages/fastapi/routing.py", line 161, in run_endpoint_function
    return await dependant.call(**values)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/kserve/protocol/rest/v2_endpoints.py", line 130, in infer
    response, response_headers = await self.dataplane.infer(
  File "/home/ubuntu/.local/lib/python3.10/site-packages/kserve/protocol/dataplane.py", line 276, in infer
    response = await model(body, headers=headers)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/kserve/model.py", line 116, in __call__
    response = (await self.predict(payload, headers)) if inspect.iscoroutinefunction(self.predict) \
TypeError: TorchserveModel.predict() takes 2 positional arguments but 3 were given
````

- [ ] After Change
```
573924 root INFO [__call__():128] requestId: N.A., preprocess_ms: 0.020742416, explain_ms: 0, predict_ms: 1501.895904541, postprocess_ms: 0.00667572
573924 root INFO [timing():49] kserve.io.kserve.protocol.rest.v2_endpoints.infer 1.5054492950439453, ['http_status:200', 'http_method:POST', 'time:wall']
573924 root INFO [timing():49] kserve.io.kserve.protocol.rest.v2_endpoints.infer 0.063466, ['http_status:200', 'http_method:POST', 'time:cpu']
```

## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?