### PR TITLE
Enable `torch.compile` support for torch 2.0.0 pre release

### DIFF
--- a/ts/torch_handler/base_handler.py
+++ b/ts/torch_handler/base_handler.py
@@ -37,7 +37,7 @@ except ImportError as error:
     XLA_AVAILABLE = False
 
 
-if packaging.version.parse(torch.__version__) >= packaging.version.parse("2.0.0"):
+if packaging.version.parse(torch.__version__) >= packaging.version.parse("2.0.0a"):
     PT2_AVAILABLE = True
     if torch.cuda.is_available():
         # If Ampere enable tensor cores which will give better performance


### PR DESCRIPTION
We are currently locked on an alpha version of torch 2.0.0. TorchServe (HEAD) was working for us before the PT2 refactor when the `base_handler` was deciding PT2, as below:
```
    try:
        import torch._dynamo

        pt2_enabled = True
```
Creating a minor PR for enable torch2.0.0 alpha pre release to use torch.compile. 