### PR TITLE
skip flaky tests

### DIFF
--- a/test/pytest/conftest.py
+++ b/test/pytest/conftest.py
@@ -20,7 +20,7 @@ collect_ignore.append("test_sm_mme_requirements.py")
 collect_ignore.append("test_example_dcgan.py")
 
 # ldconfig dependency issue
-collect_ignore.append("test_torch_compile")
+collect_ignore.append("test_torch_compile.py")
 
 @pytest.fixture(scope="module")
 def model_archiver():

--- a/test/pytest/conftest.py
+++ b/test/pytest/conftest.py
@@ -19,6 +19,8 @@ collect_ignore.append("test_dali_preprocess.py")
 collect_ignore.append("test_sm_mme_requirements.py")
 collect_ignore.append("test_example_dcgan.py")
 
+# ldconfig dependency issue
+collect_ignore.append("test_torch_compile")
 
 @pytest.fixture(scope="module")
 def model_archiver():

--- a/test/pytest/conftest.py
+++ b/test/pytest/conftest.py
@@ -15,6 +15,10 @@ collect_ignore.append("test_example_torchrec_dlrm.py")
 collect_ignore.append("test_example_near_real_time_video.py")
 collect_ignore.append("test_dali_preprocess.py")
 
+# Flaky tests
+collect_ignore.append("test_sm_mme_requirements.py")
+collect_ignore.append("test_example_dcgan.py")
+
 
 @pytest.fixture(scope="module")
 def model_archiver():


### PR DESCRIPTION
* dcgan recently started failing recently and fix hasn't been merged
* sm oom test has been flaky for as long as i can remember
* compile started failing with missing ldconfig, this issue pops up a lot in core - resolution is manually linking for now

We should never have flaky tests in CI because it makes the signal from our tests poor and noone can merge anything, please open a seperate issue to enable the flaky test. if the test is important then mark the issue to reenable it as a p0 do not keep ci red

General policy: Revert and ask questions later