### PR TITLE
fix tcp port in model_service_worker.py

### DIFF
--- a/frontend/archive/src/main/java/org/pytorch/serve/archive/model/ModelConfig.java
+++ b/frontend/archive/src/main/java/org/pytorch/serve/archive/model/ModelConfig.java
@@ -339,7 +339,6 @@ public class ModelConfig {
         private String rdzvEndpoint;
         private String rdzvBackend = "c10d";
         private String rdzvConf;
-        private int maxRestarts = 3;
         private int monitorInterval = 5;
         private int nodeRank;
         private String masterAddr;
@@ -388,13 +387,6 @@ public class ModelConfig {
                                     logger.warn("Invalid torchrun.rdzv-conf:{}", v);
                                 }
                                 break;
-                            case "max-restarts":
-                                if (v instanceof Integer) {
-                                    torchRun.setMaxRestarts((Integer) v);
-                                } else {
-                                    logger.warn("Invalid torchrun.max-restarts:{}, reset to 3", v);
-                                }
-                                break;
                             case "monitor-interval":
                                 if (v instanceof Integer) {
                                     torchRun.setMonitorInterval((Integer) v);
@@ -417,6 +409,7 @@ public class ModelConfig {
                                 }
                                 break;
                             default:
+                                logger.warn("unsupported parameter {}", k);
                                 break;
                         }
                     });
@@ -477,18 +470,6 @@ public class ModelConfig {
 
         public void setRdzvConf(String rdzvConf) {
             this.rdzvConf = rdzvConf;
-        }
-
-        public int getMaxRestarts() {
-            return maxRestarts;
-        }
-
-        public void setMaxRestarts(int maxRestarts) {
-            if (maxRestarts <= 0) {
-                logger.warn("Invalid torchrun.max-restarts:{}, reset to 3", maxRestarts);
-                return;
-            }
-            this.maxRestarts = maxRestarts;
         }
 
         public int getMonitorInterval() {

--- a/frontend/server/src/main/java/org/pytorch/serve/wlm/WorkerLifeCycle.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/wlm/WorkerLifeCycle.java
@@ -195,21 +195,17 @@ public class WorkerLifeCycle {
         argl.add("torchrun");
         argl.add("--nnodes");
         argl.add(String.valueOf(torchRun.getNnodes()));
-        argl.add("--nproc_per_node");
+        argl.add("--nproc-per-node");
         argl.add(String.valueOf(torchRun.getNprocPerNode()));
-        argl.add("--max_restarts");
-        argl.add(String.valueOf(torchRun.getMaxRestarts()));
-        argl.add("--log_dir");
+        argl.add("--log-dir");
         argl.add(ConfigManager.getInstance().getTorchRunLogDir());
-        argl.add("--rdzv_backend");
+        argl.add("--rdzv-backend");
         argl.add(torchRun.getRdzvBackend());
-        argl.add("--rdzv_endpoint");
         if (torchRun.getRdzvEndpoint() != null) {
+            argl.add("--rdzv-endpoint");
             argl.add(torchRun.getRdzvEndpoint());
-        } else {
-            argl.add(String.format("localhost:%d", port));
         }
-        argl.add("--rdzv_id");
+        argl.add("--rdzv-id");
         argl.add(String.format("%s_%d", model.getModelName(), port));
         if (torchRun.getMasterAddr() != null) {
             argl.add("--master-addr");

--- a/ts/model_service_worker.py
+++ b/ts/model_service_worker.py
@@ -61,16 +61,16 @@ class TorchModelServiceWorker(object):
                     raise RuntimeError(
                         "socket already in use: {}.".format(s_name_new)
                     ) from e
-
+            logging.info("Listening on port: %s", s_name_new)
         elif s_type == "tcp":
             self.sock_name = host_addr if host_addr is not None else "127.0.0.1"
             if port_num is None:
                 raise ValueError("Wrong arguments passed. No socket port given.")
             self.port = int(port_num) + LOCAL_RANK
+            logging.info("Listening on addr:port: %s:%d", self.sock_name, self.port)
         else:
             raise ValueError("Incomplete data provided")
 
-        logging.info("Listening on port: %s", s_name)
         socket_family = socket.AF_INET if s_type == "tcp" else socket.AF_UNIX
         self.sock = socket.socket(socket_family, socket.SOCK_STREAM)
         self.metrics_cache = MetricsCacheYamlImpl(config_file_path=metrics_config)

--- a/ts/model_service_worker.py
+++ b/ts/model_service_worker.py
@@ -66,7 +66,7 @@ class TorchModelServiceWorker(object):
             self.sock_name = host_addr if host_addr is not None else "127.0.0.1"
             if port_num is None:
                 raise ValueError("Wrong arguments passed. No socket port given.")
-            self.port = port_num + LOCAL_RANK
+            self.port = int(port_num) + LOCAL_RANK
         else:
             raise ValueError("Incomplete data provided")
 


### PR DESCRIPTION
## Description

Please read our [CONTRIBUTING.md](https://github.com/pytorch/serve/blob/master/CONTRIBUTING.md) prior to creating your first pull request.

Please include a summary of the feature or issue being fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #(issue)
#2368 #2349 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- Test
 torchserve --ncs --start --model-store model_store/ --models opt-30b-pippy.mar --ts-config benchmarks/config.properties

```config.properties
inference_address=http://0.0.0.0:8080
management_address=http://0.0.0.0:8081

number_of_netty_threads=32
job_queue_size=1000

vmargs=-Xmx4g -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError
prefer_direct_buffer=True

default_response_timeout=300
unregister_model_timeout=300
install_py_dep_per_model=true
default_workers_per_model=1
use_native_io=false
```
```log
2023-06-01T06:16:40,278 [DEBUG] W-29500-opt-30b-pippy_1.0 org.pytorch.serve.wlm.WorkerLifeCycle - Worker cmdline: [torchrun, --nnodes, 1, --nproc-per-node, 4, --log-dir, /home/ubuntu/serve/logs/torchelastic_ts, --rdzv-backend, c10d, --rdzv-id, opt-30b-pippy_29500, --max-restarts, 1, /opt/conda/envs/py38/lib/python3.8/site-packages/ts/model_service_worker.py, --sock-type, tcp, --port, 29500, --metrics-config, /opt/conda/envs/py38/lib/python3.8/site-packages/ts/configs/metrics.yaml]
```

curl "http://localhost:8081/models"
2023-06-01T06:22:13,177 [INFO ] nioEventLoopGroup-3-1 ACCESS_LOG - /127.0.0.1:52714 "GET /models HTTP/1.1" 200 6
2023-06-01T06:22:13,177 [INFO ] nioEventLoopGroup-3-1 TS_METRICS - Requests2XX.Count:1.0|#Level:Host|#hostname:ip-172-31-6-222,timestamp:1685600533
{
  "models": [
    {
      "modelName": "opt-30b-pippy",
      "modelUrl": "opt-30b-pippy.mar"
    }
  ]
}

## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?