### PR TITLE
always use tmp dir to load model

### DIFF
--- a/frontend/archive/src/main/java/org/pytorch/serve/archive/model/ModelArchive.java
+++ b/frontend/archive/src/main/java/org/pytorch/serve/archive/model/ModelArchive.java
@@ -205,8 +205,12 @@ public class ModelArchive {
     }
 
     public void clean() {
-        if (url != null && extracted) {
-            FileUtils.deleteQuietly(modelDir);
+        if (url != null) {
+            if (Files.isSymbolicLink(modelDir.toPath())) {
+                FileUtils.deleteQuietly(modelDir.getParentFile());
+            } else {
+                FileUtils.deleteQuietly(modelDir);
+            }
         }
     }
 

--- a/frontend/archive/src/main/java/org/pytorch/serve/archive/model/ModelArchive.java
+++ b/frontend/archive/src/main/java/org/pytorch/serve/archive/model/ModelArchive.java
@@ -79,6 +79,8 @@ public class ModelArchive {
             }
         }
 
+        File tempDir = ZipUtils.createTempDir(null, "models");
+        logger.info("createTempDir {}", tempDir.getAbsolutePath());
         File directory = new File(url);
         if (directory.isDirectory()) {
             // handle the case that the input url is a directory.
@@ -88,9 +90,13 @@ public class ModelArchive {
             if (fileList.length == 1 && fileList[0].isDirectory()) {
                 // handle the case that a model tgz file
                 // has root dir after decompression on SageMaker
-                return load(url, fileList[0], false);
+                File targetLink = ZipUtils.createSymbolicDir(fileList[0], tempDir);
+                logger.info("createSymbolicDir {}", targetLink.getAbsolutePath());
+                return load(url, targetLink, false);
             }
-            return load(url, directory, false);
+            File targetLink = ZipUtils.createSymbolicDir(directory, tempDir);
+            logger.info("createSymbolicDir {}", targetLink.getAbsolutePath());
+            return load(url, targetLink, false);
         } else if (modelLocation.exists()) {
             // handle the case that "/xxx/model_store/modelXXX" is directory.
             // the input of url is modelXXX when torchserve is started
@@ -99,9 +105,13 @@ public class ModelArchive {
             if (fileList.length == 1 && fileList[0].isDirectory()) {
                 // handle the case that a model tgz file
                 // has root dir after decompression on SageMaker
-                return load(url, fileList[0], false);
+                File targetLink = ZipUtils.createSymbolicDir(fileList[0], tempDir);
+                logger.info("createSymbolicDir {}", targetLink.getAbsolutePath());
+                return load(url, targetLink, false);
             }
-            return load(url, modelLocation, false);
+            File targetLink = ZipUtils.createSymbolicDir(modelLocation, tempDir);
+            logger.info("createSymbolicDir {}", targetLink.getAbsolutePath());
+            return load(url, targetLink, false);
         }
 
         throw new ModelNotFoundException("Model not found at: " + url);

--- a/frontend/archive/src/main/java/org/pytorch/serve/archive/model/ModelArchive.java
+++ b/frontend/archive/src/main/java/org/pytorch/serve/archive/model/ModelArchive.java
@@ -132,8 +132,12 @@ public class ModelArchive {
             failed = false;
             return new ModelArchive(manifest, url, dir, extracted);
         } finally {
-            if (extracted && failed) {
-                FileUtils.deleteQuietly(dir);
+            if (failed) {
+                if (Files.isSymbolicLink(dir.toPath())) {
+                    FileUtils.deleteQuietly(dir.getParentFile());
+                } else {
+                    FileUtils.deleteQuietly(dir);
+                }
             }
         }
     }

--- a/frontend/archive/src/main/java/org/pytorch/serve/archive/utils/ZipUtils.java
+++ b/frontend/archive/src/main/java/org/pytorch/serve/archive/utils/ZipUtils.java
@@ -120,4 +120,29 @@ public final class ZipUtils {
             }
         }
     }
