### PR TITLE
Fix syntax error in base_handler initialize

### DIFF
--- a/ts/torch_handler/base_handler.py
+++ b/ts/torch_handler/base_handler.py
@@ -198,7 +198,7 @@ class BaseHandler(abc.ABC):
                     backend=pt2_backend,
                 )
                 logger.info(f"Compiled model with backend {pt2_backend}")
-            except e:
+            except Exception as e:
                 logger.warning(
                     f"Compiling model model with backend {pt2_backend} has failed \n Proceeding without compilation"
                 )


### PR DESCRIPTION
## Description

Fixes a one-line syntax error in the base_handler initialize method, in the torch.compile section.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
