### PR TITLE
support torchrun and optimize gpu assignment

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -266,11 +266,13 @@ models={\
   }\
 }
 ```
-As of version 0.8.0, TorchServe allows for model configuration using a YAML file embedded in the MAR file. This YAML file contains two distinct parts that determine how a model is configured: frontend parameters and backend parameters. (see [details](https://github.com/pytorch/serve/tree/master/model-archiver))
+Starting from version 0.8.0, TorchServe allows for model configuration using a YAML file embedded in the MAR file. This YAML file contains two distinct parts that determine how a model is configured: frontend parameters and backend parameters. (see [details](https://github.com/pytorch/serve/tree/master/model-archiver#config-file))
 
 * The frontend parameters are controlled by TorchServe's frontend and specify the parameter name and default values. TorchServe now uses a priority order to determine the final value of a model's parameters in frontend. Specifically, the config.property file has the lowest priority, followed by the model configuration YAML file, and finally, the REST or gRPC model management API has the highest priority.
 
-* The backend parameters are fully controlled by the user. Users customized handler can access the backend parameters via the `model_yaml_config` property of the context object.
+* The backend parameters are fully controlled by the user. Users customized handler can access the backend parameters via the `model_yaml_config` property of the [context object](https://github.com/pytorch/serve/blob/master/ts/context.py#L24).
+
+* User can allocate specific GPU device IDs to a model by defining "deviceIds" in the frontend parameters in the YAML file. TorchServe uses a round-robin strategy to assign device IDs to a model's worker. If specified in the YAML file, it round-robins the device IDs listed; otherwise, it uses all visible device IDs on the host.
 
 ### Other properties
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -270,7 +270,7 @@ Starting from version 0.8.0, TorchServe allows for model configuration using a Y
 
 * The frontend parameters are controlled by TorchServe's frontend and specify the parameter name and default values. TorchServe now uses a priority order to determine the final value of a model's parameters in frontend. Specifically, the config.property file has the lowest priority, followed by the model configuration YAML file, and finally, the REST or gRPC model management API has the highest priority.
 
-* The backend parameters are fully controlled by the user. Users customized handler can access the backend parameters via the `model_yaml_config` property of the [context object](https://github.com/pytorch/serve/blob/master/ts/context.py#L24).
+* The backend parameters are fully controlled by the user. Users customized handler can access the backend parameters via the `model_yaml_config` property of the [context object](https://github.com/pytorch/serve/blob/master/ts/context.py#L24). For example, context.model_yaml_config["pippy"]["rpc_timeout"].
 
 * User can allocate specific GPU device IDs to a model by defining "deviceIds" in the frontend parameters in the YAML file. TorchServe uses a round-robin strategy to assign device IDs to a model's worker. If specified in the YAML file, it round-robins the device IDs listed; otherwise, it uses all visible device IDs on the host.
 

--- a/frontend/archive/src/main/java/org/pytorch/serve/archive/model/ModelConfig.java
+++ b/frontend/archive/src/main/java/org/pytorch/serve/archive/model/ModelConfig.java
@@ -351,7 +351,6 @@ public class ModelConfig {
                             default:
                                 break;
                         }
-                        ;
                     });
             return torchRun;
         }

--- a/frontend/archive/src/main/java/org/pytorch/serve/archive/model/ModelConfig.java
+++ b/frontend/archive/src/main/java/org/pytorch/serve/archive/model/ModelConfig.java
@@ -20,6 +20,7 @@ public class ModelConfig {
     private List<Integer> deviceIds;
     private int parallelLevel = 1;
     private ParallelType parallelType = ParallelType.NONE;
+    private TorchRun torchRun;
 
     public static ModelConfig build(Map<String, Object> yamlMap) {
         ModelConfig modelConfig = new ModelConfig();
@@ -68,13 +69,6 @@ public class ModelConfig {
                                 logger.warn("Invalid deviceType: {}, should be cpu, or gpu", v);
                             }
                             break;
-                        case "parallelLevel":
-                            if (v instanceof Integer) {
-                                modelConfig.setParallelLevel((int) v);
-                            } else {
-                                logger.warn("Invalid parallelLevel: {}, should be integer >= 1", v);
-                            }
-                            break;
                         case "parallelType":
                             if (v instanceof String) {
                                 modelConfig.setParallelMode((String) v);
@@ -88,6 +82,16 @@ public class ModelConfig {
                                 modelConfig.setDeviceIds((List<?>) v);
                             } else {
                                 logger.warn("Invalid deviceIds: {}, should be list of integer", v);
+                            }
+                            break;
+                        case "torchrun":
+                            if (v instanceof Map<?, ?>) {
+                                modelConfig.torchRun = TorchRun.build((Map<?, ?>) v);
+                                modelConfig.setParallelLevel(
+                                        modelConfig.torchRun.getNprocPerNode());
+                            } else {
+                                logger.warn(
+                                        "Invalid torchrun: {}, should be Torchrun parameters", v);
                             }
                             break;
                         default:
@@ -203,6 +207,10 @@ public class ModelConfig {
         return deviceType;
     }
 
+    public TorchRun getTorchRun() {
+        return torchRun;
+    }
+
     public enum ParallelType {
         NONE(""),
         PP("pp"),
@@ -261,6 +269,199 @@ public class ModelConfig {
                 logger.warn("Invalid DeviceType:{}", deviceType, e);
             }
             return dType;
+        }
+    }
+
+    public static class TorchRun {
+        private int nnodes = 1;
+        private int nprocPerNode = 1;
+        private String rdzvId;
+        private String rdzvEndpoint;
+        private String rdzvBackend = "c10d";
+        private String rdzvConf;
+        private int maxRestarts = 3;
+        private int monitorInterval = 5;
+        private int nodeRank;
+        private String masterAddr;
+        private int masterPort;
+
+        public static TorchRun build(Map<?, ?> torchRunMap) {
+            TorchRun torchRun = new TorchRun();
+            torchRunMap.forEach(
+                    (k, v) -> {
+                        switch ((String) k) {
+                            case "nnodes":
+                                if (v instanceof Integer) {
+                                    torchRun.setNnodes((Integer) v);
+                                } else {
+                                    logger.warn("Invalid torchrun.nnodes:{}, reset to 1", v);
+                                }
+                                break;
+                            case "nproc-per-node":
+                                if (v instanceof Integer) {
+                                    torchRun.setNprocPerNode((Integer) v);
+                                } else {
+                                    logger.warn(
+                                            "Invalid torchrun.nproc-per-node:{}, reset to 1", v);
+                                }
+                                break;
+                            case "rdzv-backend":
+                                if (v instanceof String) {
+                                    torchRun.setRdzvBackend((String) v);
+                                } else {
+                                    logger.warn(
+                                            "Invalid torchrun.rdzv-backend:{}, reset to c10d", v);
+                                }
+                                break;
+                            case "rdzv-endpoint":
+                                if (v instanceof String) {
+                                    torchRun.setRdzvEndpoint((String) v);
+                                } else {
+                                    logger.warn("Invalid torchrun.rdzv-endpoint:{}", v);
+                                }
+                                break;
+                            case "rdzv-conf":
+                                if (v instanceof String) {
+                                    torchRun.setRdzvConf((String) v);
+                                } else {
+                                    logger.warn("Invalid torchrun.rdzv-conf:{}", v);
+                                }
+                                break;
+                            case "max-restarts":
+                                if (v instanceof Integer) {
+                                    torchRun.setMaxRestarts((Integer) v);
+                                } else {
+                                    logger.warn("Invalid torchrun.max-restarts:{}, reset to 3", v);
+                                }
+                                break;
+                            case "monitor-interval":
+                                if (v instanceof Integer) {
+                                    torchRun.setMonitorInterval((Integer) v);
+                                } else {
+                                    logger.warn("Invalid torchrun.max-restarts:{}, reset to 5", v);
+                                }
+                                break;
+                            case "node-rank":
+                                if (v instanceof Integer) {
+                                    torchRun.setNodeRank((Integer) v);
+                                } else {
+                                    logger.warn("Invalid torchrun.node-rank:{}, reset to 0", v);
+                                }
+                                break;
+                            default:
+                                break;
+                        }
+                        ;
+                    });
+            return torchRun;
+        }
+
+        public int getNnodes() {
+            return nnodes;
+        }
+
+        public void setNnodes(int nnodes) {
+            if (nnodes <= 0) {
+                logger.warn("Invalid torchrun.nnodes:{}, reset to 1", nnodes);
+                return;
+            }
+            this.nnodes = nnodes;
+        }
+
+        public int getNprocPerNode() {
+            return nprocPerNode;
+        }
+
+        public void setNprocPerNode(int nprocPerNode) {
+            if (nprocPerNode <= 0) {
+                logger.warn("Invalid torchrun.nproc-per-node:{}, reset to 1", nprocPerNode);
+                return;
+            }
+            this.nprocPerNode = nprocPerNode;
+        }
+
+        public String getRdzvId() {
+            return rdzvId;
+        }
+
+        public void setRdzvId(String rdzvId) {
+            this.rdzvId = rdzvId;
+        }
+
+        public String getRdzvEndpoint() {
+            return rdzvEndpoint;
+        }
+
+        public void setRdzvEndpoint(String rdzvEndpoint) {
+            this.rdzvEndpoint = rdzvEndpoint;
+        }
+
+        public String getRdzvBackend() {
+            return rdzvBackend;
+        }
+
+        public void setRdzvBackend(String rdzvBackend) {
+            this.rdzvBackend = rdzvBackend;
+        }
+
+        public String getRdzvConf() {
+            return rdzvConf;
+        }
+
+        public void setRdzvConf(String rdzvConf) {
+            this.rdzvConf = rdzvConf;
+        }
+
+        public int getMaxRestarts() {
+            return maxRestarts;
+        }
+
+        public void setMaxRestarts(int maxRestarts) {
+            if (maxRestarts <= 0) {
+                logger.warn("Invalid torchrun.max-restarts:{}, reset to 3", maxRestarts);
+                return;
+            }
+            this.maxRestarts = maxRestarts;
+        }
+
+        public int getMonitorInterval() {
+            return monitorInterval;
+        }
+
+        public void setMonitorInterval(int monitorInterval) {
+            if (monitorInterval <= 0) {
+                logger.warn("Invalid torchrun.monitor-interval:{}, reset to 5", monitorInterval);
+                return;
+            }
+            this.monitorInterval = monitorInterval;
+        }
+
+        public int getNodeRank() {
+            return nodeRank;
+        }
+
+        public void setNodeRank(int nodeRank) {
+            if (nodeRank < 0) {
+                logger.warn("Invalid torchrun.node-rank:{}, reset to 0", nodeRank);
+                return;
+            }
+            this.nodeRank = nodeRank;
+        }
+
+        public String getMasterAddr() {
+            return masterAddr;
+        }
+
+        public void setMasterAddr(String masterAddr) {
+            this.masterAddr = masterAddr;
+        }
+
+        public int getMasterPort() {
+            return masterPort;
+        }
+
+        public void setMasterPort(int masterPort) {
+            this.masterPort = masterPort;
         }
     }
 }

--- a/frontend/archive/src/test/java/org/pytorch/serve/archive/model/ModelConfigTest.java
+++ b/frontend/archive/src/test/java/org/pytorch/serve/archive/model/ModelConfigTest.java
@@ -41,7 +41,7 @@ public class ModelConfigTest {
         Assert.assertEquals(modelConfig.getMaxBatchDelay(), 100);
         Assert.assertEquals(modelConfig.getResponseTimeout(), 120);
         Assert.assertNotEquals(modelConfig.getDeviceType(), ModelConfig.DeviceType.GPU);
-        Assert.assertEquals(modelConfig.getParallelLevel(), 4);
+        Assert.assertEquals(modelConfig.getParallelLevel(), 1);
         Assert.assertNotEquals(modelConfig.getParallelType(), ModelConfig.ParallelType.PPTP);
         Assert.assertNull(modelConfig.getDeviceIds());
     }

--- a/frontend/archive/src/test/java/org/pytorch/serve/archive/model/ModelConfigTest.java
+++ b/frontend/archive/src/test/java/org/pytorch/serve/archive/model/ModelConfigTest.java
@@ -9,7 +9,7 @@ import org.testng.annotations.Test;
 
 public class ModelConfigTest {
     @Test
-    public void TestValidYamlConfig() throws InvalidModelException, IOException {
+    public void testValidYamlConfig() throws InvalidModelException, IOException {
         String yamlConfigFile = "src/test/resources/modelConfig/valid.yaml";
         ModelConfig modelConfig;
         File configFile = new File(yamlConfigFile);
@@ -25,10 +25,12 @@ public class ModelConfigTest {
         Assert.assertEquals(modelConfig.getParallelLevel(), 4);
         Assert.assertEquals(modelConfig.getParallelType(), ModelConfig.ParallelType.PP);
         Assert.assertEquals(modelConfig.getDeviceIds().get(2).intValue(), 2);
+        Assert.assertEquals(modelConfig.getTorchRun().getNodeRank(), 0);
+        Assert.assertEquals(modelConfig.getTorchRun().getRdzvBackend(), "c10d");
     }
 
     @Test
-    public void TestInvalidYamlConfig() throws InvalidModelException, IOException {
+    public void testInvalidYamlConfig() throws InvalidModelException, IOException {
         String yamlConfigFile = "src/test/resources/modelConfig/invalid.yaml";
         ModelConfig modelConfig;
         File configFile = new File(yamlConfigFile);

--- a/frontend/archive/src/test/resources/modelConfig/invalid.yaml
+++ b/frontend/archive/src/test/resources/modelConfig/invalid.yaml
@@ -6,5 +6,4 @@ maxBatchDelay: 100
 responseTimeout: 120
 deviceType: xpu # cpu, gpu
 deviceIds: 0,1,2,3] # device index for gpu
-parallelLevel: 4 # rpc world size
 parallelType: "xpp" # pp: pipeline parallel; pptp: tensor+pipeline parallel

--- a/frontend/archive/src/test/resources/modelConfig/valid.yaml
+++ b/frontend/archive/src/test/resources/modelConfig/valid.yaml
@@ -5,6 +5,9 @@ batchSize: 1
 maxBatchDelay: 100
 responseTimeout: 120
 deviceType: "gpu" # cpu, gpu
-deviceIds: [0,1,2,3] # device index for gpu, neuron
-parallelLevel: 4 # rpc world size
+deviceIds: [0,1,2,3] # device index for gpu
 parallelType: "pp" # pp: pipeline parallel; pptp: tensor+pipeline parallel
+
+torchrun:
+  nproc-per-node: 4
+

--- a/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
@@ -135,6 +135,7 @@ public final class ConfigManager {
     private static ConfigManager instance;
     private String hostName;
     private Map<String, Map<String, JsonObject>> modelConfig = new HashMap<>();
+    private String torchrunLogDir;
 
     private ConfigManager(Arguments args) throws IOException {
         prop = new Properties();
@@ -373,6 +374,14 @@ public final class ConfigManager {
             path = getModelServerHome() + "/ts/configs/metrics.yaml";
         }
         return path;
+    }
+
+    public String getTorchRunLogDir() {
+        if (torchrunLogDir == null) {
+            torchrunLogDir =
+                    getCanonicalPath(System.getProperty("LOG_LOCATION")) + "/torchelastic_ts";
+        }
+        return torchrunLogDir;
     }
 
     public boolean isSystemMetricsDisabled() {

--- a/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
@@ -380,8 +380,8 @@ public final class ConfigManager {
         if (torchrunLogDir == null) {
             torchrunLogDir =
                     Paths.get(
-                            getCanonicalPath(System.getProperty("LOG_LOCATION")),
-                            "torchelastic_ts")
+                                    getCanonicalPath(System.getProperty("LOG_LOCATION")),
+                                    "torchelastic_ts")
                             .toString();
         }
         return torchrunLogDir;

--- a/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
@@ -379,7 +379,10 @@ public final class ConfigManager {
     public String getTorchRunLogDir() {
         if (torchrunLogDir == null) {
             torchrunLogDir =
-                    getCanonicalPath(System.getProperty("LOG_LOCATION")) + "/torchelastic_ts";
+                    Paths.get(
+                            getCanonicalPath(System.getProperty("LOG_LOCATION")),
+                            "torchelastic_ts")
+                            .toString();
         }
         return torchrunLogDir;
     }

--- a/frontend/server/src/main/java/org/pytorch/serve/wlm/Model.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/wlm/Model.java
@@ -52,7 +52,7 @@ public class Model {
     private int responseTimeout;
     private ModelVersionName modelVersionName;
     private AtomicInteger gpuCounter = new AtomicInteger(0);
-    private boolean hasDeviceIds;
+    private boolean hasCfgDeviceIds;
     private boolean isWorkflowModel;
 
     // Total number of subsequent inference request failures
@@ -80,12 +80,12 @@ public class Model {
 
             deviceIds = modelArchive.getModelConfig().getDeviceIds();
             if (deviceIds != null && deviceIds.size() > 0) {
-                hasDeviceIds = true;
+                hasCfgDeviceIds = true;
                 for (Integer deviceId : deviceIds) {
                     if (deviceId < 0 || deviceId >= ConfigManager.getInstance().getNumberOfGpu()) {
                         logger.warn("Invalid deviceId:{}, ignore deviceIds list", deviceId);
                         deviceIds = null;
-                        hasDeviceIds = false;
+                        hasCfgDeviceIds = false;
                         break;
                     }
                 }
@@ -95,11 +95,10 @@ public class Model {
             maxBatchDelay = 100;
         }
 
-        if (ConfigManager.getInstance().getNumberOfGpu() > 0) {
+        if (ConfigManager.getInstance().getNumberOfGpu() > 0
+                && deviceType != ModelConfig.DeviceType.CPU) {
             numCores =
-                    (deviceType == ModelConfig.DeviceType.GPU
-                                    && deviceIds != null
-                                    && deviceIds.size() > 0)
+                    hasCfgDeviceIds
                             ? deviceIds.size()
                             : ConfigManager.getInstance().getNumberOfGpu();
         }
@@ -321,10 +320,6 @@ public class Model {
         return this.parallelLevel;
     }
 
-    public void setParallelLevel(int parallelLevel) {
-        this.parallelLevel = parallelLevel;
-    }
-
     public ModelConfig.ParallelType getParallelType() {
         return this.parallelType;
     }
@@ -341,7 +336,7 @@ public class Model {
         return gpuCounter;
     }
 
-    public boolean isHasDeviceIds() {
-        return hasDeviceIds;
+    public boolean isHasCfgDeviceIds() {
+        return hasCfgDeviceIds;
     }
 }

--- a/frontend/server/src/main/java/org/pytorch/serve/wlm/WorkLoadManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/wlm/WorkLoadManager.java
@@ -196,15 +196,16 @@ public class WorkLoadManager {
             int gpuId = -1;
 
             if (maxGpu > 0) {
-                if (model.isHasDeviceIds()) {
+                if (model.isHasCfgDeviceIds() || model.getParallelLevel() > 1) {
                     gpuId =
-                            1000
-                                    + model.getGpuCounter()
-                                            .getAndAccumulate(
-                                                    maxGpu,
-                                                    (prev, maxGpuId) ->
-                                                            (prev + model.getParallelLevel())
-                                                                    % maxGpuId);
+                            model.getGpuCounter()
+                                    .getAndAccumulate(
+                                            maxGpu,
+                                            (prev, maxGpuId) ->
+                                                    (prev + model.getParallelLevel()) % maxGpuId);
+                    if (model.getParallelLevel() == 1) {
+                        gpuId = model.getDeviceIds().get(gpuId);
+                    }
                 } else {
                     gpuId =
                             gpuCounter.accumulateAndGet(

--- a/frontend/server/src/main/java/org/pytorch/serve/wlm/WorkerLifeCycle.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/wlm/WorkerLifeCycle.java
@@ -150,7 +150,6 @@ public class WorkerLifeCycle {
             String[] args = argl.toArray(new String[argl.size()]);
             String[] envs = envp.toArray(new String[envp.size()]);
             logger.debug("Worker cmdline: {}", argl.toString());
-            logger.debug("Worker environment: {}", envp.toString());
 
             synchronized (this) {
                 process = Runtime.getRuntime().exec(args, envs, modelPath);

--- a/frontend/server/src/main/java/org/pytorch/serve/wlm/WorkerLifeCycle.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/wlm/WorkerLifeCycle.java
@@ -100,12 +100,13 @@ public class WorkerLifeCycle {
         }
 
         ArrayList<String> argl = new ArrayList<>();
-        List<String> envp =
+        ArrayList<String> envp = new ArrayList<>();
+        envp.addAll(
                 Arrays.asList(
                         EnvironmentUtils.getEnvString(
                                 workingDir.getAbsolutePath(),
                                 modelPath.getAbsolutePath(),
-                                model.getModelArchive().getManifest().getModel().getHandler()));
+                                model.getModelArchive().getManifest().getModel().getHandler())));
 
         if (model.getParallelLevel() > 1) {
             attachRunner(argl, envp, port, deviceIds);
@@ -201,7 +202,7 @@ public class WorkerLifeCycle {
         } else {
             argl.add(String.format("localhost:%d", port));
         }
-        argl.add("--rdzv_id=");
+        argl.add("--rdzv_id");
         argl.add(String.format("%s_%d", model.getModelName(), port));
         if (torchRun.getMasterAddr() != null) {
             argl.add("--master-addr");

--- a/frontend/server/src/main/java/org/pytorch/serve/wlm/WorkerLifeCycle.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/wlm/WorkerLifeCycle.java
@@ -150,6 +150,7 @@ public class WorkerLifeCycle {
             String[] args = argl.toArray(new String[argl.size()]);
             String[] envs = envp.toArray(new String[envp.size()]);
             logger.debug("Worker cmdline: {}", argl.toString());
+            logger.debug("Worker environment: {}", envp.toString());
 
             synchronized (this) {
                 process = Runtime.getRuntime().exec(args, envs, modelPath);
@@ -193,7 +194,7 @@ public class WorkerLifeCycle {
         argl.add("--max_restarts");
         argl.add(String.valueOf(torchRun.getMaxRestarts()));
         argl.add("--log_dir");
-        argl.add("/tmp/torchelastic_ts");
+        argl.add(ConfigManager.getInstance().getTorchRunLogDir());
         argl.add("--rdzv_backend");
         argl.add(torchRun.getRdzvBackend());
         argl.add("--rdzv_endpoint");

--- a/frontend/server/src/main/java/org/pytorch/serve/wlm/WorkerThread.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/wlm/WorkerThread.java
@@ -515,7 +515,7 @@ public class WorkerThread implements Runnable {
 
     private String getDeviceIds() {
         List<Integer> deviceIds;
-        if (gpuId == -1) {
+        if (gpuId == -1 || model.getParallelLevel() == 1) {
             return null;
         } else if (model.isHasCfgDeviceIds()) {
             return model.getDeviceIds().subList(gpuId, gpuId + model.getParallelLevel()).stream()

--- a/model-archiver/README.md
+++ b/model-archiver/README.md
@@ -164,16 +164,20 @@ For more details refer [default handler documentation](../docs/default_handlers.
 A model config yaml file. For example: 
 
 ```