+
+    public static File createTempDir(String eTag, String type) throws IOException {
+        File tmpDir = FileUtils.getTempDirectory();
+        File modelDir = new File(tmpDir, type);
+
+        if (eTag == null) {
+            eTag = UUID.randomUUID().toString().replaceAll("-", "");
+        }
+
+        File dir = new File(modelDir, eTag);
+        if (dir.exists()) {
+            FileUtils.forceDelete(dir);
+        }
+        FileUtils.forceMkdir(dir);
+
+        return dir;
+    }
+
+    public static File createSymbolicDir(File source, File dest) throws IOException {
+        String sourceDirName = source.getName();
+        File targetLink = new File(dest, sourceDirName);
+        Files.createSymbolicLink(targetLink.toPath(), source.toPath());
+
+        return targetLink;
+    }
 }

--- a/frontend/server/src/main/java/org/pytorch/serve/util/messages/EnvironmentUtils.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/messages/EnvironmentUtils.java
@@ -1,6 +1,7 @@
 package org.pytorch.serve.util.messages;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -39,6 +40,12 @@ public final class EnvironmentUtils {
 
         if (modelPath != null) {
             pythonPath.append(modelPath).append(File.pathSeparatorChar);
+            File dependencyPath = new File(modelPath);
+            if (Files.isSymbolicLink(dependencyPath.toPath())) {
+                pythonPath
+                        .append(dependencyPath.getParentFile().getAbsolutePath())
+                        .append(File.pathSeparatorChar);
+            }
         }
 
         if (!cwd.contains("site-packages") && !cwd.contains("dist-packages")) {

--- a/frontend/server/src/main/java/org/pytorch/serve/util/messages/EnvironmentUtils.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/messages/EnvironmentUtils.java
@@ -10,7 +10,6 @@ import java.util.regex.Pattern;
 import org.pytorch.serve.archive.model.Manifest;
 import org.pytorch.serve.util.ConfigManager;
 import org.pytorch.serve.wlm.Model;
-import org.pytorch.serve.wlm.WorkerInitializationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/frontend/server/src/main/java/org/pytorch/serve/wlm/ModelManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/wlm/ModelManager.java
@@ -213,7 +213,7 @@ public final class ModelManager {
 
             String pythonRuntime = EnvironmentUtils.getPythonRunTime(model);
 
-            File dependencyPath = model.getModelDir().getCanonicalFile();
+            File dependencyPath = model.getModelDir();
             if (Files.isSymbolicLink(dependencyPath.toPath())) {
                 dependencyPath = dependencyPath.getParentFile();
             }

--- a/frontend/server/src/main/java/org/pytorch/serve/wlm/ModelManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/wlm/ModelManager.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashSet;
@@ -212,10 +213,14 @@ public final class ModelManager {
 
             String pythonRuntime = EnvironmentUtils.getPythonRunTime(model);
 
+            File dependencyPath = model.getModelDir().getCanonicalFile();
+            if (Files.isSymbolicLink(dependencyPath.toPath())) {
+                dependencyPath = dependencyPath.getParentFile();
+            }
             String packageInstallCommand =
                     pythonRuntime
                             + " -m pip install -U -t "
-                            + model.getModelDir().getAbsolutePath()
+                            + dependencyPath.getAbsolutePath()
                             + " -r "
                             + requirementsFilePath; // NOPMD
 
@@ -251,7 +256,6 @@ public final class ModelManager {
                     errorString.append(line);
                 }
 
-                logger.info("Dependency installation stdout:\n" + outputString.toString());
                 logger.error("Dependency installation stderr:\n" + errorString.toString());
 
                 throw new ModelException(

--- a/frontend/server/src/main/java/org/pytorch/serve/wlm/WorkerLifeCycle.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/wlm/WorkerLifeCycle.java
@@ -99,7 +99,9 @@ public class WorkerLifeCycle {
         File modelPath;
         setPort(port);
         try {
-            modelPath = model.getModelDir().getCanonicalFile();
+            modelPath = model.getModelDir();
+            // Test if modelPath is valid
+            modelPath.getCanonicalFile();
         } catch (IOException e) {
             throw new WorkerInitializationException("Failed get TS home directory", e);
         }


### PR DESCRIPTION
## Description

Please read our [CONTRIBUTING.md](https://github.com/pytorch/serve/blob/master/CONTRIBUTING.md) prior to creating your first pull request.

Please include a summary of the feature or issue being fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #(issue)
#2454 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing
This is workaround solution to fix 3rd party dependency installation on SM. It always uses tmp dir to load model and install 3rd party dependency. If the model url is a dir, it creates a symbolic link under tmp to link with the url.

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- Test 
all existing ci/regression tests should be pass


## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?