### PR TITLE
Added arg to build docker with torchserve nightly

### DIFF
--- a/.github/workflows/docker-nightly-build.yml
+++ b/.github/workflows/docker-nightly-build.yml
@@ -1,7 +1,7 @@
 name: Push Docker Nightly
 
 on:
-  # run every day at 1:15am
+  # run every day at 1:15pm
   schedule:
     - cron:  '15 13 * * *'
 jobs:

--- a/.github/workflows/docker-nightly-build.yml
+++ b/.github/workflows/docker-nightly-build.yml
@@ -1,7 +1,7 @@
 name: Push Docker Nightly
 
 on:
-  # run every day at 11:15am
+  # run every day at 1:15am
   schedule:
     - cron:  '15 13 * * *'
 jobs:

--- a/.github/workflows/docker-nightly-build.yml
+++ b/.github/workflows/docker-nightly-build.yml
@@ -3,7 +3,7 @@ name: Push Docker Nightly
 on:
   # run every day at 11:15am
   schedule:
-    - cron:  '15 11 * * *'
+    - cron:  '15 13 * * *'
 jobs:
   nightly:
     runs-on: ubuntu-20.04

--- a/.github/workflows/regression_tests_docker.yml
+++ b/.github/workflows/regression_tests_docker.yml
@@ -35,12 +35,12 @@ jobs:
         if: contains(matrix.hardware, 'ubuntu')
         run: |
           cd docker
-          ./build_image.sh -bt ci -b $GITHUB_REF_NAME -t pytorch/torchserve:ci
+          ./build_image.sh -bt ci -n -b $GITHUB_REF_NAME -t pytorch/torchserve:ci
       - name: Build GPU Docker Image
         if: false == contains(matrix.hardware, 'ubuntu')
         run: |
           cd docker
-          ./build_image.sh -g -cv cu117 -bt ci -b $GITHUB_REF_NAME -t pytorch/torchserve:ci
+          ./build_image.sh -g -cv cu117 -bt ci -n -b $GITHUB_REF_NAME -t pytorch/torchserve:ci
       - name: Torchserve GPU Regression Tests
         if: false == contains(matrix.hardware, 'ubuntu')
         run: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,6 +30,7 @@ ARG PYTHON_VERSION=3.9
 FROM ${BASE_IMAGE} AS compile-image
 ARG BASE_IMAGE=ubuntu:rolling
 ARG PYTHON_VERSION
+ARG BUILD_NIGHTLY
 ENV PYTHONUNBUFFERED TRUE
 
 RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt \
@@ -82,7 +83,12 @@ RUN \
     fi
 
 # Make sure latest version of torchserve is uploaded before running this
-RUN python -m pip install --no-cache-dir torchserve torch-model-archiver torch-workflow-archiver
+RUN \
+    if echo "$BUILD_NIGHTLY" | grep -q "false"; then \
+        python -m pip install --no-cache-dir torchserve torch-model-archiver torch-workflow-archiver;\
+    else \
+        python -m pip install --no-cache-dir torchserve-nightly torch-model-archiver-nightly torch-workflow-archiver-nightly;\
+    fi
 
 # Final image for production
 FROM ${BASE_IMAGE} AS production-image
@@ -174,4 +180,5 @@ RUN mkdir /home/serve
 ENV TS_RUN_IN_DOCKER True
 
 WORKDIR /home/serve
