### PR TITLE
workaround solution for archiver tgz format on SageMaker

### DIFF
--- a/frontend/archive/src/main/java/org/pytorch/serve/archive/model/ModelArchive.java
+++ b/frontend/archive/src/main/java/org/pytorch/serve/archive/model/ModelArchive.java
@@ -80,15 +80,28 @@ public class ModelArchive {
             }
         }
 
-        if (new File(url).isDirectory()) {
+        File directory = new File(url);
+        if (directory.isDirectory()) {
             // handle the case that the input url is a directory.
             // the input of url is "/xxx/model_store/modelXXX" or
             // "xxxx/yyyyy/modelXXX".
-            return load(url, new File(url), false);
+            File[] fileList = directory.listFiles();
+            if (fileList.length == 1 && fileList[0].isDirectory()) {
+                // handle the case that a model tgz file
+                // has root dir after decompression on SageMaker
+                return load(url, fileList[0], false);
+            }
+            return load(url, directory, false);
         } else if (modelLocation.exists()) {
             // handle the case that "/xxx/model_store/modelXXX" is directory.
             // the input of url is modelXXX when torchserve is started
             // with snapshot or with parameter --models modelXXX
+            File[] fileList = modelLocation.listFiles();
+            if (fileList.length == 1 && fileList[0].isDirectory()) {
+                // handle the case that a model tgz file
+                // has root dir after decompression on SageMaker
+                return load(url, fileList[0], false);
+            }
             return load(url, modelLocation, false);
         }
 


### PR DESCRIPTION
## Description

Please read our [CONTRIBUTING.md](https://github.com/pytorch/serve/blob/master/CONTRIBUTING.md) prior to creating your first pull request.

Please include a summary of the feature or issue being fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Torchserve archiver add a root dir when it generates tgz archive format. For example.
```
torch-model-archiver --model-name mnist_scripted_v2 --version 2.0 --serialized-file mnist_script.pt --handler  mnist_handler.py --config-file model-config.yaml --archive-format tgz
=> mnist_scripted_v2.tar.gz

tar xvzf mnist_scripted_v2.tar.gz
=> mnist_scripted_v2

tree mnist_scripted_v2
mnist_scripted_v2
├── MAR-INF
│   └── MANIFEST.json
├── __pycache__
│   └── mnist_handler.cpython-38.pyc
├── mnist_handler.py
├── mnist_script.pt
└── model-config.yam
```

SageMaker put dir `mnist_scripted_v2` under /opt/ml/model. So the dir structure is as following.
```
/opt/ml/model/mnist_scripted_v2
├── MAR-INF
│   └── MANIFEST.json
├── __pycache__
│   └── mnist_handler.cpython-38.pyc
├── mnist_handler.py
├── mnist_script.pt
└── model-config.yam
```
However, SageMaker starts torchserve using the following command. It cause the wrong model dir passed to torchserve.
```
torchserve --ncs --start --model-store model_store --models model
```
Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- Test
```
torch-model-archiver --model-name mnist_scripted_v2 --version 2.0 --serialized-file mnist_script.pt --handler  mnist_handler.py --config-file model-config.yaml --archive-format tgz
=> mnist_scripted_v2.tar.gz

tar xvzf mnist_scripted_v2.tar.gz

mkdir -p model_store/model
mv mnist_scripted_v model_store/model/

 torchserve --ncs --start --model-store model_store --models model

curl "http://localhost:8081/models"
{
  "models": [
    {
      "modelName": "mnist_scripted_v2",
      "modelUrl": "mme_mnist"
    }
  ]
}
```


## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?