### PR TITLE
Fix metric unit assignment

### DIFF
--- a/examples/custom_metrics/README.md
+++ b/examples/custom_metrics/README.md
@@ -72,24 +72,24 @@ curl http://127.0.0.1:8082/metrics
 Requests2XX{Level="Host",Hostname="88665a372f4b.ant.amazon.com",} 1.0
 # HELP PredictionTime Torchserve prometheus gauge metric with unit: ms
 # TYPE PredictionTime gauge
-PredictionTime{ModelName="mnist",Level="Model",Hostname="88665a372f4b.ant.amazon.com",} 62.78
+PredictionTime{ModelName="mnist",Level="Model",Hostname="88665a372f4b.ant.amazon.com",} 17.63
 # HELP DiskUsage Torchserve prometheus gauge metric with unit: Gigabytes
 # TYPE DiskUsage gauge
-DiskUsage{Level="Host",Hostname="88665a372f4b.ant.amazon.com",} 8.438858032226562
+DiskUsage{Level="Host",Hostname="88665a372f4b.ant.amazon.com",} 8.538421630859375
 # HELP WorkerLoadTime Torchserve prometheus gauge metric with unit: Milliseconds
 # TYPE WorkerLoadTime gauge
-WorkerLoadTime{WorkerName="W-9000-mnist_1.0",Level="Host",Hostname="88665a372f4b.ant.amazon.com",} 7425.0
+WorkerLoadTime{WorkerName="W-9000-mnist_1.0",Level="Host",Hostname="88665a372f4b.ant.amazon.com",} 17688.0
 # HELP Requests5XX Torchserve prometheus counter metric with unit: Count
 # TYPE Requests5XX counter
 # HELP CPUUtilization Torchserve prometheus gauge metric with unit: Percent
 # TYPE CPUUtilization gauge
-CPUUtilization{Level="Host",Hostname="88665a372f4b.ant.amazon.com",} 100.0
+CPUUtilization{Level="Host",Hostname="88665a372f4b.ant.amazon.com",} 33.3
 # HELP WorkerThreadTime Torchserve prometheus gauge metric with unit: Milliseconds
 # TYPE WorkerThreadTime gauge
-WorkerThreadTime{Level="Host",Hostname="88665a372f4b.ant.amazon.com",} 3.0
+WorkerThreadTime{Level="Host",Hostname="88665a372f4b.ant.amazon.com",} 2.0
 # HELP DiskAvailable Torchserve prometheus gauge metric with unit: Gigabytes
 # TYPE DiskAvailable gauge
-DiskAvailable{Level="Host",Hostname="88665a372f4b.ant.amazon.com",} 308.94310760498047
+DiskAvailable{Level="Host",Hostname="88665a372f4b.ant.amazon.com",} 294.73255157470703
 # HELP ts_inference_requests_total Torchserve prometheus counter metric with unit: Count
 # TYPE ts_inference_requests_total counter
 ts_inference_requests_total{model_name="mnist",model_version="default",hostname="88665a372f4b.ant.amazon.com",} 1.0
