### PR TITLE
(WIP)Fixes scripted model loading when model file is specified

### DIFF
--- a/examples/image_classifier/resnet_18/script.py
+++ b/examples/image_classifier/resnet_18/script.py
@@ -1,0 +1,14 @@
+import torch
+from torchvision import models
+
+SCRIPTED_MODEL = "resnet-18.pt"
+
+
+def create_pt_file(SCRIPTED_MODEL):
+    model = models.resnet18(weights=models.ResNet18_Weights.DEFAULT)
+    sm = torch.jit.script(model)
+    sm.save(SCRIPTED_MODEL)
+
+
+if __name__ == "__main__":
+    create_pt_file(SCRIPTED_MODEL)

--- a/test/pytest/test_handler.py
+++ b/test/pytest/test_handler.py
@@ -9,6 +9,8 @@ import requests
 import test_utils
 import torch
 
+from ts.torch_handler.unit_tests.test_utils.mock_context import MockContext
+
 REPO_ROOT = os.path.normpath(
     os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../")
 )
@@ -417,3 +419,30 @@ def test_echo_stream_inference():
 
     assert str(" ".join(prediction)) == "hello hello hello hello world "
     test_utils.unregister_model("echo_stream")
+
+
+def test_scripted_model_load_with_model_file():
+    from ts.torch_handler.image_classifier import ImageClassifier
+
+    EXAMPLE_ROOT_DIR = os.path.join(
+        REPO_ROOT, "examples", "image_classifier", "resnet_18"
+    )
+
+    script_path = os.path.join(EXAMPLE_ROOT_DIR, "script.py")
+    create_res18_pt = test_utils.load_module_from_py_file(script_path)
+
+    MODEL_PT_FILE = os.path.join(EXAMPLE_ROOT_DIR, "resnet-18.pt")
+
+    torch.manual_seed(42 * 42)
+    create_res18_pt.create_pt_file(MODEL_PT_FILE)
+
+    handler = ImageClassifier()
+
+    ctx = MockContext(
+        model_pt_file=MODEL_PT_FILE,
+        model_dir=EXAMPLE_ROOT_DIR,
+        model_file="model.py",
+    )
+
+    torch.manual_seed(42 * 42)
+    handler.initialize(ctx)

--- a/ts/torch_handler/base_handler.py
+++ b/ts/torch_handler/base_handler.py
@@ -161,17 +161,9 @@ class BaseHandler(abc.ABC):
         # model def file
         model_file = self.manifest["model"].get("modelFile", "")
 
-        if model_file:
-            logger.debug("Loading eager model")
-            self.model = self._load_pickled_model(
-                model_dir, model_file, self.model_pt_path
-            )
-            self.model.to(self.device)
-            self.model.eval()
-
         # Convert your model by following instructions: https://pytorch.org/tutorials/intermediate/nvfuser_intro_tutorial.html
         # For TensorRT support follow instructions here: https://pytorch.org/TensorRT/getting_started/getting_started_with_python_api.html#getting-started-with-python-api
-        elif self.model_pt_path.endswith(".pt"):
+        if self.model_pt_path.endswith(".pt"):
             self.model = self._load_torchscript_model(self.model_pt_path)
             self.model.eval()
 
@@ -179,6 +171,14 @@ class BaseHandler(abc.ABC):
         elif self.model_pt_path.endswith(".onnx") and ONNX_AVAILABLE:
             self.model = setup_ort_session(self.model_pt_path, self.map_location)
             logger.info("Succesfully setup ort session")
+        # Eager model
+        elif model_file:
+            logger.debug("Loading eager model")
+            self.model = self._load_pickled_model(
+                model_dir, model_file, self.model_pt_path
+            )
+            self.model.to(self.device)
+            self.model.eval()
 
         else:
             raise RuntimeError("No model weights could be loaded")


### PR DESCRIPTION
## Description

If user specifies the model file when using scripted model, base handler errors. 
This is a negative test case

Fixes #(https://github.com/pytorch/serve/issues/2481)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Failure
```
================================================================================== test session starts ===================================================================================
platform linux -- Python 3.8.13, pytest-7.3.1, pluggy-1.0.0 -- /home/ubuntu/anaconda3/envs/torchserve/bin/python
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/home/ubuntu/serve/test/pytest/.hypothesis/examples')
rootdir: /home/ubuntu/serve
plugins: mock-3.10.0, anyio-3.6.1, cov-4.1.0, hypothesis-6.54.3
collected 1 item                                                                                                                                                                         

test_tmp.py::test_scripted_model FAILED                                                                                                                                            [100%]

======================================================================================== FAILURES ========================================================================================
__________________________________________________________________________________ test_scripted_model ___________________________________________________________________________________

    def test_scripted_model():
    
        from ts.torch_handler.image_classifier import ImageClassifier
    
        EXAMPLE_ROOT_DIR = os.path.join(REPO_ROOT, "examples", "image_classifier", "resnet_18")
    
        script_path = os.path.join(EXAMPLE_ROOT_DIR, "script.py")
        create_res18_pt = test_utils.load_module_from_py_file(script_path)
    
        MODEL_PT_FILE = os.path.join(EXAMPLE_ROOT_DIR, "resnet-18.pt")
    
        torch.manual_seed(42 * 42)
        create_res18_pt.create_pt_file(MODEL_PT_FILE)
    
        handler = ImageClassifier()
    
        ctx = MockContext(
            model_pt_file=MODEL_PT_FILE,
            model_dir=EXAMPLE_ROOT_DIR,
            model_file="model.py",
        )
    
        torch.manual_seed(42 * 42)
>       handler.initialize(ctx)

test_tmp.py:33: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../../anaconda3/envs/torchserve/lib/python3.8/site-packages/ts/torch_handler/vision_handler.py:23: in initialize
    super().initialize(context)
../../../anaconda3/envs/torchserve/lib/python3.8/site-packages/ts/handler_utils/cache/utils.py:13: in wrap_func
    result = func(self, *args, **kwargs)
../../../anaconda3/envs/torchserve/lib/python3.8/site-packages/ts/torch_handler/base_handler.py:167: in initialize
    self.model = self._load_pickled_model(
../../../anaconda3/envs/torchserve/lib/python3.8/site-packages/ts/torch_handler/base_handler.py:253: in _load_pickled_model
    module = importlib.import_module(model_file.split(".")[0])
../../../anaconda3/envs/torchserve/lib/python3.8/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1014: in _gcd_import
    ???
<frozen importlib._bootstrap>:991: in _find_and_load
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

name = 'model', import_ = <function _gcd_import at 0x7fe069d47430>

>   ???
E   ModuleNotFoundError: No module named 'model'

<frozen importlib._bootstrap>:973: ModuleNotFoundError
----------------------------------------------------------------------------------- Ca
```

- [ ] Passing
```
~/serve/test/pytest$ pytest -v test_tmp.py 
================================================================================== test session starts ===================================================================================
platform linux -- Python 3.8.13, pytest-7.3.1, pluggy-1.0.0 -- /home/ubuntu/anaconda3/envs/torchserve/bin/python
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/home/ubuntu/serve/test/pytest/.hypothesis/examples')
rootdir: /home/ubuntu/serve
plugins: mock-3.10.0, anyio-3.6.1, cov-4.1.0, hypothesis-6.54.3
collected 1 item                                                                                                                                                                         

test_tmp.py::test_scripted_model PASSED                                                                                                                                            [100%]

```


## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?