### PR TITLE
Update nvidia base image version

### DIFF
--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -43,7 +43,7 @@ do
         -g|--gpu)
           MACHINE=gpu
           DOCKER_TAG="pytorch/torchserve:latest-gpu"
-          BASE_IMAGE="nvidia/cuda:11.7.0-base-ubuntu20.04"
+          BASE_IMAGE="nvidia/cuda:11.7.1-base-ubuntu20.04"
           CUDA_VERSION="cu117"
           shift
           ;;
@@ -85,7 +85,7 @@ do
             BASE_IMAGE="nvidia/cuda:11.8.0-base-ubuntu20.04"
           elif [ "${CUDA_VERSION}" == "cu117" ];
           then
-            BASE_IMAGE="nvidia/cuda:11.7.0-base-ubuntu20.04"
+            BASE_IMAGE="nvidia/cuda:11.7.1-base-ubuntu20.04"
           elif [ "${CUDA_VERSION}" == "cu116" ];
           then
             BASE_IMAGE="nvidia/cuda:11.6.0-cudnn8-runtime-ubuntu20.04"


### PR DESCRIPTION
## Description

Nightly docker builds are failing because NVIDIA has deprecated `nvidia/cuda:11.7.0-base-ubuntu20.04`

Updated to `nvidia/cuda:11.7.1-base-ubuntu20.04`


Fixes #([issue](https://github.com/pytorch/serve/issues/2439))

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

```
[+] Building 254.9s (24/24) FINISHED                                                                                                                                                      
 => [internal] load build definition from Dockerfile                                                                                                                                 0.0s
 => => transferring dockerfile: 4.97kB                                                                                                                                               0.0s
 => [internal] load .dockerignore                                                                                                                                                    0.0s
 => => transferring context: 2B                                                                                                                                                      0.0s
 => resolve image config for docker.io/docker/dockerfile:experimental                                                                                                                0.5s
 => CACHED docker-image://docker.io/docker/dockerfile:experimental@sha256:600e5c62eedff338b3f7a0850beb7c05866e0ef27b2d2e8c02aa468e78496ff5                                           0.0s
 => [internal] load metadata for docker.io/nvidia/cuda:11.7.1-base-ubuntu20.04                                                                                                       0.0s
 => [compile-image 1/9] FROM docker.io/nvidia/cuda:11.7.1-base-ubuntu20.04                                                                                                           0.1s
 => [internal] load build context                                                                                                                                                    0.1s
 => => transferring context: 541B                                                                                                                                                    0.0s
 => [compile-image 2/9] RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt     apt-get update &&     apt-get upgrade -y &&     apt-get install software-properties-common -y   97.8s
 => [runtime-image 2/9] RUN --mount=type=cache,target=/var/cache/apt     apt-get update &&     apt-get upgrade -y &&     apt-get install software-properties-common -y &&     add  104.5s
 => [compile-image 3/9] RUN python3.9 -m venv /home/venv                                                                                                                             3.0s
 => [compile-image 4/9] RUN python -m pip install -U pip setuptools                                                                                                                  3.4s
 => [compile-image 5/9] RUN export USE_CUDA=1                                                                                                                                        0.6s
 => [runtime-image 3/9] RUN useradd -m model-server     && mkdir -p /home/model-server/tmp                                                                                           0.5s
 => [compile-image 6/9] RUN git clone --depth 1 https://github.com/pytorch/serve.git                                                                                                 2.9s 
 => [compile-image 7/9] WORKDIR serve                                                                                                                                                0.0s 
 => [compile-image 8/9] RUN     if echo "nvidia/cuda:11.7.1-base-ubuntu20.04" | grep -q "cuda:"; then         if [ "cu117" ]; then             python ./ts_scripts/install_depende  97.3s 
 => [compile-image 9/9] RUN python -m pip install --no-cache-dir torchserve torch-model-archiver torch-workflow-archiver                                                             2.6s 
 => [runtime-image 4/9] COPY --chown=model-server --from=compile-image /home/venv /home/venv                                                                                        18.2s 
 => [runtime-image 5/9] COPY dockerd-entrypoint.sh /usr/local/bin/dockerd-entrypoint.sh                                                                                              0.0s 
 => [runtime-image 6/9] RUN chmod +x /usr/local/bin/dockerd-entrypoint.sh     && chown -R model-server /home/model-server                                                            0.3s 
 => [runtime-image 7/9] COPY config.properties /home/model-server/config.properties                                                                                                  0.0s 
 => [runtime-image 8/9] RUN mkdir /home/model-server/model-store && chown -R model-server /home/model-server/model-store                                                             0.3s 
 => [runtime-image 9/9] WORKDIR /home/model-server                                                                                                                                   0.0s 
 => exporting to image                                                                                                                                                              15.9s
 => => exporting layers                                                                                                                                                             15.9s
 => => writing image sha256:13fb4e3a44336125d1d03d01ceb4d27b7a52b0b5a13c7b2e45e36aed48b9ce50                                                                                         0.0s
 => => naming to docker.io/pytorch/ts-nightly:latest 
```

## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?