@@ -97,17 +97,17 @@ ts_inference_requests_total{model_name="mnist",model_version="default",hostname=
 # TYPE GPUMemoryUtilization gauge
 # HELP HandlerTime Torchserve prometheus gauge metric with unit: ms
 # TYPE HandlerTime gauge
-HandlerTime{ModelName="mnist",Level="Model",Hostname="88665a372f4b.ant.amazon.com",} 62.64
+HandlerTime{ModelName="mnist",Level="Model",Hostname="88665a372f4b.ant.amazon.com",} 17.54
 # HELP ts_inference_latency_microseconds Torchserve prometheus counter metric with unit: Microseconds
 # TYPE ts_inference_latency_microseconds counter
-ts_inference_latency_microseconds{model_name="mnist",model_version="default",hostname="88665a372f4b.ant.amazon.com",} 64694.367
+ts_inference_latency_microseconds{model_name="mnist",model_version="default",hostname="88665a372f4b.ant.amazon.com",} 4315280.097
 # HELP MemoryUtilization Torchserve prometheus gauge metric with unit: Percent
 # TYPE MemoryUtilization gauge
-MemoryUtilization{Level="Host",Hostname="88665a372f4b.ant.amazon.com",} 53.1
+MemoryUtilization{Level="Host",Hostname="88665a372f4b.ant.amazon.com",} 67.1
 # HELP MemoryAvailable Torchserve prometheus gauge metric with unit: Megabytes
 # TYPE MemoryAvailable gauge
-MemoryAvailable{Level="Host",Hostname="88665a372f4b.ant.amazon.com",} 7677.29296875
-# HELP PostprocessCallCount Torchserve prometheus counter metric with unit: count
+MemoryAvailable{Level="Host",Hostname="88665a372f4b.ant.amazon.com",} 5383.73828125
+# HELP PostprocessCallCount Torchserve prometheus counter metric with unit: CallCount
 # TYPE PostprocessCallCount counter
 PostprocessCallCount{ModelName="mnist",Level="Model",Hostname="88665a372f4b.ant.amazon.com",} 1.0
 # HELP ExamplePercentMetric Torchserve prometheus histogram metric with unit: percent
@@ -133,13 +133,13 @@ ExamplePercentMetric_sum{ModelName="mnist",Level="Model",Hostname="88665a372f4b.
 # TYPE GPUUtilization gauge
 # HELP MemoryUsed Torchserve prometheus gauge metric with unit: Megabytes
 # TYPE MemoryUsed gauge
-MemoryUsed{Level="Host",Hostname="88665a372f4b.ant.amazon.com",} 7903.734375
+MemoryUsed{Level="Host",Hostname="88665a372f4b.ant.amazon.com",} 8286.08984375
 # HELP QueueTime Torchserve prometheus gauge metric with unit: Milliseconds
 # TYPE QueueTime gauge
-QueueTime{Level="Host",Hostname="88665a372f4b.ant.amazon.com",} 0.0
+QueueTime{Level="Host",Hostname="88665a372f4b.ant.amazon.com",} 4295.0
 # HELP ts_queue_latency_microseconds Torchserve prometheus counter metric with unit: Microseconds
 # TYPE ts_queue_latency_microseconds counter
-ts_queue_latency_microseconds{model_name="mnist",model_version="default",hostname="88665a372f4b.ant.amazon.com",} 115.79
+ts_queue_latency_microseconds{model_name="mnist",model_version="default",hostname="88665a372f4b.ant.amazon.com",} 4295688.02
 # HELP PreprocessCallCount Torchserve prometheus counter metric with unit: count
 # TYPE PreprocessCallCount counter
 PreprocessCallCount{ModelName="mnist",Hostname="88665a372f4b.ant.amazon.com",} 1.0
@@ -153,13 +153,13 @@ SizeOfImage{ModelName="mnist",Level="Model",Hostname="88665a372f4b.ant.amazon.co
 # TYPE Requests4XX counter
 # HELP HandlerMethodTime Torchserve prometheus gauge metric with unit: ms
 # TYPE HandlerMethodTime gauge
-HandlerMethodTime{MethodName="preprocess",ModelName="mnist",Level="Model",Hostname="88665a372f4b.ant.amazon.com",} 25.554895401000977
+HandlerMethodTime{MethodName="preprocess",ModelName="mnist",Level="Model",Hostname="88665a372f4b.ant.amazon.com",} 9.392976760864258
 # HELP InitializeCallCount Torchserve prometheus counter metric with unit: count
 # TYPE InitializeCallCount counter
 InitializeCallCount{ModelName="mnist",Level="Model",Hostname="88665a372f4b.ant.amazon.com",} 1.0
 # HELP DiskUtilization Torchserve prometheus gauge metric with unit: Percent
 # TYPE DiskUtilization gauge
-DiskUtilization{Level="Host",Hostname="88665a372f4b.ant.amazon.com",} 2.7
+DiskUtilization{Level="Host",Hostname="88665a372f4b.ant.amazon.com",} 2.8
 # HELP GPUMemoryUsed Torchserve prometheus gauge metric with unit: Megabytes
 # TYPE GPUMemoryUsed gauge
 # HELP InferenceRequestCount Torchserve prometheus counter metric with unit: count

--- a/examples/custom_metrics/metrics.yaml
+++ b/examples/custom_metrics/metrics.yaml
@@ -79,7 +79,7 @@ model_metrics:
       unit: count
       dimensions: [*model_name]
     - name: PostprocessCallCount
-      unit: count
+      unit: CallCount
       dimensions: [*model_name, *level]
   gauge:
     - name: HandlerTime

--- a/ts/metrics/metric_abstract.py
+++ b/ts/metrics/metric_abstract.py
@@ -41,6 +41,7 @@ class MetricAbstract(metaclass=abc.ABCMeta):
 
         """
         self.metric_name = metric_name
+        self.unit = unit
         if unit in list(MetricUnit.units.keys()):
             self.unit = MetricUnit.units[unit]
         self.dimension_names = dimension_names or []

--- a/ts/tests/unit_tests/metrics_yaml_testing/metric_cache_unit_test.py
+++ b/ts/tests/unit_tests/metrics_yaml_testing/metric_cache_unit_test.py
@@ -62,6 +62,26 @@ class TestAddMetrics:
         metric.add_or_update(42.5, ["dummy_model"])
         assert "42.5" in caplog.text
 
+    def test_add_metric_to_cache_with_non_default_unit_passing(self):
+        metrics_cache_obj = MetricsCacheYamlImpl(os.path.join(dir_path, "metrics.yaml"))
+        metrics_cache_obj.add_metric_to_cache(
+            metric_name="test_add_metric_to_cache_with_non_default_unit_passing",
+            unit="custom_unit",
+            dimension_names=["ModelName", "Host"],
+            metric_type=MetricTypes.GAUGE,
+        )
+        assert MetricTypes.GAUGE in metrics_cache_obj.cache.keys()
+        assert (
+            "test_add_metric_to_cache_with_non_default_unit_passing"
+            in metrics_cache_obj.cache[MetricTypes.GAUGE].keys()
+        )
+        assert (
+            metrics_cache_obj.cache[MetricTypes.GAUGE][
+                "test_add_metric_to_cache_with_non_default_unit_passing"
+            ].unit
+            == "custom_unit"
+        )
+
     def test_add_metric_to_cache_fail_metric_name(self):
         metrics_cache_obj = MetricsCacheYamlImpl(os.path.join(dir_path, "metrics.yaml"))
         with pytest.raises(merrors.MetricsCacheTypeError) as exc_info:


### PR DESCRIPTION
## Description
In `metric_abstract.py`, the `unit` attribute is not assigned if it is not one of the units defined in [unit.py](https://github.com/pytorch/serve/blob/master/ts/metrics/unit.py)

https://github.com/pytorch/serve/blob/0510772a8490fc3e3ea394c21d36858234900287/ts/metrics/metric_abstract.py#L43-L44

This can lead to the following error when attempting to emit the metric:
```
stdout MODEL_LOG - AttributeError: 'CachingMetric' object has no attribute 'unit'
```

Fixes #2637

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Feature/Issue validation/testing
- [ ] Unit test included in this PR that runs as part of CI

- [ ] Manual test
Testing the following call to emit metric in handler code across different versions
```
self.context.metrics.add_metric('batchSize', len(data), 'request', dimensions=[Dimension(name="ModelName", value=self.context.model_name), Dimension(name="Level", value="Model")])
```

**v0.6.0**
```
2023-10-09T16:29:59,894 [INFO ] W-9009-mnist_1.0-stdout MODEL_METRICS - batchSize.request:1|#ModelName:mnist,Level:Model|#hostname:88665a372f4b.ant.amazon.com,requestID:136830d9-a9b0-4450-940e-2b1b6b01e0e5,timestamp:1696894199
```

**v0.8.2**
```
2023-10-09T16:32:42,152 [INFO ] W-9006-mnist_1.0-stdout MODEL_LOG - AttributeError: 'CachingMetric' object has no attribute 'unit'
```

**With fix in this PR**
```
2023-10-09T16:41:42,765 [INFO ] W-9006-mnist_1.0-stdout MODEL_METRICS - batchSize.request:1.0|#ModelName:mnist,Level:Model|#hostname:88665a372f4b.ant.amazon.com,requestID:3d5f3d3d-e927-415a-ba1f-c95baef60987,timestamp:1696894902
```