### PR TITLE
wip Add url validation in s3 utils

### DIFF
--- a/frontend/archive/src/main/java/org/pytorch/serve/archive/model/s3/HttpUtils.java
+++ b/frontend/archive/src/main/java/org/pytorch/serve/archive/model/s3/HttpUtils.java
@@ -21,7 +21,6 @@ public final class HttpUtils {
 
     private static void validateURL(URL url) {
         if ("file".equalsIgnoreCase(url.getProtocol())) {
-            // For local file URLs, you might want to check if the file exists or just return
             File file = new File(url.getPath());
             if (!file.exists()) {
                 throw new IllegalArgumentException("Local file does not exist.");

--- a/frontend/archive/src/main/java/org/pytorch/serve/archive/model/s3/HttpUtils.java
+++ b/frontend/archive/src/main/java/org/pytorch/serve/archive/model/s3/HttpUtils.java
@@ -18,6 +18,13 @@ public final class HttpUtils {
 
     private HttpUtils() {}
 
+    private static void validateURL(URL url) {
+        UrlValidator urlValidator = new UrlValidator(UrlValidator.ALLOW_LOCAL_URLS);
+        if (!urlValidator.isValid(url.toString())) {
+            throw new IllegalArgumentException("Invalid URL provided.");
+        }
+    }
+
     /** Copy model from S3 url to local model store */
     public static void copyURLToFile(URL endpointUrl, File modelLocation, boolean s3SseKmsEnabled)
             throws IOException {
@@ -58,13 +65,14 @@ public final class HttpUtils {
                                 + "AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY or AWS_DEFAULT_REGION");
             }
         } else {
+            validateURL(endpointUrl);
             FileUtils.copyURLToFile(endpointUrl, modelLocation);
         }
     }
 
     public static HttpURLConnection createHttpConnection(
             URL endpointUrl, String httpMethod, Map<String, String> headers) throws IOException {
-
+        validateURL(endpointUrl);
         HttpURLConnection connection = (HttpURLConnection) endpointUrl.openConnection();
         connection.setRequestMethod(httpMethod);
 

--- a/frontend/archive/src/main/java/org/pytorch/serve/archive/model/s3/HttpUtils.java
+++ b/frontend/archive/src/main/java/org/pytorch/serve/archive/model/s3/HttpUtils.java
@@ -20,6 +20,15 @@ public final class HttpUtils {
     private HttpUtils() {}
 
     private static void validateURL(URL url) {
+        if ("file".equalsIgnoreCase(url.getProtocol())) {
+            // For local file URLs, you might want to check if the file exists or just return
+            File file = new File(url.getPath());
+            if (!file.exists()) {
+                throw new IllegalArgumentException("Local file does not exist.");
+            }
+            return; // If it's a file URL and the file exists, consider it valid and return early
+        }
+
         UrlValidator urlValidator = new UrlValidator(UrlValidator.ALLOW_LOCAL_URLS);
         if (!urlValidator.isValid(url.toString())) {
             throw new IllegalArgumentException("Invalid URL provided.");

--- a/frontend/archive/src/main/java/org/pytorch/serve/archive/model/s3/HttpUtils.java
+++ b/frontend/archive/src/main/java/org/pytorch/serve/archive/model/s3/HttpUtils.java
@@ -9,6 +9,7 @@ import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.validator.routines.UrlValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/frontend/archive/src/test/java/org/pytorch/serve/archive/model/ModelArchiveTest.java
+++ b/frontend/archive/src/test/java/org/pytorch/serve/archive/model/ModelArchiveTest.java
@@ -83,7 +83,8 @@ public class ModelArchiveTest {
 
     @Test
     public void testLocalFile()
-            throws ModelException, IOException, InterruptedException, DownloadArchiveException {
+            throws ModelException, IOException, InterruptedException, DownloadArchiveException,
+                    IllegalArgumentException {
         String modelStore = "src/test/resources/models";
         String curDir = System.getProperty("user.dir");
         File curDirFile = new File(curDir);
@@ -157,7 +158,8 @@ public class ModelArchiveTest {
     }
 
     @Test(expectedExceptions = DownloadArchiveException.class)
-    public void testMalformedURL() throws ModelException, IOException, DownloadArchiveException {
+    public void testMalformedURL()
+            throws ModelException, IOException, DownloadArchiveException, IllegalArgumentException {
         String modelStore = "src/test/resources/models";
         ModelArchive.downloadModel(
                 ALLOWED_URLS_LIST,
@@ -202,7 +204,8 @@ public class ModelArchiveTest {
 
     @Test(expectedExceptions = DownloadArchiveException.class)
     public void testMalformLocalURL()
-            throws ModelException, IOException, InterruptedException, DownloadArchiveException {
+            throws ModelException, IOException, InterruptedException, DownloadArchiveException,
+                    IllegalArgumentException {
         String modelStore = "src/test/resources/models";
         ModelArchive.downloadModel(
                 ALLOWED_URLS_LIST, modelStore, "file:///" + modelStore + "/mnist1.mar");

--- a/frontend/archive/src/test/java/org/pytorch/serve/archive/model/ModelArchiveTest.java
+++ b/frontend/archive/src/test/java/org/pytorch/serve/archive/model/ModelArchiveTest.java
@@ -157,7 +157,7 @@ public class ModelArchiveTest {
         archive.clean();
     }
 
-    @Test(expectedExceptions = DownloadArchiveException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void testMalformedURL()
             throws ModelException, IOException, DownloadArchiveException, IllegalArgumentException {
         String modelStore = "src/test/resources/models";
@@ -202,7 +202,7 @@ public class ModelArchiveTest {
                 "https://torchserve.pytorch.org/mar_files/mnist.mar");
     }
 
-    @Test(expectedExceptions = DownloadArchiveException.class)
+    @Test(expectedExceptions = llegalArgumentException.class)
     public void testMalformLocalURL()
             throws ModelException, IOException, InterruptedException, DownloadArchiveException,
                     IllegalArgumentException {

--- a/frontend/archive/src/test/java/org/pytorch/serve/archive/model/ModelArchiveTest.java
+++ b/frontend/archive/src/test/java/org/pytorch/serve/archive/model/ModelArchiveTest.java
@@ -202,7 +202,7 @@ public class ModelArchiveTest {
                 "https://torchserve.pytorch.org/mar_files/mnist.mar");
     }
 
-    @Test(expectedExceptions = llegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void testMalformLocalURL()
             throws ModelException, IOException, InterruptedException, DownloadArchiveException,
                     IllegalArgumentException {

--- a/frontend/build.gradle
+++ b/frontend/build.gradle
@@ -41,6 +41,10 @@ configure(javaProjects()) {
     targetCompatibility = 1.8
 
     defaultTasks 'jar'
+    
+    dependencies {
+        implementation 'commons-validator:commons-validator:1.7'
+    }
 
 	apply from: file("${rootProject.projectDir}/tools/gradle/formatter.gradle")
 	apply from: file("${rootProject.projectDir}/tools/gradle/check.gradle")


### PR DESCRIPTION
Solves
https://github.com/pytorch/serve/security/code-scanning/16
https://github.com/pytorch/serve/security/code-scanning/15

Not sure what's the right way to change the failing tests now that an IllegalArgumentException will be the default

EDIT: Ok I'm gonna move on to something else, this PR is a bit annoying to merge since it will make breaking changes to the HTTP status to a lot of requests, will look at other stuff when i have free time