### PR TITLE
Fix "direct buffer access" issue for Plugin SDK

### DIFF
--- a/frontend/server/src/main/java/org/pytorch/serve/servingsdk/impl/ModelServerRequest.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/servingsdk/impl/ModelServerRequest.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.pytorch.serve.servingsdk.http.Request;
+import org.pytorch.serve.util.NettyUtils;
 
 public class ModelServerRequest implements Request {
     private FullHttpRequest req;
@@ -45,6 +46,6 @@ public class ModelServerRequest implements Request {
 
     @Override
     public ByteArrayInputStream getInputStream() {
-        return new ByteArrayInputStream(req.content().array());
+        return new ByteArrayInputStream(NettyUtils.getBytes(req.content()));
     }
 }

--- a/frontend/server/src/test/java/org/pytorch/serve/util/PluginSdkTest.java
+++ b/frontend/server/src/test/java/org/pytorch/serve/util/PluginSdkTest.java
@@ -3,23 +3,24 @@ package org.pytorch.serve.util;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import org.pytorch.serve.servingsdk.http.Request;
 import org.pytorch.serve.servingsdk.impl.ModelServerRequest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-
 public class PluginSdkTest {
-  @Test
-  public void testReadRequestBodyFromPlugin() throws IOException {
-    ByteBuf buf = Unpooled.directBuffer();
-    buf.writeBytes("test".getBytes());
-    FullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "", buf);
-    Request request = new ModelServerRequest(req, new QueryStringDecoder(""));
-    String line = new BufferedReader(new InputStreamReader(request.getInputStream())).readLine();
-    Assert.assertEquals(line, "test");
-  }
+    @Test
+    public void testReadRequestBodyFromPlugin() throws IOException {
+        ByteBuf buf = Unpooled.directBuffer();
+        buf.writeBytes("test".getBytes());
+        FullHttpRequest req =
+                new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "", buf);
+        Request request = new ModelServerRequest(req, new QueryStringDecoder(""));
+        String line =
+                new BufferedReader(new InputStreamReader(request.getInputStream())).readLine();
+        Assert.assertEquals(line, "test");
+    }
 }

--- a/frontend/server/src/test/java/org/pytorch/serve/util/PluginSdkTest.java
+++ b/frontend/server/src/test/java/org/pytorch/serve/util/PluginSdkTest.java
@@ -1,0 +1,25 @@
+package org.pytorch.serve.util;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.*;
+import org.pytorch.serve.servingsdk.http.Request;
+import org.pytorch.serve.servingsdk.impl.ModelServerRequest;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class PluginSdkTest {
+  @Test
+  public void testReadRequestBodyFromPlugin() throws IOException {
+    ByteBuf buf = Unpooled.directBuffer();
+    buf.writeBytes("test".getBytes());
+    FullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "", buf);
+    Request request = new ModelServerRequest(req, new QueryStringDecoder(""));
+    String line = new BufferedReader(new InputStreamReader(request.getInputStream())).readLine();
+    Assert.assertEquals(line, "test");
+  }
+}

--- a/frontend/server/testng.xml
+++ b/frontend/server/testng.xml
@@ -5,6 +5,7 @@
     <classes>
       <class name="org.pytorch.serve.util.ConfigManagerTest"/>
       <class name="org.pytorch.serve.util.ConnectorTest"/>
+      <class name="org.pytorch.serve.util.PluginSdkTest"/>
       <class name="org.pytorch.serve.CoverageTest"/>
       <class name="org.pytorch.serve.ModelServerTest"/>
       <class name="org.pytorch.serve.SnapshotTest"/>


### PR DESCRIPTION
## Description

Fixes `ModelServerRequest.getInputStream()` issue when the underlying buffer is a Netty direct buffer.

Fixes #2498 

## Type of change
[x] Bug fix (non-breaking change which fixes an issue)

## Feature/Issue validation/testing

Added a [simple test](./frontend/server/src/test/java/org/pytorch/serve/util/PluginSdkTest.java) for direct buffer write/read using SDK abstractions. 
Not sure if a new test suite is justified, would be happy to move elsewhere.

## Checklist:

- [x] Did you have fun?
- [x] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?