### PR TITLE
Upgrade transformers version

### DIFF
--- a/requirements/developer.txt
+++ b/requirements/developer.txt
@@ -7,7 +7,7 @@ pytest-cov
 grpcio
 protobuf
 grpcio-tools
-transformers==4.25.1
+transformers==4.28.1
 pyspelling
 pygit2
 pyspelling


### PR DESCRIPTION
## Description
Upgrade `transformers` package version to `4.28.1`

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Feature/Issue validation/testing

- [ ] Sanity test as part of CI
- [ ] Regression tests
  - CPU: [cpu_regression_log.txt](https://github.com/pytorch/serve/files/11408540/cpu_regression_log.txt) Pass
  - GPU: [gpu_regression_log.txt](https://github.com/pytorch/serve/files/11408543/gpu_regression_log.txt)
    - `test_sm_mme_requirements.py::test_oom_on_model_load` and `test_sm_mme_requirements.py::test_oom_on_invoke` fail. This is expected because of the different instance type the regression test was run on.
- [ ] Manual test with [Huggingface transformers sequence classification example](https://github.com/pytorch/serve/tree/master/examples/Huggingface_Transformers)
  - CPU:
    - `2023-05-05T17:20:44,927 [INFO ] W-9001-bert_1.0-stdout MODEL_LOG - This the output from the Seq classification model SequenceClassifierOutput(loss=None, logits=tensor([[ 0.5240, -0.4551]], grad_fn=<AddmmBackward0>), hidden_states=None, attentions=None)`
    - `2023-05-05T17:20:44,927 [INFO ] W-9001-bert_1.0-stdout MODEL_LOG - Generated text ['Not Accepted']`  
  - GPU:
    - `2023-05-05T17:28:21,131 [INFO ] W-9000-bert_1.0-stdout MODEL_LOG - This the output from the Seq classification model SequenceClassifierOutput(loss=None, logits=tensor([[ 0.5240, -0.4551]], device='cuda:1', grad_fn=<AddmmBackward0>), hidden_states=None, attentions=None)`
    - `2023-05-05T17:28:21,131 [INFO ] W-9000-bert_1.0-stdout MODEL_LOG - Generated text ['Not Accepted']`