### PR TITLE
Make model-archiver tests runnable from any directory

### DIFF
--- a/model-archiver/model_archiver/tests/integ_tests/test_integration_model_archiver.py
+++ b/model-archiver/model_archiver/tests/integ_tests/test_integration_model_archiver.py
@@ -1,16 +1,23 @@
-import platform
-import time
-from datetime import datetime
 import errno
 import json
 import os
+import platform
 import shutil
-import tempfile
 import subprocess
+import tempfile
+import time
+from datetime import datetime
+from pathlib import Path
+
 import model_archiver
 
 DEFAULT_RUNTIME = "python"
 MANIFEST_FILE = "MAR-INF/MANIFEST.json"
+INTEG_TEST_CONFIG_FILE = "integ_tests/configuration.json"
+DEFAULT_HANDLER_CONFIG_FILE = "integ_tests/default_handler_configuration.json"
+
+TEST_ROOT_DIR = Path(__file__).parents[1]
+MODEL_ARCHIVER_ROOT_DIR = Path(__file__).parents[3]
 
 
 def create_file_path(path):
@@ -49,11 +56,17 @@ def run_test(test, cmd):
 def validate_archive_exists(test):
     fmt = test.get("archive-format")
     if fmt == "tgz":
-        assert os.path.isfile(os.path.join(test.get("export-path"), test.get("model-name")+".tar.gz"))
+        assert os.path.isfile(
+            os.path.join(test.get("export-path"), test.get("model-name") + ".tar.gz")
+        )
     elif fmt == "no-archive":
-        assert os.path.isdir(os.path.join(test.get("export-path"), test.get("model-name")))
+        assert os.path.isdir(
+            os.path.join(test.get("export-path"), test.get("model-name"))
+        )
     else:
-        assert os.path.isfile(os.path.join(test.get("export-path"), test.get("model-name")+".mar"))
+        assert os.path.isfile(
+            os.path.join(test.get("export-path"), test.get("model-name") + ".mar")
+        )
 
 
 def validate_manifest_file(manifest, test, default_handler=None):
@@ -67,7 +80,9 @@ def validate_manifest_file(manifest, test, default_handler=None):
     assert manifest.get("runtime") == test.get("runtime")
     assert manifest.get("model").get("modelName") == test.get("model-name")
     if not default_handler:
-        assert manifest.get("model").get("handler") == test.get("handler").split("/")[-1]
+        assert (
+            manifest.get("model").get("handler") == test.get("handler").split("/")[-1]
+        )
     else:
         assert manifest.get("model").get("handler") == test.get("handler")
     assert manifest.get("archiverVersion") == model_archiver.__version__
@@ -87,21 +102,29 @@ def validate_files(file_list, prefix, default_handler=None):
 
 def validate_tar_archive(test_cfg):
     import tarfile
-    file_name = os.path.join(test_cfg.get("export-path"), test_cfg.get("model-name") + ".tar.gz")
+
+    file_name = os.path.join(
+        test_cfg.get("export-path"), test_cfg.get("model-name") + ".tar.gz"
+    )
     f = tarfile.open(file_name, "r:gz")
-    manifest = json.loads(f.extractfile(os.path.join(test_cfg.get("model-name"), MANIFEST_FILE)).read())
+    manifest = json.loads(
+        f.extractfile(os.path.join(test_cfg.get("model-name"), MANIFEST_FILE)).read()
+    )
     validate_manifest_file(manifest, test_cfg)
     validate_files(f.getnames(), test_cfg.get("model-name"))
 
 
 def validate_noarchive_archive(test):
-    file_name = os.path.join(test.get("export-path"), test.get("model-name"), MANIFEST_FILE)
+    file_name = os.path.join(
+        test.get("export-path"), test.get("model-name"), MANIFEST_FILE
+    )
     manifest = json.loads(open(file_name).read())
     validate_manifest_file(manifest, test)
 
 
 def validate_mar_archive(test):
     import zipfile
+
     file_name = os.path.join(test.get("export-path"), test.get("model-name") + ".mar")
     zf = zipfile.ZipFile(file_name, "r")
     manifest = json.loads(zf.open(MANIFEST_FILE).read())
@@ -124,8 +147,17 @@ def validate(test):
 
 
 def build_cmd(test):
-    args = ['model-name', 'model-file', 'serialized-file', 'handler', 'extra-files', 'archive-format',
-            'version', 'export-path', 'runtime']
+    args = [
+        "model-name",
+        "model-file",
+        "serialized-file",
+        "handler",
+        "extra-files",
+        "archive-format",
+        "version",
+        "export-path",
+        "runtime",
+    ]
 
     cmd = ["torch-model-archiver"]
 
@@ -136,19 +168,42 @@ def build_cmd(test):
     return " ".join(cmd)
 
 
+def make_paths_absolute(test, keys):
+    def make_absolute(paths):
+        if "," in paths:
+            return ",".join([make_absolute(p) for p in paths.split(",")])
+        return MODEL_ARCHIVER_ROOT_DIR.joinpath(paths).as_posix()
+
+    for k in keys:
+        test[k] = make_absolute(test[k])
+
+    return test
+
+
 def test_model_archiver():