-CMD ["python", "test/regression_tests.py"]
+#CMD ["python", "test/regression_tests.py"]
+CMD ["/bin/bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -180,5 +180,4 @@ RUN mkdir /home/serve
 ENV TS_RUN_IN_DOCKER True
 
 WORKDIR /home/serve
-#CMD ["python", "test/regression_tests.py"]
-CMD ["/bin/bash"]
+CMD ["python", "test/regression_tests.py"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -38,6 +38,7 @@ Use `build_image.sh` script to build the docker images. The script builds the `p
 |-t, --tag|Tag name for image. If not specified, script uses torchserve default tag names.|
 |-cv, --cudaversion| Specify to cuda version to use. Supported values `cu92`, `cu101`, `cu102`, `cu111`, `cu113`, `cu116`, `cu117`, `cu118`. Default `cu117`|
 |-ipex, --build-with-ipex| Specify to build with intel_extension_for_pytorch. If not specified, script builds without intel_extension_for_pytorch.|
+|-n, --nightly| Specify to build with TorchServe nightly.|
 |--codebuild| Set if you need [AWS CodeBuild](https://aws.amazon.com/codebuild/)|
 |-py, --pythonversion| Specify the python version to use. Supported values `3.8`, `3.9`, `3.10`. Default `3.9`|
 

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -11,6 +11,7 @@ USE_CUSTOM_TAG=false
 CUDA_VERSION=""
 USE_LOCAL_SERVE_FOLDER=false
 BUILD_WITH_IPEX=false
+BUILD_NIGHTLY=false
 PYTHON_VERSION=3.9
 
 for arg in "$@"
@@ -27,6 +28,7 @@ do
           echo "-lf, --use-local-serve-folder specify this option for the benchmark image if the current 'serve' folder should be used during automated benchmarks"
           echo "-ipex, --build-with-ipex specify to build with intel_extension_for_pytorch"
           echo "-py, --pythonversion specify to python version to use: Possible values: 3.8 3.9 3.10"
+          echo "-n, --nightly specify to build with TorchServe nightly"
           exit 0
           ;;
         -b|--branch_name)
@@ -64,6 +66,10 @@ do
           ;;
         -ipex|--build-with-ipex)
           BUILD_WITH_IPEX=true
+          shift
+          ;;
+        -n|--nightly)
+          BUILD_NIGHTLY=true
           shift
           ;;
         -py|--pythonversion)
@@ -137,10 +143,10 @@ fi
 
 if [ "${BUILD_TYPE}" == "production" ]
 then
-  DOCKER_BUILDKIT=1 docker build --file Dockerfile --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg CUDA_VERSION="${CUDA_VERSION}"  --build-arg PYTHON_VERSION="${PYTHON_VERSION}" -t "${DOCKER_TAG}" --target production-image  .
+  DOCKER_BUILDKIT=1 docker build --file Dockerfile --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg CUDA_VERSION="${CUDA_VERSION}"  --build-arg PYTHON_VERSION="${PYTHON_VERSION}" --build-arg BUILD_NIGHTLY="${BUILD_NIGHTLY}" -t "${DOCKER_TAG}" --target production-image  .
 elif [ "${BUILD_TYPE}" == "ci" ]
 then
-  DOCKER_BUILDKIT=1 docker build --file Dockerfile --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg CUDA_VERSION="${CUDA_VERSION}"  --build-arg PYTHON_VERSION="${PYTHON_VERSION}" --build-arg BRANCH_NAME="${BRANCH_NAME}"  -t "${DOCKER_TAG}" --target ci-image  .
+  DOCKER_BUILDKIT=1 docker build --file Dockerfile --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg CUDA_VERSION="${CUDA_VERSION}"  --build-arg PYTHON_VERSION="${PYTHON_VERSION}" --build-arg BUILD_NIGHTLY="${BUILD_NIGHTLY}" --build-arg BRANCH_NAME="${BRANCH_NAME}"  -t "${DOCKER_TAG}" --target ci-image  .
 elif [ "${BUILD_TYPE}" == "benchmark" ]
 then
   DOCKER_BUILDKIT=1 docker build --pull --no-cache --file Dockerfile.benchmark --build-arg USE_LOCAL_SERVE_FOLDER=$USE_LOCAL_SERVE_FOLDER --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg BRANCH_NAME="${BRANCH_NAME}" --build-arg CUDA_VERSION="${CUDA_VERSION}" --build-arg MACHINE_TYPE="${MACHINE}" --build-arg PYTHON_VERSION="${PYTHON_VERSION}" -t "${DOCKER_TAG}" .

--- a/docker/docker_nightly.py
+++ b/docker/docker_nightly.py
@@ -32,9 +32,9 @@ if __name__ == "__main__":
     gpu_version = f"{project}:gpu-{get_nightly_version()}"
 
     # Build Nightly images and append the date in the name
-    try_and_handle(f"./build_image.sh -t {organization}/{cpu_version}", dry_run)
+    try_and_handle(f"./build_image.sh -n -t {organization}/{cpu_version}", dry_run)
     try_and_handle(
-        f"./build_image.sh -g -cv cu117 -t {organization}/{gpu_version}",
+        f"./build_image.sh -g -cv cu117 -n -t {organization}/{gpu_version}",
         dry_run,
     )
 


### PR DESCRIPTION
## Description

Since we moved away from using Dockerfile.dev for production, Docker nightly builds are using the official version of TorchServe

This PR adds 
- an arg to docker script to build with torchserve nightly
- Changes docker regression scripts to use nightly
- This setups the infra to use PyTorch nightly for docker nightlies

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

```
(torchserve) ubuntu@ip-172-31-8-237:~/serve/docker$ ./build_image.sh  -bt ci  -t pytorch/torchserve:latest
[+] Building 185.9s (20/20) FINISHED                                                                                                                                                      
 => [internal] load build definition from Dockerfile                                                                                                                                 0.0s
 => => transferring dockerfile: 38B                                                                                                                                                  0.0s
 => [internal] load .dockerignore                                                                                                                                                    0.0s
 => => transferring context: 2B                                                                                                                                                      0.0s
 => resolve image config for docker.io/docker/dockerfile:experimental                                                                                                                0.3s
 => CACHED docker-image://docker.io/docker/dockerfile:experimental@sha256:600e5c62eedff338b3f7a0850beb7c05866e0ef27b2d2e8c02aa468e78496ff5                                           0.0s
 => [internal] load metadata for docker.io/library/ubuntu:20.04                                                                                                                      0.3s
 => CACHED [compile-image 1/9] FROM docker.io/library/ubuntu:20.04@sha256:c9820a44b950956a790c354700c1166a7ec648bc0d215fa438d3a339812f1d01                                           0.0s
 => [compile-image 2/9] RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt     apt-get update &&     apt-get upgrade -y &&     apt-get install software-properties-common -y   94.4s
 => [compile-image 3/9] RUN python3.9 -m venv /home/venv                                                                                                                             3.1s
 => [compile-image 4/9] RUN python -m pip install -U pip setuptools                                                                                                                  3.2s 
 => [compile-image 5/9] RUN export USE_CUDA=1                                                                                                                                        0.4s 
 => [compile-image 6/9] RUN git clone --depth 1 https://github.com/pytorch/serve.git                                                                                                 2.4s 
 => [compile-image 7/9] WORKDIR serve                                                                                                                                                0.0s 
 => [compile-image 8/9] RUN     if echo "ubuntu:20.04" | grep -q "cuda:"; then         if [ "" ]; then             python ./ts_scripts/install_dependencies.py --cuda ;         el  38.1s 
 => [compile-image 9/9] RUN     if echo "false" | grep -q "false"; then         python -m pip install --no-cache-dir torchserve torch-model-archiver torch-workflow-archiver;    el  2.2s 
 => CACHED [ci-image 2/6] RUN --mount=type=cache,target=/var/cache/apt     apt-get update &&     apt-get upgrade -y &&     apt-get install software-properties-common -y &&     add  0.0s 
 => [ci-image 3/6] COPY --from=compile-image /home/venv /home/venv                                                                                                                   5.5s 
 => [ci-image 4/6] RUN python -m pip install --no-cache-dir -r https://raw.githubusercontent.com/pytorch/serve/master/requirements/developer.txt                                    26.6s 
 => [ci-image 5/6] RUN mkdir /home/serve                                                                                                                                             0.4s 
 => [ci-image 6/6] WORKDIR /home/serve                                                                                                                                               0.0s 
 => exporting to image                                                                                                                                                               5.1s 
 => => exporting layers                                                                                                                                                              5.1s 
 => => writing image sha256:f5b027ab0c1d2ac2a2193034494fb4e091b1354570bdf401cc544eb4e7620f61                                                                                         0.0s 
 => => naming to docker.io/pytorch/torchserve:latest                                                                                                                                 0.0s 
(torchserve) ubuntu@ip-172-31-8-237:~/serve/docker$ docker run -it pytorch/torchserve:latest
root@21eda49b79cb:/home/serve# pip list | grep -i torch
intel-extension-for-pytorch 2.0.100
torch                       2.0.1+cpu
torch-model-archiver        0.8.1
torch-workflow-archiver     0.2.9
torchaudio                  2.0.2+cpu
torchdata                   0.6.1
torchpippy                  0.1.1
torchserve                  0.8.1
torchtext                   0.15.2+cpu
torchvision                 0.15.2+cpu
root@21eda49b79cb:/home/serve# pip list | grep -i torchserve
torchserve                  0.8.1
root@21eda49b79cb:/home/serve# pip list | grep -i archive   
torch-model-archiver        0.8.1
torch-workflow-archiver     0.2.9
root@21eda49b79cb:/home/serve# exit
exit
(torchserve) ubuntu@ip-172-31-8-237:~/serve/docker$ ./build_image.sh -n -bt ci  -t pytorch/torchserve:nightly
[+] Building 38.1s (20/20) FINISHED                                                                                                                                                       
 => [internal] load build definition from Dockerfile                                                                                                                                 0.0s
 => => transferring dockerfile: 38B                                                                                                                                                  0.0s
 => [internal] load .dockerignore                                                                                                                                                    0.0s
 => => transferring context: 2B                                                                                                                                                      0.0s
 => resolve image config for docker.io/docker/dockerfile:experimental                                                                                                                0.6s
 => CACHED docker-image://docker.io/docker/dockerfile:experimental@sha256:600e5c62eedff338b3f7a0850beb7c05866e0ef27b2d2e8c02aa468e78496ff5                                           0.0s
 => [internal] load metadata for docker.io/library/ubuntu:20.04                                                                                                                      0.4s
 => [ci-image 1/6] FROM docker.io/library/ubuntu:20.04@sha256:c9820a44b950956a790c354700c1166a7ec648bc0d215fa438d3a339812f1d01                                                       0.0s
 => CACHED [compile-image 2/9] RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt     apt-get update &&     apt-get upgrade -y &&     apt-get install software-properties-comm  0.0s
 => CACHED [compile-image 3/9] RUN python3.9 -m venv /home/venv                                                                                                                      0.0s
 => CACHED [compile-image 4/9] RUN python -m pip install -U pip setuptools                                                                                                           0.0s
 => CACHED [compile-image 5/9] RUN export USE_CUDA=1                                                                                                                                 0.0s
 => CACHED [compile-image 6/9] RUN git clone --depth 1 https://github.com/pytorch/serve.git                                                                                          0.0s
 => CACHED [compile-image 7/9] WORKDIR serve                                                                                                                                         0.0s
 => CACHED [compile-image 8/9] RUN     if echo "ubuntu:20.04" | grep -q "cuda:"; then         if [ "" ]; then             python ./ts_scripts/install_dependencies.py --cuda ;       0.0s
 => CACHED [compile-image 9/9] RUN     if echo "true" | grep -q "false"; then         python -m pip install --no-cache-dir torchserve torch-model-archiver torch-workflow-archiver;  0.0s
 => CACHED [ci-image 2/6] RUN --mount=type=cache,target=/var/cache/apt     apt-get update &&     apt-get upgrade -y &&     apt-get install software-properties-common -y &&     add  0.0s
 => [ci-image 3/6] COPY --from=compile-image /home/venv /home/venv                                                                                                                   5.4s
 => [ci-image 4/6] RUN python -m pip install --no-cache-dir -r https://raw.githubusercontent.com/pytorch/serve/master/requirements/developer.txt                                    26.0s
 => [ci-image 5/6] RUN mkdir /home/serve                                                                                                                                             0.4s
 => [ci-image 6/6] WORKDIR /home/serve                                                                                                                                               0.0s 
 => exporting to image                                                                                                                                                               5.1s 
 => => exporting layers                                                                                                                                                              5.1s 
 => => writing image sha256:6cd9c1d2e81e2a030b2fd973347142511985d7386f29b8f1c00a02a9ca1ad086                                                                                         0.0s 
 => => naming to docker.io/pytorch/torchserve:nightly                                                                                                                                0.0s 
(torchserve) ubuntu@ip-172-31-8-237:~/serve/docker$ docker run -it pytorch/torchserve:nightly
root@f41dc46529dd:/home/serve# pip list | grep -i torchserve
torchserve-nightly              2023.7.21
root@f41dc46529dd:/home/serve# pip list | grep -i archive   
torch-model-archiver-nightly    2023.7.21
torch-workflow-archiver-nightly 2023.7.21
```

## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?