-# TS Frontend parameters
+# TS frontend parameters
+# See all supported parameters: https://github.com/pytorch/serve/blob/master/frontend/archive/src/main/java/org/pytorch/serve/archive/model/ModelConfig.java#L14 
 minWorkers: 1 # default: #CPU or #GPU
 maxWorkers: 1 # default: #CPU or #GPU
 batchSize: 1 # default: 1
 maxBatchDelay: 100 # default: 100 msec
 responseTimeout: 120 # default: 120 sec
 deviceType: cpu # cpu, gpu, neuron
-deviceIds: [0,1,2,3] # device index for gpu, neuron. Default: all visible devices
-parallelLevel: 4 # rpc world size. Default: 1
+deviceIds: [0,1,2,3] # gpu device ids allocated to this model. 
 parallelType: pp # pp: pipeline parallel; pptp: tensor+pipeline parallel. Default: empty
+
+# See torchrun parameters: https://pytorch.org/docs/stable/elastic/run.html
+torchrun:
+  nproc-per-node: 2
 
 # TS backend parameters
 pippy:

--- a/ts/service.py
+++ b/ts/service.py
@@ -40,23 +40,6 @@ class Service(object):
                     os.path.join(model_dir, model_yaml_config_file)
                 )
 
-        parallelLevel = 1
-        if (
-            "parallelLevel" in model_yaml_config
-            and type(model_yaml_config["parallelLevel"]) is int
-            and int(model_yaml_config["parallelLevel"]) > 1
-        ):
-            parallelLevel = int(model_yaml_config["parallelLevel"])
-
-        # devicedIds in model config yaml file
-        if type(gpu) is int and gpu >= 1000:
-            if parallelLevel == 1:
-                gpu = int(model_yaml_config["deviceIds"][gpu % 1000])
-            else:
-                gpu = gpu % 1000
-        elif "deviceIds" in model_yaml_config:
-            del model_yaml_config["deviceIds"]
-
         self._context = Context(
             model_name,
             model_dir,

--- a/ts_scripts/spellcheck_conf/wordlist.txt
+++ b/ts_scripts/spellcheck_conf/wordlist.txt
@@ -1030,3 +1030,5 @@ LLMs
 MPS
 mps
 deviceIds
+rpc
+pippy

--- a/ts_scripts/spellcheck_conf/wordlist.txt
+++ b/ts_scripts/spellcheck_conf/wordlist.txt
@@ -1029,3 +1029,4 @@ StreamPredictions
 LLMs
 MPS
 mps
+deviceIds


### PR DESCRIPTION
## Description

Please read our [CONTRIBUTING.md](https://github.com/pytorch/serve/blob/master/CONTRIBUTING.md) prior to creating your first pull request.

Please include a summary of the feature or issue being fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

- support torchrun parameters in model config yaml file.
- support gpu assignment "deviceIds" in model config yaml file.
- update doc about model config and gpu assignment algorithm.
- set torchrun log-dir under logs

Fixes #(issue)
#2207 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- test gpu assignment
```
cat model-store/t/model-config.yaml
minWorkers: 1
maxWorkers: 1
maxBatchDelay: 100
responseTimeout: 120
parallelType: "pp"
deviceType: "gpu"
deviceIds: [2,3]

torchrun:
    nproc-per-node: 2

pippy:
    rpc_timeout: 1800
```
1. model-config.yaml
2. log
```
2023-03-30T23:45:17,829 [INFO ] W-29500-bloom_1.0-stdout MODEL_LOG - [PID]67915
2023-03-30T23:45:17,830 [INFO ] W-29500-bloom_1.0-stdout MODEL_LOG - Torch worker started.
2023-03-30T23:45:17,830 [INFO ] W-29500-bloom_1.0-stdout MODEL_LOG - Python runtime: 3.8.16
2023-03-30T23:45:17,830 [DEBUG] W-29500-bloom_1.0 org.pytorch.serve.wlm.WorkerThread - W-29500-bloom_1.0 State change null -> WORKER_STARTED
2023-03-30T23:45:17,830 [DEBUG] W-29500-bloom_1.0 org.pytorch.serve.wlm.WorkerThread - W-29500-bloom_1.0 State change null -> WORKER_STARTED
2023-03-30T23:45:17,834 [INFO ] W-29500-bloom_1.0 org.pytorch.serve.wlm.WorkerThread - Connecting to: /tmp/.ts.sock.29500
2023-03-30T23:45:17,834 [INFO ] W-29500-bloom_1.0 org.pytorch.serve.wlm.WorkerThread - Connecting to: /tmp/.ts.sock.29500
2023-03-30T23:45:17,840 [INFO ] W-29500-bloom_1.0-stdout MODEL_LOG - Connection accepted: /tmp/.ts.sock.29500.
2023-03-30T23:45:17,840 [INFO ] W-29500-bloom_1.0 org.pytorch.serve.wlm.WorkerThread - Connecting to: /tmp/.ts.sock.29501
2023-03-30T23:45:17,840 [INFO ] W-29500-bloom_1.0 org.pytorch.serve.wlm.WorkerThread - Connecting to: /tmp/.ts.sock.29501
2023-03-30T23:45:17,842 [INFO ] W-29500-bloom_1.0-stdout MODEL_LOG - Connection accepted: /tmp/.ts.sock.29501.
2023-03-30T23:45:17,843 [INFO ] W-29500-bloom_1.0 org.pytorch.serve.wlm.WorkerThread - Flushing req.cmd LOAD to backend at: 1680219917843
2023-03-30T23:45:17,843 [INFO ] W-29500-bloom_1.0 org.pytorch.serve.wlm.WorkerThread - Flushing req.cmd LOAD to backend at: 1680219917843
2023-03-30T23:45:17,858 [INFO ] W-29500-bloom_1.0-stdout MODEL_LOG - model_name: bloom, batchSize: 1
2023-03-30T23:45:17,864 [INFO ] W-29500-bloom_1.0-stdout MODEL_LOG - model_name: bloom, batchSize: 1
2023-03-30T23:45:18,439 [INFO ] W-29500-bloom_1.0-stdout MODEL_LOG - Transformers version 4.27.4
2023-03-30T23:45:18,440 [INFO ] W-29500-bloom_1.0-stdout MODEL_LOG - CUDA_VISIBLE_DEVICES=2,3
2023-03-30T23:45:18,440 [INFO ] W-29500-bloom_1.0-stdout MODEL_LOG - Transformers version 4.27.4
2023-03-30T23:45:18,440 [INFO ] W-29500-bloom_1.0-stdout MODEL_LOG - CUDA_VISIBLE_DEVICES=2,3
2023-03-30T23:45:18,470 [INFO ] W-29500-bloom_1.0-stdout MODEL_LOG - n_devs=2
2023-03-30T23:45:18,471 [INFO ] W-29500-bloom_1.0-stdout MODEL_LOG - worker0, 1: 0
2023-03-30T23:45:18,471 [INFO ] W-29500-bloom_1.0-stdout MODEL_LOG - worker1, 1: 1
2023-03-30T23:45:18,471 [INFO ] W-29500-bloom_1.0-stdout MODEL_LOG - rank = 1 pid/device = 67916/cuda:1
2023-03-30T23:45:18,472 [INFO ] W-29500-bloom_1.0-stdout MODEL_LOG - n_devs=2
2023-03-30T23:45:18,472 [INFO ] W-29500-bloom_1.0-stdout MODEL_LOG - worker0, 0: 0
2023-03-30T23:45:18,472 [INFO ] W-29500-bloom_1.0-stdout MODEL_LOG - worker1, 0: 1
2023-03-30T23:45:18,473 [INFO ] W-29500-bloom_1.0-stdout MODEL_LOG - rank = 0 pid/device = 67915/cuda:0
2023-03-30T23:45:18,859 [INFO ] W-29500-bloom_1.0-stdout MODEL_LOG - rpc.timeout=1800
2023-03-30T23:45:18,859 [INFO ] W-29500-bloom_1.0-stdout MODEL_LOG - rpc.timeout=1800
```



## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?