### PR TITLE
Publish torchserve-plugins-sdk artifacts to Maven Central repository

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -43,14 +43,6 @@ jobs:
           retry_on: error
           command: |
             python torchserve_sanity.py
-      - name: mvn install - unix
-        if: matrix.os != 'windows-latest'
-        run: |
-            cd serving-sdk/ && ./mvnw clean install -q && cd ../
-      - name: mvn install - windows
-        if: matrix.os == 'windows-latest'
-        run: |
-            cd serving-sdk/ && .\mvnw.cmd clean install -q && cd ../
       # Any coverage.xml will be picked up by this step
       # Just make sure each coverage.xml is in a different folder
       - name: Upload codecov

--- a/.github/workflows/ci_gpu.yml
+++ b/.github/workflows/ci_gpu.yml
@@ -47,9 +47,6 @@ jobs:
           max_attempts: 3
           command: |
             python torchserve_sanity.py
-      - name: mvn install
-        run: |
-            cd serving-sdk/ && ./mvnw clean install -q && cd ../
 
       # Any coverage.xml will be picked up by this step
       # Just make sure each coverage.xml is in a different folder

--- a/frontend/build.gradle
+++ b/frontend/build.gradle
@@ -19,8 +19,6 @@ allprojects {
 
     repositories {
         mavenCentral()
-        jcenter()
-        mavenLocal()
     }
 
     apply plugin: 'idea'

--- a/serving-sdk/pom.xml
+++ b/serving-sdk/pom.xml
@@ -33,7 +33,7 @@
   <url>http://maven.apache.org</url>
   <properties>
     <repo_url>file://${project.build.directory}/repo</repo_url>
-    <skip.gpg>false</skip.gpg>
+    <skip.gpg>true</skip.gpg>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
@@ -69,6 +69,10 @@
           <skip>${skip.gpg}</skip>
           <keyname>${gpg.keyname}</keyname>
           <passphrase>${gpg.passphrase}</passphrase>
+          <gpgArguments>
+            <arg>--pinentry-mode</arg>
+            <arg>loopback</arg>
+          </gpgArguments>
         </configuration>
         <executions>
           <execution>
@@ -120,7 +124,7 @@
           <execution>
             <id>attach-sources</id>
             <goals>
-              <goal>jar</goal>
+              <goal>jar-no-fork</goal>
             </goals>
           </execution>
         </executions>
@@ -157,8 +161,8 @@
         <extensions>true</extensions>
         <configuration>
           <serverId>ossrh</serverId>
-          <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>false</autoReleaseAfterClose>
         </configuration>
       </plugin>
     </plugins>
@@ -167,7 +171,11 @@
   <distributionManagement>
     <snapshotRepository>
       <id>ossrh</id>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
     </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
   </distributionManagement>
 </project>

--- a/serving-sdk/pom.xml
+++ b/serving-sdk/pom.xml
@@ -24,6 +24,12 @@
     </developer>
   </developers>
 
+  <scm>
+    <connection>scm:git:git://github.com/pytorch/serve.git</connection>
+    <developerConnection>scm:git:ssh://github.com:pytorch/serve.git</developerConnection>
+    <url>https://github.com/pytorch/serve</url>
+  </scm>
+
   <url>http://maven.apache.org</url>
   <properties>
     <repo_url>file://${project.build.directory}/repo</repo_url>
@@ -142,14 +148,24 @@
           <target>8</target>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.13</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>ossrh</serverId>
+          <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 
   <distributionManagement>
-    <repository>
-      <id>central</id>
-      <name>pytorch-maven</name>
-      <url>https://repo1.maven.org/maven2/org/pytorch/torchserve_plugins_sdk/</url>
-    </repository>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
   </distributionManagement>
 </project>

--- a/serving-sdk/pom.xml
+++ b/serving-sdk/pom.xml
@@ -33,7 +33,7 @@
   <url>http://maven.apache.org</url>
   <properties>
     <repo_url>file://${project.build.directory}/repo</repo_url>
-    <skip.gpg>true</skip.gpg>
+    <skip.gpg>false</skip.gpg>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
@@ -67,6 +67,8 @@
         <version>1.6</version>
         <configuration>
           <skip>${skip.gpg}</skip>
+          <keyname>${gpg.keyname}</keyname>
+          <passphrase>${gpg.passphrase}</passphrase>
         </configuration>
         <executions>
           <execution>

--- a/serving-sdk/pom.xml
+++ b/serving-sdk/pom.xml
@@ -147,9 +147,9 @@
 
   <distributionManagement>
     <repository>
-      <id>bintray-pytorch-maven</id>
+      <id>central</id>
       <name>pytorch-maven</name>
-      <url>https://api.bintray.com/maven/pytorch/maven/org.pytorch:torchserve_plugins_sdk/</url>
+      <url>https://repo1.maven.org/maven2/org/pytorch/torchserve_plugins_sdk/</url>
     </repository>
   </distributionManagement>
 </project>

--- a/ts_scripts/install_dependencies.py
+++ b/ts_scripts/install_dependencies.py
@@ -81,9 +81,6 @@ class Common:
     def install_numactl(self):
         pass
 
-    def install_torchserve_plugins_sdk(self):
-        pass
-
 
 class Linux(Common):
     def __init__(self):
@@ -113,9 +110,6 @@ class Linux(Common):
         if os.system("numactl --show") != 0 or args.force:
             os.system(f"{self.sudo_cmd}apt-get install -y numactl")
 
-    def install_torchserve_plugins_sdk(self):
-        os.system(f"cd {REPO_ROOT}/serving-sdk/ && ./mvnw clean install -q && cd ../")
-
 
 class Windows(Common):
     def __init__(self):
@@ -133,11 +127,6 @@ class Windows(Common):
 
     def install_numactl(self):
         pass
-
-    def install_torchserve_plugins_sdk(self):
-        os.system(
-            f"cd {REPO_ROOT}/serving-sdk/ && .\mvnw.cmd clean install -q && cd ../"
-        )
 
 
 class Darwin(Common):
@@ -167,9 +156,6 @@ class Darwin(Common):
         if os.system("numactl --show") != 0 or args.force:
             os.system("brew install numactl")
 
-    def install_torchserve_plugins_sdk(self):
-        os.system(f"cd {REPO_ROOT}/serving-sdk/ && ./mvnw clean install -q && cd ../")
-
 
 def install_dependencies(cuda_version=None, nightly=False):
     os_map = {"Linux": Linux, "Windows": Windows, "Darwin": Darwin}
@@ -180,7 +166,6 @@ def install_dependencies(cuda_version=None, nightly=False):
         system.install_nodejs()
         system.install_node_packages()
         system.install_numactl()
-        system.install_torchserve_plugins_sdk()
 
     # Sequence of installation to be maintained
     system.install_java()


### PR DESCRIPTION
## Description

Sanity in CI currently fails with the following error:
```
A problem occurred evaluating project ':server'.
> Could not resolve all files for configuration ':server:runtimeClasspath'.
   > Could not find org.pytorch:torchserve-plugins-sdk:0.0.4.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/org/pytorch/torchserve-plugins-sdk/0.0.4/torchserve-plugins-sdk-0.0.4.pom
       - https://jcenter.bintray.com/org/pytorch/torchserve-plugins-sdk/0.0.4/torchserve-plugins-sdk-0.0.4.pom
     Required by:
         project :server
```

The `torchserve-plugins-sdk` artifacts are currently unavailable via JCenter or Maven Central repositories.

### The fix (Reference: https://central.sonatype.org/publish/publish-maven):
- Update the `distributionManagement` definition in `torchserve-plugins-sdk` `pom.xml` to point to Sonatype OSSRH repo.
- Update the `torchserve-plugins-sdk` version used as dependencies since the current version being built is `0.0.5`
- Add `nexus-staging-maven-plugin` to `pom.xml`
- Configure maven settings on the host used to deploy to nexus OSSRH
```
<settings>
  <servers>
    <server>
      <id>ossrh</id>
      <username>your-ossrh-user-id</username>
      <password>your-ossrh-pwd</password>
    </server>
  </servers>
  <profiles>
    <profile>
      <id>ossrh_deploy</id>
      <activation>
        <activeByDefault>true</activeByDefault>
      </activation>
      <properties>
        <skip.gpg>false</skip.gpg>
        <gpg.keyname>your-gpg-keyname</gpg.keyname>
        <gpg.passphrase>your-gpg-passphrase</gpg.passphrase>
      </properties>
    </profile>
  </profiles>
</settings>
```
- Publish artifacts to maven central repository:
  - `cd serving-sdk`
  - `mvn clean deploy`
- Release artifacts from OSSRH account

#### In addition to publishing the `torchserve-plugins-sdk` artifacts to maven central, this PR also includes:
- Revert prior workaround to build and install `torchserve-plugins-sdk` locally: https://github.com/pytorch/serve/pull/2429
- Disable building and installing `torchserve-plugins-sdk` locally in GPU and CPU CI workflows
- Remove dependence on `JCenter` to fetch dependency build artifacts

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests
- `torchserve-plugins-sdk` artifacts have been released and are now available on maven central repository: https://repo1.maven.org/maven2/org/pytorch/torchserve-plugins-sdk/0.0.5/
- Successful CI workflow runs shown below