### PR TITLE
Manually Dispatch Most workflows

### DIFF
--- a/.github/workflows/ci_cpu.yml
+++ b/.github/workflows/ci_cpu.yml
@@ -1,6 +1,7 @@
 name: CI CPU
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/ci_gpu.yml
+++ b/.github/workflows/ci_gpu.yml
@@ -1,6 +1,7 @@
 name: CI GPU
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,7 @@
 name: "CodeQL"
 
 on:
+  workflow_dispatch:
   # run every day at 11:15am
   schedule:
     - cron:  '15 11 * * *'

--- a/.github/workflows/regression_tests_docker.yml
+++ b/.github/workflows/regression_tests_docker.yml
@@ -1,6 +1,7 @@
 name: Run Regression Tests on Docker
 
 on:
+  workflow_dispatch:
   # run every day at 5:15am
   schedule:
     - cron:  '15 5 * * *'

--- a/.github/workflows/regression_tests_gpu.yml
+++ b/.github/workflows/regression_tests_gpu.yml
@@ -1,6 +1,7 @@
 name: Run Regression Tests on GPU
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master


### PR DESCRIPTION
If a CI has `workflow_dispatch:` that means you can manually trigger it from the Actions tab using your branch name. This is useful for example if we'd like to run code scanning on a PR without merging it to master first

This would also be ideal for running benchmarks but we'd need to then add an option to skip benchmark results upload to S3 