-    with open("model_archiver/tests/integ_tests/configuration.json", "r") as f:
+    with open(TEST_ROOT_DIR.joinpath(INTEG_TEST_CONFIG_FILE), "r") as f:
         tests = json.loads(f.read())
+        keys = (
+            "model-file",
+            "serialized-file",
+            "handler",
+            "extra-files",
+        )
+        tests = [make_paths_absolute(t, keys) for t in tests]
         for test in tests:
             # tar.gz format problem on windows hence ignore
-            if platform.system() == "Windows" and test['archive-format'] == 'tgz':
+            if platform.system() == "Windows" and test["archive-format"] == "tgz":
                 continue
             try:
-                test["export-path"] = os.path.join(tempfile.gettempdir(), test["export-path"])
+                test["export-path"] = os.path.join(
+                    tempfile.gettempdir(), test["export-path"]
+                )
                 delete_file_path(test.get("export-path"))
                 create_file_path(test.get("export-path"))
                 test["runtime"] = test.get("runtime", DEFAULT_RUNTIME)
-                test["model-name"] = test["model-name"] + '_' + str(int(time.time()*1000.0))
+                test["model-name"] = (
+                    test["model-name"] + "_" + str(int(time.time() * 1000.0))
+                )
                 cmd = build_cmd(test)
                 if test.get("force"):
                     cmd += " -f"
@@ -160,8 +215,14 @@ def test_model_archiver():
 
 
 def test_default_handlers():
-    with open("model_archiver/tests/integ_tests/default_handler_configuration.json", "r") as f:
+    with open(TEST_ROOT_DIR.joinpath(DEFAULT_HANDLER_CONFIG_FILE), "r") as f:
         tests = json.loads(f.read())
+        keys = (
+            "model-file",
+            "serialized-file",
+            "extra-files",
+        )
+        tests = [make_paths_absolute(t, keys) for t in tests]
         for test in tests:
             cmd = build_cmd(test)
             try:

--- a/model-archiver/model_archiver/tests/unit_tests/test_version.py
+++ b/model-archiver/model_archiver/tests/unit_tests/test_version.py
@@ -1,7 +1,8 @@
+from pathlib import Path
 
-
-import os
 import model_archiver
+
+MODEL_ARCHIVER_ROOT_DIR = Path(__file__).parent.parent.parent
 
 
 def test_model_export_tool_version():
@@ -9,7 +10,7 @@ def test_model_export_tool_version():
     Test the model archive version
     :return:
     """
-    with open(os.path.join('model_archiver', 'version.txt')) as f:
+    with open(MODEL_ARCHIVER_ROOT_DIR.joinpath("version.txt")) as f:
         __version__ = f.readline().strip()
 
     assert __version__ == str(model_archiver.__version__), "Versions do not match"


### PR DESCRIPTION
## Description

So far tests for model-archiver had to be called from model-archiver folder. This PR changes this to make them callable from any folder.

The rest is just pre-commit beautification.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [X] ~/serve$ pytest model-archiver/model_archiver/tests/ 
```
========================================================================================= test session starts =========================================================================================
platform linux -- Python 3.9.16, pytest-7.2.2, pluggy-1.0.0
rootdir: /home/ubuntu/serve/model-archiver
plugins: mock-3.10.0, cov-4.0.0
collected 28 items

model-archiver/model_archiver/tests/integ_tests/test_integration_model_archiver.py ..                                                                                                           [  7%]
model-archiver/model_archiver/tests/unit_tests/test_model_packaging.py ....                                                                                                                     [ 21%]
model-archiver/model_archiver/tests/unit_tests/test_model_packaging_utils.py .....................                                                                                              [ 96%]
model-archiver/model_archiver/tests/unit_tests/test_version.py .                                                                                                                                [100%]

========================================================================================= 28 passed in 0.59s ==========================================================================================
```

- [X] ~/serve/model-archiver$ pytest model_archiver/tests/

```
========================================================================================= test session starts =========================================================================================
platform linux -- Python 3.9.16, pytest-7.2.2, pluggy-1.0.0
rootdir: /home/ubuntu/serve/model-archiver
plugins: mock-3.10.0, cov-4.0.0
collected 28 items

model_archiver/tests/integ_tests/test_integration_model_archiver.py ..                                                                                                                          [  7%]
model_archiver/tests/unit_tests/test_model_packaging.py ....                                                                                                                                    [ 21%]
model_archiver/tests/unit_tests/test_model_packaging_utils.py .....................                                                                                                             [ 96%]
model_archiver/tests/unit_tests/test_version.py .                                                                                                                                               [100%]

========================================================================================= 28 passed in 0.57s ==========================================================================================
```


## Checklist:

- [X] Did you have fun?
- [X] Have you added tests that prove your fix is effective or that this feature works?
- [X] Has code been commented, particularly in hard-to-understand areas?
- [X] Have you made corresponding changes to the documentation?