### PR TITLE
Upgrade setup-conda from v1 to v1.2.1

### DIFF
--- a/.github/workflows/official_release.yml
+++ b/.github/workflows/official_release.yml
@@ -10,7 +10,7 @@ jobs:
       name: official-release
     steps:
       - name: Setup Conda
-        uses: s-weigand/setup-conda@v1
+        uses: s-weigand/setup-conda@v1.2.1
       - name: Setup Anaconda
         run: |
           conda --version

--- a/.github/workflows/regression_tests_cpu_binaries.yml
+++ b/.github/workflows/regression_tests_cpu_binaries.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup conda with Python ${{ matrix.python-version }}
-        uses: s-weigand/setup-conda@v1
+        uses: s-weigand/setup-conda@v1.2.1
         with:
           update-conda: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/regression_tests_gpu_binaries.yml
+++ b/.github/workflows/regression_tests_gpu_binaries.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           miniconda-version: "latest"
       - name: Setup Conda
-        uses: s-weigand/setup-conda@v1
+        uses: s-weigand/setup-conda@v1.2.1
         with:
           python-version: ${{ matrix.python-version }}
       - name: Setup Python ${{ matrix.python_version }}

--- a/.github/workflows/torchserve-nightly-build.yml
+++ b/.github/workflows/torchserve-nightly-build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Setup Conda
-        uses: s-weigand/setup-conda@v1
+        uses: s-weigand/setup-conda@v1.2.1
       - run: conda --version
       - run: conda install -y conda-build anaconda-client
       - name: Checkout TorchServe


### PR DESCRIPTION
## Description
Upgrade setup-conda from v1 to v1.2.1

Example failures observed with setup-conda v1: https://github.com/pytorch/serve/actions/runs/6404244594/job/17384395423

```
Getting original pythonLocation
  /usr/bin/which python
  Error: The process '/usr/bin/which' failed with exit code 1
```