### PR TITLE
Notify regression failure on weekdays only

### DIFF
--- a/.github/workflows/regression_tests_cpu.yml
+++ b/.github/workflows/regression_tests_cpu.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Torchserve Regression Tests
         run: |
           python test/regression_tests.py
-      - name: Open issue on failure
-        if: ${{ failure() && github.event_name  == 'schedule' }}
+      - name: Open issue on failure (weekday only)
+        if: ${{ failure() && github.event_name == 'schedule' && steps.regression-cpu.outputs.day_of_week != 'Saturday' && steps.regression-cpu.outputs.day_of_week != 'Sunday' }}
         uses: dacbd/create-issue-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/regression_tests_gpu.yml
+++ b/.github/workflows/regression_tests_gpu.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Torchserve Regression Tests
         run: |
           python test/regression_tests.py
-      - name: Open issue on failure
-        if: ${{ failure() && github.event_name  == 'schedule' }}
+      - name: Open issue on failure (weekday only)
+        if: ${{ failure() && github.event_name == 'schedule' && steps.regression-cpu.outputs.day_of_week != 'Saturday' && steps.regression-cpu.outputs.day_of_week != 'Sunday' }}
         uses: dacbd/create-issue-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Alternative is notification spam

![image](https://user-images.githubusercontent.com/3282513/235316588-a79eea1b-cef5-4c43-8316-e57060dd2cfd.png)
