### PR TITLE
pinning newman version to 5.3.2 as mac CI was flaky

### DIFF
--- a/ts_scripts/install_dependencies.py
+++ b/ts_scripts/install_dependencies.py
@@ -83,7 +83,7 @@ class Common:
 
     def install_node_packages(self):
         os.system(
-            f"{self.sudo_cmd}npm install -g newman newman-reporter-htmlextra markdown-link-check"
+            f"{self.sudo_cmd}npm install -g newman@5.3.2 newman-reporter-htmlextra markdown-link-check"
         )
 
     def install_jmeter(self):

--- a/ts_scripts/mac_npm_deps
+++ b/ts_scripts/mac_npm_deps
@@ -13,4 +13,4 @@ then
     exit -1
 fi
 
-npm install -g newman newman-reporter-html markdown-link-check
+npm install -g newman@5.3.2 newman-reporter-html markdown-link-check


### PR DESCRIPTION
## Description

newman published a new version yesterday, which started breaking our CI

https://www.npmjs.com/package/newman?activeTab=versions

Pinning the version to 5.3.2

This fixes mac regression issues
https://github.com/pytorch/serve/actions/runs/6201889968/job/16839506337

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B


## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?