### PR TITLE
Typehints for model_loader and model_service_worker

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
 ; A good-first-issue is to add types to a file
 ; As you do start adding them in files and slowly make the excluded files empty
-files = ts/context.py, ts/model_server.py, ts/model_loader
+files = ts/context.py, ts/model_server.py, ts/model_loader, ts/model_service_worker.py
 
 exclude = examples, binaries, ts_scripts, test, kubernetes, benchmarks, model-archiver, workflow-archiver, ts/tests, ts/utils
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
 ; A good-first-issue is to add types to a file
 ; As you do start adding them in files and slowly make the excluded files empty
-files = ts/context.py, ts/model_server.py, ts/model_loader, ts/model_service_worker.py
+files = ts/context.py, ts/model_server.py, ts/model_loader.py, ts/model_service_worker.py
 
 exclude = examples, binaries, ts_scripts, test, kubernetes, benchmarks, model-archiver, workflow-archiver, ts/tests, ts/utils
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
 ; A good-first-issue is to add types to a file
 ; As you do start adding them in files and slowly make the excluded files empty
-files = ts/context.py, ts/model_server.py
+files = ts/context.py, ts/model_server.py, ts/model_loader
 
 exclude = examples, binaries, ts_scripts, test, kubernetes, benchmarks, model-archiver, workflow-archiver, ts/tests, ts/utils
 

--- a/ts/model_loader.py
+++ b/ts/model_loader.py
@@ -73,7 +73,7 @@ class TsModelLoader(ModelLoader):
         batch_size: Optional[int] = None,
         envelope: Optional[str] = None,
         limit_max_image_pixels: Optional[bool] = True,
-        metrics_cache: MetricsCacheYamlImpl = None,
+        metrics_cache: Optional[MetricsCacheYamlImpl] = None,
     ) -> Service:
         """
         Load TorchServe 1.0 model from file.

--- a/ts/tests/unit_tests/test_model_service_worker.py
+++ b/ts/tests/unit_tests/test_model_service_worker.py
@@ -185,3 +185,16 @@ class TestHandleConnection:
             model_service_worker.handle_connection(cl_socket)
 
         cl_socket.sendall.assert_called()
+
+    def test_handle_connection_recv_inference_before_load(
+        self, patches, model_service_worker
+    ):
+        patches.retrieve_msg.side_effect = [(b"I", "")]
+        service = Mock()
+        service.context = None
+        cl_socket = Mock()
+
+        with pytest.raises(
+            RuntimeError, match=r"Received command: .*, but service is not loaded"
+        ):
+            model_service_worker.handle_connection(cl_socket)


### PR DESCRIPTION
## Description

1. Adds necessary typehinting and checks for `None` to make `mypy` happy in two files: `ts/model_loader.py`, `ts/model_service_worker.py`
2. Adds unit test for `None` check in `handle_connection`

Related to #1512 

## Type of change

Code quality - typehints

## Feature/Issue validation/testing

- [x] Added unit test for new `None` checking in `handle_connection`.
 See `ts/tests/unit_tests/test_model_service_worker.py`
- [x] Ran `mypy` on changed files
- [x] Ran sanity check (`torchserve_sanity.py`)
- [x] Ran regression tests (`test/regression_tests.py`)

## Checklist:

- [x] Did you have fun?
- [x] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?