### PR TITLE
Bind torchserve container ports to localhost ports

### DIFF
--- a/benchmarks/benchmark-ab.py
+++ b/benchmarks/benchmark-ab.py
@@ -364,7 +364,7 @@ def docker_torchserve_start():
     management_port = urlparse(execution_params["management_url"]).port
     docker_run_cmd = (
         f"docker run {execution_params['docker_runtime']} {backend_profiling} --name ts --user root -p "
-        f"{inference_port}:{inference_port} -p {management_port}:{management_port} "
+        f"127.0.0.1:{inference_port}:{inference_port} -p 127.0.0.1:{management_port}:{management_port} "
         f"-v {execution_params['tmp_dir']}:/tmp {enable_gpu} -itd {docker_image} "
         f'"torchserve --start --model-store /home/model-server/model-store '
         f"\--workflow-store /home/model-server/wf-store "

--- a/benchmarks/jmeter.md
+++ b/benchmarks/jmeter.md
@@ -195,7 +195,7 @@ The benchmarks can also be used to analyze the backend performance using cProfil
     If using external docker container for TorchServe:
     * start docker with /tmp directory mapped to local /tmp and set `TS_BENCHMARK` to True.
     ```
-        docker run --rm -it -e TS_BENCHMARK=True -v /tmp:/tmp -p 8080:8080 -p 8081:8081 pytorch/torchserve:latest
+        docker run --rm -it -e TS_BENCHMARK=True -v /tmp:/tmp -p 127.0.0.1:8080:8080 -p 127.0.0.1:8081:8081 pytorch/torchserve:latest
     ```
 
 3. Register a model & perform inference to collect profiling data. This can be done with the benchmark script described in the previous section.

--- a/docker/README.md
+++ b/docker/README.md
@@ -194,19 +194,19 @@ The following examples will start the container with 8080/81/82 and 7070/71 port
 For the latest version, you can use the `latest` tag:
 
 ```bash
-docker run --rm -it -p 8080:8080 -p 8081:8081 -p 8082:8082 -p 7070:7070 -p 7071:7071 pytorch/torchserve:latest
+docker run --rm -it -p 127.0.0.1:8080:8080 -p 127.0.0.1:8081:8081 -p 127.0.0.1:8082:8082 -p 127.0.0.1:7070:7070 -p 127.0.0.1:7071:7071 pytorch/torchserve:latest
 ```
 
 For specific versions you can pass in the specific tag to use (ex: pytorch/torchserve:0.1.1-cpu):
 
 ```bash
-docker run --rm -it -p 8080:8080 -p 8081:8081 -p 8082:8082 -p 7070:7070 -p 7071:7071  pytorch/torchserve:0.1.1-cpu
+docker run --rm -it -p 127.0.0.1:8080:8080 -p 127.0.0.1:8081:8081 -p 127.0.0.1:8082:8082 -p 127.0.0.1:7070:7070 -p 127.0.0.1:7071:7071 pytorch/torchserve:0.1.1-cpu
 ```
 
 #### Start CPU container with Intel® Extension for PyTorch*
 
 ```bash
-docker run --rm -it -p 8080:8080 -p 8081:8081 -p 8082:8082 -p 7070:7070 -p 7071:7071  torchserve-ipex:1.0
+docker run --rm -it -p 127.0.0.1:8080:8080 -p 127.0.0.1:8081:8081 -p 127.0.0.1:8082:8082 -p 127.0.0.1:7070:7070 -p 127.0.0.1:7071:7071  torchserve-ipex:1.0
 ```
 
 #### Start GPU container
@@ -214,19 +214,19 @@ docker run --rm -it -p 8080:8080 -p 8081:8081 -p 8082:8082 -p 7070:7070 -p 7071:
 For GPU latest image with gpu devices 1 and 2:
 
 ```bash
-docker run --rm -it --gpus '"device=1,2"' -p 8080:8080 -p 8081:8081 -p 8082:8082 -p 7070:7070 -p 7071:7071 pytorch/torchserve:latest-gpu
+docker run --rm -it --gpus '"device=1,2"' -p 127.0.0.1:8080:8080 -p 127.0.0.1:8081:8081 -p 127.0.0.1:8082:8082 -p 127.0.0.1:7070:7070 -p 127.0.0.1:7071:7071 pytorch/torchserve:latest-gpu
 ```
 
 For specific versions you can pass in the specific tag to use (ex: `0.1.1-cuda10.1-cudnn7-runtime`):
 
 ```bash
-docker run --rm -it --gpus all -p 8080:8080 -p 8081:8081 -p 8082:8082 -p 7070:7070 -p 7071:7071 pytorch/torchserve:0.1.1-cuda10.1-cudnn7-runtime
+docker run --rm -it --gpus all -p 127.0.0.1:8080:8080 -p 127.0.0.1:8081:8081 -p 127.0.0.1:8082:8082 -p 127.0.0.1:7070:7070 -p 127.0.0.1:7071:7071 pytorch/torchserve:0.1.1-cuda10.1-cudnn7-runtime
 ```
 
 For the latest version, you can use the `latest-gpu` tag:
 
 ```bash
-docker run --rm -it --gpus all -p 8080:8080 -p 8081:8081 -p 8082:8082 -p 7070:7070 -p 7071:7071 pytorch/torchserve:latest-gpu
+docker run --rm -it --gpus all -p 127.0.0.1:8080:8080 -p 127.0.0.1:8081:8081 -p 127.0.0.1:8082:8082 -p 127.0.0.1:7070:7070 -p 127.0.0.1:7071:7071 pytorch/torchserve:latest-gpu
 ```
 
 #### Accessing TorchServe APIs inside container
@@ -244,7 +244,7 @@ To create mar [model archive] file for TorchServe deployment, you can use follow
 1. Start container by sharing your local model-store/any directory containing custom/example mar contents as well as model-store directory (if not there, create it)
 
 ```bash
-docker run --rm -it -p 8080:8080 -p 8081:8081 --name mar -v $(pwd)/model-store:/home/model-server/model-store -v $(pwd)/examples:/home/model-server/examples pytorch/torchserve:latest
+docker run --rm -it -p 127.0.0.1:8080:8080 -p 127.0.0.1:8081:8081 --name mar -v $(pwd)/model-store:/home/model-server/model-store -v $(pwd)/examples:/home/model-server/examples pytorch/torchserve:latest
 ```
 
 1.a. If starting container with Intel® Extension for PyTorch*, add the following lines in `config.properties` to enable IPEX and launcher with its default configuration.
@@ -254,7 +254,7 @@ cpu_launcher_enable=true
 ```
 
 ```bash
-docker run --rm -it -p 8080:8080 -p 8081:8081 --name mar -v $(pwd)/config.properties:/home/model-server/config.properties -v $(pwd)/model-store:/home/model-server/model-store -v $(pwd)/examples:/home/model-server/examples torchserve-ipex:1.0
+docker run --rm -it -p 127.0.0.1:8080:8080 -p 127.0.0.1:8081:8081 --name mar -v $(pwd)/config.properties:/home/model-server/config.properties -v $(pwd)/model-store:/home/model-server/model-store -v $(pwd)/examples:/home/model-server/examples torchserve-ipex:1.0
 ```
 
 2. List your container or skip this if you know container name
@@ -310,11 +310,11 @@ For example,
 docker run --rm --shm-size=1g \
         --ulimit memlock=-1 \
         --ulimit stack=67108864 \
-        -p8080:8080 \
-        -p8081:8081 \
-        -p8082:8082 \
-        -p7070:7070 \
-        -p7071:7071 \
+        -p 127.0.0.1:8080:8080 \
+        -p 127.0.0.1:8081:8081 \
+        -p 127.0.0.1:8082:8082 \
+        -p 127.0.0.1:7070:7070 \
+        -p 127.0.0.1:7071:7071 \
         --mount type=bind,source=/path/to/model/store,target=/tmp/models <container> torchserve --model-store=/tmp/models
 ```
 

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -20,7 +20,7 @@ do
           if test $
           then
             IMAGE_NAME="pytorch/torchserve:dev-gpu"
-            GPU_DEVICES='--gpus '"\"device=$2\""'' 
+            GPU_DEVICES='--gpus '"\"device=$2\""''
             shift
           fi
           shift
@@ -29,7 +29,7 @@ do
 done
 echo "Starting $IMAGE_NAME docker image"
 
-docker run $DOCKER_RUNTIME $GPU_DEVICES -d --rm -it -p 8080:8080 -p 8081:8081 $IMAGE_NAME > /dev/null 2>&1
+docker run $DOCKER_RUNTIME $GPU_DEVICES -d --rm -it -p 127.0.0.1:8080:8080 -p 127.0.0.1:8081:8081 $IMAGE_NAME > /dev/null 2>&1
 
 container_id=$(docker ps --filter="ancestor=$IMAGE_NAME" -q | xargs)
 

--- a/docker/test_container_health.sh
+++ b/docker/test_container_health.sh
@@ -7,7 +7,7 @@ CONTAINER="test-container-py${IMAGE_TAG}"
 
 
 healthcheck() {
-    docker run -d --rm -it -p 8080:8080 --name="${CONTAINER}" "${IMAGE_TAG}"
+    docker run -d --rm -it -p 127.0.0.1:8080:8080 --name="${CONTAINER}" "${IMAGE_TAG}"
 
     echo "Waiting 5s for container to come up..."
     sleep 5

--- a/docker/test_container_model_prediction.sh
+++ b/docker/test_container_model_prediction.sh
@@ -23,7 +23,7 @@ torchserve --start --ts-config=/home/model-server/config.properties --models mni
 EOF
 
 echo "Starting container ${CONTAINER}"
-docker run --rm -d -it --name "${CONTAINER}" -p 8080:8080 -p 8081:8081 -p 8082:8082 \
+docker run --rm -d -it --name "${CONTAINER}" -p 127.0.0.1:8080:8080 -p 127.0.0.1:8081:8081 -p 127.0.0.1:8082:8082 \
     -v "${FILES_PATH}/mnist.py":"${SERVER_PATH}/mnist.py" \
     -v "${FILES_PATH}/mnist_cnn.pt":"${SERVER_PATH}/mnist_cnn.pt" \
     -v "${FILES_PATH}/mnist_handler.py":"${SERVER_PATH}/mnist_handler.py" \

--- a/docs/batch_inference_with_ts.md
+++ b/docs/batch_inference_with_ts.md
@@ -294,7 +294,7 @@ models={\
 * Start serving the model with the container and pass the config.properties to the container
 
 ```bash
- docker run --rm -it --gpus all -p 8080:8080 -p 8081:8081 --name mar -v /home/ubuntu/serve/model_store:/home/model-server/model-store  -v $ path to config.properties:/home/model-server/config.properties  pytorch/torchserve:latest-gpu
+ docker run --rm -it --gpus all -p 127.0.0.1:8080:8080 -p 127.0.0.1:8081:8081 --name mar -v /home/ubuntu/serve/model_store:/home/model-server/model-store  -v $ path to config.properties:/home/model-server/config.properties  pytorch/torchserve:latest-gpu
 ```
 * Verify that the workers were started properly.
 ```bash

--- a/docs/use_cases.md
+++ b/docs/use_cases.md
@@ -1,12 +1,12 @@
 # Torchserve Use Cases
 
 Torchserve can be used for different use cases. In order to make it convenient for users, some of them have been documented here.
-These use-cases assume you have pre-trained model(s) and `torchserve`, `torch-model-archiver` is installed on your target system. 
+These use-cases assume you have pre-trained model(s) and `torchserve`, `torch-model-archiver` is installed on your target system.
 This should help you in moving your development environment model to production/serving environment.
 
 NOTES
 - If you have not installed latest torchserve and torch-model-archiver then follow [installation](../README.md#install-torchserve-and-torch-model-archiver) instructions and complete installation
-- If planning to use docker make sure following prerequisites are in place - 
+- If planning to use docker make sure following prerequisites are in place -
     - Make sure you have latest docker engine install on your target node. If not then use [this](https://docs.docker.com/engine/install/) link to install it.
     - Follow instructions [install using docker](../docker/README.md#running-torchserve-in-a-production-docker-environment) to share `model-store` directory and start torchserve
 - The following use-case steps uses `curl` to execute torchserve REST api calls. However, you can also use chrome plugin `postman` for this.
@@ -45,10 +45,10 @@ NOTES
     - Docker -  Make sure that MAR file is being copied in volume/directory shared while starting torchserve docker image
 - Start torchserve with following command - `torchserve --start --ncs --model-store <model_store or your_model_store_dir>`
     - Docker - This is not applicable.
-- Register model i.e. MAR file created in step 1 above as `curl -v -X POST "http://localhost:8081/models?initial_workers=1&synchronous=true&url=<your model_name>.mar"` 
+- Register model i.e. MAR file created in step 1 above as `curl -v -X POST "http://localhost:8081/models?initial_workers=1&synchronous=true&url=<your model_name>.mar"`
 - Check if model has been successfully registered as `curl http://localhost:8081/models/<your_model_name>`
 - Scale up workers based on kind of load you are expecting. We have kept min-worker as 1 in registration request above. `curl -v -X PUT "http://localhost:8081/models/<your model_name>?min_worker=1&synchronous=true”`
-- Do inference using following `curl` api call - `curl http://localhost:8080/predictions/<your_model_name> -T <your_input_file>`. You can also use `Postman` GUI tool for HTTP request and response. 
+- Do inference using following `curl` api call - `curl http://localhost:8080/predictions/<your_model_name> -T <your_input_file>`. You can also use `Postman` GUI tool for HTTP request and response.
 
 **Expected outcome**
 - Able to deploy any scripted model
@@ -70,10 +70,10 @@ NOTES
     - Docker -  Make sure that MAR file is being copied in volume/directory shared while starting torchserve docker image
 - Start torchserve with following command - `torchserve --start --ncs --model-store <model_store or your_model_store_dir>`
     - Docker - This is not applicable.
-- Register model i.e. MAR file created in step 1 above as `curl -v -X POST "http://localhost:8081/models?initial_workers=1&synchronous=true&url=<your model_name>.mar"` 
+- Register model i.e. MAR file created in step 1 above as `curl -v -X POST "http://localhost:8081/models?initial_workers=1&synchronous=true&url=<your model_name>.mar"`
 - Check if model has been successfully registered as `curl http://localhost:8081/models/<your_model_name>`
 - Scale up workers based on kind of load you are expecting. We have kept min-worker as 1 in registration request above. `curl -v -X PUT "http://localhost:8081/models/<your model_name>?min_worker=1&synchronous=true”`
-- Do inference using following `curl` api call - `curl http://localhost:8080/predictions/<your_model_name> -T <your_input_file>`. You can also use `Postman` GUI tool for HTTP request and response. 
+- Do inference using following `curl` api call - `curl http://localhost:8080/predictions/<your_model_name> -T <your_input_file>`. You can also use `Postman` GUI tool for HTTP request and response.
 
 **Expected outcome**
 - Able to deploy any scripted model
@@ -83,16 +83,16 @@ NOTES
 - ../examples/image_classifier
 
 ### Serve readymade models on torchserve model zoo
-This use case demostrates deployment of [torch hub](https://pytorch.org/hub/) based `vision` models (classifier, object detector, segmenter) available on [torchserve model zoo](https://github.com/pytorch/serve/blob/master/docs/model_zoo.md). 
+This use case demostrates deployment of [torch hub](https://pytorch.org/hub/) based `vision` models (classifier, object detector, segmenter) available on [torchserve model zoo](https://github.com/pytorch/serve/blob/master/docs/model_zoo.md).
 Use these steps to deploy **publically hosted** models as well.
 
 **Steps to deploy your model(s)**
 - Start torchserve with following command - `torchserve --start --ncs --model-store <model_store or your_model_store_dir>`
     - Docker - This is not applicable.
-- Register model i.e. MAR file created in step 1 above as `curl -v -X POST "http://localhost:8081/models?initial_workers=1&synchronous=true&url=https://<public_url>/<your model_name>.mar"` 
+- Register model i.e. MAR file created in step 1 above as `curl -v -X POST "http://localhost:8081/models?initial_workers=1&synchronous=true&url=https://<public_url>/<your model_name>.mar"`
 - Check if model has been successfully registered as `curl http://localhost:8081/models/<your_model_name>`
 - Scale up workers based on kind of load you are expecting. We have kept min-worker as 1 in registration request above. `curl -v -X PUT "http://localhost:8081/models/<your model_name>?min_worker=1&synchronous=true”`
-- Do inference using following `curl` api call - `curl http://localhost:8080/predictions/<your_model_name> -T <your_input_file>`. You can also use `Postman` GUI tool for HTTP request and response. 
+- Do inference using following `curl` api call - `curl http://localhost:8080/predictions/<your_model_name> -T <your_input_file>`. You can also use `Postman` GUI tool for HTTP request and response.
 
 **Expected outcome**
 - Able to deploy any model available in model zoo
@@ -104,7 +104,7 @@ Use these steps to deploy **publically hosted** models as well.
 - [object_detector](../examples/object_detector)
 
 ### Secure model serving
-This use case demonstrates torchserve deployment for secure model serving. 
+This use case demonstrates torchserve deployment for secure model serving.
 The example taken here uses eager mode model however you can also deploy scripted models.
 
 **Steps to deploy your model(s)**
@@ -119,14 +119,14 @@ The example taken here uses eager mode model however you can also deploy scripte
     - Docker -  Make sure that MAR file is being copied in volume/directory shared while starting torchserve docker image
 - Create `config.properties` file with parameters option 1 or 2 given in [enable SSL](https://github.com/pytorch/serve/blob/master/docs/configuration.md#examples)
 - Start torchserve using properties file created above as - `torchserve --start --ncs --model-store <model_store or your_model_store_dir> --ts-config <your_path>/config.properties`
-    - Docker - `docker run --rm -p8443:8433 -p8444:8444 -p8445:8445 -v <local_dir>/model-store:/home/model-server/model-store <your_docker_image> torchserve --model-store=/tmp/models --ts-config <your_path>/config.properties`
-- Register model i.e. MAR file created in step 1 above as `curl -k -v -X POST "https://localhost:8081/models?initial_workers=1&synchronous=true&url=https://<s3_path>/<your model_name>.mar"` 
+    - Docker - `docker run --rm -p 127.0.0.1:8443:8433 -p 127.0.0.1:8444:8444 -p 127.0.0.1:8445:8445 -v <local_dir>/model-store:/home/model-server/model-store <your_docker_image> torchserve --model-store=/tmp/models --ts-config <your_path>/config.properties`
+- Register model i.e. MAR file created in step 1 above as `curl -k -v -X POST "https://localhost:8081/models?initial_workers=1&synchronous=true&url=https://<s3_path>/<your model_name>.mar"`
 - Check if model has been successfully registered as `curl -k https://localhost:8081/models/<your_model_name>`
 - Scale up workers based on kind of load you are expecting. We have kept min-worker as 1 in registration request above. `curl -v -X PUT "http://localhost:8081/models/<your model_name>?min_worker=1&synchronous=true”`
-- Do inference using following `curl` api call - `curl -k https://localhost:8080/predictions/<your_model_name> -T <your_input_file>`. You can also use `Postman` GUI tool for HTTP request and response. 
-  
+- Do inference using following `curl` api call - `curl -k https://localhost:8080/predictions/<your_model_name> -T <your_input_file>`. You can also use `Postman` GUI tool for HTTP request and response.
+
   NOTICE the use of https and -k option in curl command. In place of -k, you can use other options such as -key etc if you have required key.
-- 
+-
 **Expected outcome**
 - Able to deploy torchserve and access APIs over HTTPs
 
@@ -134,7 +134,7 @@ The example taken here uses eager mode model however you can also deploy scripte
 - https://github.com/pytorch/serve/blob/master/docs/configuration.md#enable-ssl
 
 ### Serve models on GPUs
-This use case demonstrates torchserve deployment on GPU. 
+This use case demonstrates torchserve deployment on GPU.
 The example taken here uses scripted mode model however you can also deploy eager models.
 
 **Prerequisites**
@@ -154,12 +154,12 @@ The example taken here uses scripted mode model however you can also deploy eage
 then use `nvidia-smi` to determine the number of GPU and corresponding ids. Once you have gpu details, you can add `number_of_gpu` param in config.proerties and use second command as given next instruction.
 e.g. number_of_gpu=2
 - Start torchserve with all GPUs- `torchserve --start --ncs --model-store <model_store or your_model_store_dir>`. With restricted GPUs - `torchserve --start --ncs --model-store <model_store or your_model_store_dir> --ts-config <your_path>/config.properties`
-    - Docker -  For all GPU `docker run --rm -it --gpus all -p 8080:8080 -p 8081:8081 torchserve:gpu-latest` For GPUs 1 and 2 `docker run --rm -it --gpus '"device=1,2"' -p 8080:8080 -p 8081:8081 pytorch/torchserve:latest-gpu`
+    - Docker -  For all GPU `docker run --rm -it --gpus all -p 127.0.0.1:8080:8080 -p 127.0.0.1:8081:8081 torchserve:gpu-latest` For GPUs 1 and 2 `docker run --rm -it --gpus '"device=1,2"' -p 8080:8080 -p 8081:8081 pytorch/torchserve:latest-gpu`
     - Docker - For details refer [start gpu container](../docker#start-gpu-container)
-- Register model i.e. MAR file created in step 1 above as `curl -v -X POST "http://localhost:8081/models?initial_workers=1&synchronous=true&url=<your model_name>.mar"` 
+- Register model i.e. MAR file created in step 1 above as `curl -v -X POST "http://localhost:8081/models?initial_workers=1&synchronous=true&url=<your model_name>.mar"`
 - Check if model has been successfully registered as `curl http://localhost:8081/models/<your_model_name>` The response includes flag indicating model has been loaded on GPU.
 - Scale up workers based on kind of load you are expecting. We have kept min-worker as 1 in registration request above. `curl -v -X PUT "http://localhost:8081/models/<your model_name>?min_worker=1&synchronous=true”`
-- Do inference using following `curl` api call - `curl http://localhost:8080/predictions/<your_model_name> -T <your_input_file>`. You can also use `Postman` GUI tool for HTTP request and response. 
+- Do inference using following `curl` api call - `curl http://localhost:8080/predictions/<your_model_name> -T <your_input_file>`. You can also use `Postman` GUI tool for HTTP request and response.
 
 **Expected outcome**
 - Able to deploy any model to GPU
@@ -185,10 +185,10 @@ The example taken here uses scripted mode model however you can also deploy eage
     - Docker -  Make sure that MAR file is being copied in volume/directory shared while starting torchserve docker image
 - Start torchserve with following command - `torchserve --start --ncs --model-store <model_store or your_model_store_dir>`
     - Docker - This is not applicable.
-- Register model i.e. MAR file created in step 1 above as `curl -v -X POST "http://localhost:8081/models?initial_workers=1&synchronous=true&url=<your model_name>.mar"` 
+- Register model i.e. MAR file created in step 1 above as `curl -v -X POST "http://localhost:8081/models?initial_workers=1&synchronous=true&url=<your model_name>.mar"`
 - Check if model has been successfully registered as `curl http://localhost:8081/models/<your_model_name>`
 - Scale up workers based on kind of load you are expecting. We have kept min-worker as 1 in registration request above. `curl -v -X PUT "http://localhost:8081/models/<your model_name>?min_worker=1&synchronous=true”`
-- Do inference using following `curl` api call - `curl http://localhost:8080/predictions/<your_model_name> -T <your_input_file>`. You can also use `Postman` GUI tool for HTTP request and response. 
+- Do inference using following `curl` api call - `curl http://localhost:8080/predictions/<your_model_name> -T <your_input_file>`. You can also use `Postman` GUI tool for HTTP request and response.
 
 **Expected outcome**
 - Able to deploy any model with custom handler
@@ -218,11 +218,11 @@ The example taken here uses scripted mode model however you can also deploy eage
     - Docker -  Make sure that MAR file is being copied in volume/directory shared while starting torchserve docker image
 - Add following parameter to config.properties file - `install_py_dep_per_model=true` . For details refer [Allow model specific custom python packages](https://github.com/pytorch/serve/blob/master/docs/configuration.md#allow-model-specific-custom-python-packages) .
 - Start torchserve with following command with config.properties file - `torchserve --start --ncs --model-store <model_store or your_model_store_dir> --ts-config <your_path>/config.properties`
-    - Docker - `docker run --rm -p8080:8080 -p8081:8081 -v <local_dir>/model-store:/home/model-server/model-store <your_docker_image> torchserve --model-store=/tmp/models --ts-config <your_path>/config.properties
-- Register model i.e. MAR file created in step 1 above as `curl -v -X POST "http://localhost:8081/models?initial_workers=1&synchronous=true&url=<your model_name>.mar"` 
+    - Docker - `docker run --rm -p 127.0.0.1:8080:8080 -p 127.0.0.1:8081:8081 -v <local_dir>/model-store:/home/model-server/model-store <your_docker_image> torchserve --model-store=/tmp/models --ts-config <your_path>/config.properties
+- Register model i.e. MAR file created in step 1 above as `curl -v -X POST "http://localhost:8081/models?initial_workers=1&synchronous=true&url=<your model_name>.mar"`
 - Check if model has been successfully registered as `curl http://localhost:8081/models/<your_model_name>`
 - Scale up workers based on kind of load you are expecting. We have kept min-worker as 1 in registration request above. `curl -v -X PUT "http://localhost:8081/models/<your model_name>?min_worker=1&synchronous=true”`
-- Do inference using following `curl` api call - `curl http://localhost:8080/predictions/<your_model_name> -T <your_input_file>`. You can also use `Postman` GUI tool for HTTP request and response. 
+- Do inference using following `curl` api call - `curl http://localhost:8080/predictions/<your_model_name> -T <your_input_file>`. You can also use `Postman` GUI tool for HTTP request and response.
 
 **Expected outcome**
 - Able to deploy any model with custom handler having third party python dependency
@@ -248,11 +248,11 @@ This use case demonstrates serving two or more versions of same model using vers
 - Now you will be able to invoke these models as
   - Model version 1.0
   `curl http://localhost:8081/models/<your-model-name-X>/1.0`
-  OR 
+  OR
   `curl http://localhost:8080/predictions/<your-model-name-X>/1.0 -F "data=@kitten.jpg"`
   - Model version 2.0
   `curl http://localhost:8081/models/<your-model-name-X>/2.0`
-    OR 
+    OR
   `curl http://localhost:8080/predictions/<your-model-name-X>/2.0 -F "data=@kitten.jpg"`
 
 **Expected outcome**

--- a/examples/asr_rnnt_emformer/01_create_model_archive.sh
+++ b/examples/asr_rnnt_emformer/01_create_model_archive.sh
@@ -24,6 +24,6 @@ $CONTAINER \
 
 # serve; /home/model-server/config.properties has pre-defined model-store location
 docker run --rm --network host \
--p 8080:8080 -p 8081:8081 -p 8082:8082 -p 7070:7070 -p 7071:7071 \
+-p 127.0.0.1:8080:8080 -p 127.0.0.1:8081:8081 -p 127.0.0.1:8082:8082 -p 127.0.0.1:7070:7070 -p 127.0.0.1:7071:7071 \
 -v $PWD:/home/model-server \
 $CONTAINER

--- a/examples/image_classifier/mnist/Docker.md
+++ b/examples/image_classifier/mnist/Docker.md
@@ -28,7 +28,7 @@ Run the commands given in following steps from the parent directory of the root 
   ### Start a docker container with torchserve
 
   ```bash
-  docker run --rm -it -p 8080:8080 -p 8081:8081 -p 8082:8082 -v $(pwd)/model_store:/home/model-server/model-store pytorch/torchserve:latest-cpu
+  docker run --rm -it -p 127.0.0.1:8080:8080 -p 127.0.0.1:8081:8081 -p 127.0.0.1:8082:8082 -v $(pwd)/model_store:/home/model-server/model-store pytorch/torchserve:latest-cpu
   ```
 
   ### Register the model on TorchServe using the above model archive file

--- a/frontend/server/src/main/java/org/pytorch/serve/util/NettyUtils.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/NettyUtils.java
@@ -53,7 +53,7 @@ public final class NettyUtils {
         String remoteIp;
         if (address == null) {
             // This is can be null on UDS, or on certain case in Windows
-            remoteIp = "0.0.0.0";
+            remoteIp = "127.0.0.1";
         } else {
             remoteIp = address.toString();
         }

--- a/frontend/tools/gradle/launcher.gradle
+++ b/frontend/tools/gradle/launcher.gradle
@@ -21,7 +21,7 @@ class LauncherPlugin implements Plugin<Project> {
                 String cp = CollectionUtils.join(File.pathSeparator, list)
                 String jvmPath = Jvm.current().getJavaExecutable()
 
-                def cmd = [jvmPath, "-agentlib:jdwp=transport=dt_socket,address=0.0.0.0:4000,server=y,suspend=n",
+                def cmd = [jvmPath, "-agentlib:jdwp=transport=dt_socket,address=127.0.0.1:4000,server=y,suspend=n",
                            "-DtsConfigFile=${project.projectDir}/src/test/resources/config.properties",
                            "-DLOG_LOCATION=${project.buildDir}/logs",
                            "-DMETRICS_LOCATION=${project.buildDir}/logs",

--- a/test/pytest/test_data/torch_compile/config.properties
+++ b/test/pytest/test_data/torch_compile/config.properties
@@ -1,6 +1,6 @@
-inference_address=http://0.0.0.0:8080
-management_address=http://0.0.0.0:8081
-metrics_address=http://0.0.0.0:8082
+inference_address=http://127.0.0.1:8080
+management_address=http://127.0.0.1:8081
+metrics_address=http://127.0.0.1:8082
 model_store=/home/model-server/model-store
 load_models=half_plus_two.mar
 min_workers=1


### PR DESCRIPTION
## Description
When starting torchserve inside a container, although the address configurations are set to `0.0.0.0` which is required to access torchserve from outside the container, access to torchserve in the container can be limited to localhost by binding the container ports to localhost ports as follows

**config.properties**
```
inference_address=http://0.0.0.0:8080
management_address=http://0.0.0.0:8081
metrics_address=http://0.0.0.0:8082
number_of_netty_threads=32
job_queue_size=1000
model_store=/home/model-server/model-store
workflow_store=/home/model-server/wf-store
```

**Container ports not bound to localhost ports**
```
$ docker run --rm -it -p 8080:8080 -p 8081:8081 -p 8082:8082 pytorch/torchserve:latest-cpu
$ curl http://localhost:8080/ping
{
  "status": "Healthy"
}
$ curl http://10.31.59.11:8080/ping
{
  "status": "Healthy"
}
```

**Container ports bound to localhost ports**
```
$ docker run --rm -it -p 127.0.0.1:8080:8080 -p 127.0.0.1:8081:8081 -p 127.0.0.1:8082:8082 pytorch/torchserve:latest-cpu
$ curl http://localhost:8080/ping  
{
  "status": "Healthy"
}
$ curl http://10.31.59.11:8080/ping
curl: (7) Failed to connect to 10.31.59.11 port 8080 after 2 ms: Couldn't connect to server
```

Fixes #2610 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Feature/Issue validation/testing
- [x] Manual test shown in the description above
- [x] CI 
