### PR TITLE
Split official release workflow for binaries and docker

### DIFF
--- a/.github/workflows/official_release.yml
+++ b/.github/workflows/official_release.yml
@@ -36,17 +36,3 @@ jobs:
         env:
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: python binaries/upload.py --upload-pypi-packages
-      - name: Login to Docker
-        env:
-          DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
-        run: docker login --username pytorchbot --password "$DOCKER_PASSWORD"
-      - name: Build & Upload pytorch/torchserve Docker images
-        run: |
-          cd docker
-          python build_upload_release.py
-          cd ..
-      - name: Build & Upload pytorch/torchserve-kfs Docker images
-        run: |
-          cd kubernetes/kserve
-          python build_upload_release.py
-          cd ..

--- a/.github/workflows/official_release_docker.yml
+++ b/.github/workflows/official_release_docker.yml
@@ -1,5 +1,5 @@
 #name: Make an official Release of Docker Images
-name: Testing the official Release of Docker Images
+name: Testing official Release of Docker Images
 
 #on: workflow_dispatch
 on: push

--- a/.github/workflows/official_release_docker.yml
+++ b/.github/workflows/official_release_docker.yml
@@ -1,5 +1,5 @@
 #name: Make an official Release of Docker Images
-name: Testing official Release of Docker Images
+name: Testing the official Release of Docker Images
 
 #on: workflow_dispatch
 on: push

--- a/.github/workflows/official_release_docker.yml
+++ b/.github/workflows/official_release_docker.yml
@@ -1,6 +1,16 @@
 name: Make an official Release of Docker Images
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+          upload_docker:
+            description: 'Upload TorchServe Docker Images?'
+            required: true
+            default: 'no'
+          upload_kfs:
+            description: 'Upload TorchServe-kfs Docker Images?'
+            required: true
+            default: 'no'
 
 jobs:
   official-release-docker:
@@ -25,10 +35,12 @@ jobs:
           DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
         run: docker login --username pytorchbot --password "$DOCKER_PASSWORD"
       - name: Build & Upload pytorch/torchserve Docker images
+        if: github.event.inputs.upload_docker == 'yes'
         run: |
           cd docker
           python build_upload_release.py --cleanup
       - name: Build & Upload pytorch/torchserve-kfs Docker images
+        if: github.event.inputs.upload_kfs == 'yes'
         run: |
           cd kubernetes/kserve
           python build_upload_release.py --cleanup

--- a/.github/workflows/official_release_docker.yml
+++ b/.github/workflows/official_release_docker.yml
@@ -1,0 +1,37 @@
+#name: Make an official Release of Docker Images
+name: Testing official Release of Docker Images
+
+#on: workflow_dispatch
+on: push
+
+jobs:
+  #official-release-docker:
+  test-official-release-docker:
+    runs-on: [self-hosted, ci-gpu]
+    steps:
+      - name: Clean up previous run
+        run: |
+          echo "Cleaning up previous run"
+          ls -la ./
+          sudo rm -rf ./* || true
+          sudo rm -rf ./.??* || true
+          ls -la ./
+      - name: Setup Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+          architecture: x64
+      - name: Checkout TorchServe
+        uses: actions/checkout@v3
+      #- name: Login to Docker
+      #  env:
+      #    DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
+      #  run: docker login --username pytorchbot --password "$DOCKER_PASSWORD"
+      - name: Build & Upload pytorch/torchserve Docker images
+        run: |
+          cd docker
+          python build_upload_release.py --cleanup
+      - name: Build & Upload pytorch/torchserve-kfs Docker images
+        run: |
+          cd kubernetes/kserve
+          python build_upload_release.py --cleanup

--- a/.github/workflows/official_release_docker.yml
+++ b/.github/workflows/official_release_docker.yml
@@ -23,10 +23,10 @@ jobs:
           architecture: x64
       - name: Checkout TorchServe
         uses: actions/checkout@v3
-      - name: Login to Docker
-        env:
-          DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
-        run: docker login --username pytorchbot --password "$DOCKER_PASSWORD"
+      #- name: Login to Docker
+      #  env:
+      #    DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
+      #  run: docker login --username pytorchbot --password "$DOCKER_PASSWORD"
       - name: Build & Upload pytorch/torchserve Docker images
         run: |
           cd docker

--- a/.github/workflows/official_release_docker.yml
+++ b/.github/workflows/official_release_docker.yml
@@ -1,12 +1,9 @@
-#name: Make an official Release of Docker Images
-name: Testing official Release of Docker Images
+name: Make an official Release of Docker Images
 
-#on: workflow_dispatch
-on: push
+on: workflow_dispatch
 
 jobs:
-  #official-release-docker:
-  test-official-release-docker:
+  official-release-docker:
     runs-on: [self-hosted, ci-gpu]
     steps:
       - name: Clean up previous run
@@ -23,10 +20,10 @@ jobs:
           architecture: x64
       - name: Checkout TorchServe
         uses: actions/checkout@v3
-      #- name: Login to Docker
-      #  env:
-      #    DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
-      #  run: docker login --username pytorchbot --password "$DOCKER_PASSWORD"
+      - name: Login to Docker
+        env:
+          DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
+        run: docker login --username pytorchbot --password "$DOCKER_PASSWORD"
       - name: Build & Upload pytorch/torchserve Docker images
         run: |
           cd docker

--- a/.github/workflows/official_release_docker.yml
+++ b/.github/workflows/official_release_docker.yml
@@ -23,10 +23,10 @@ jobs:
           architecture: x64
       - name: Checkout TorchServe
         uses: actions/checkout@v3
-      #- name: Login to Docker
-      #  env:
-      #    DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
-      #  run: docker login --username pytorchbot --password "$DOCKER_PASSWORD"
+      - name: Login to Docker
+        env:
+          DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
+        run: docker login --username pytorchbot --password "$DOCKER_PASSWORD"
       - name: Build & Upload pytorch/torchserve Docker images
         run: |
           cd docker

--- a/docker/build_upload_release.py
+++ b/docker/build_upload_release.py
@@ -49,14 +49,14 @@ if __name__ == "__main__":
         dry_run,
     )
 
-    for image in [
-        f"{organization}/torchserve:latest",
-        f"{organization}/torchserve:latest-cpu",
-        f"{organization}/torchserve:latest-gpu",
-        f"{organization}/torchserve:{check_ts_version()}-cpu",
-        f"{organization}/torchserve:{check_ts_version()}-gpu",
-    ]:
-        try_and_handle(f"docker push {image}", dry_run=True)
+    # for image in [
+    #    f"{organization}/torchserve:latest",
+    #    f"{organization}/torchserve:latest-cpu",
+    #    f"{organization}/torchserve:latest-gpu",
+    #    f"{organization}/torchserve:{check_ts_version()}-cpu",
+    #    f"{organization}/torchserve:{check_ts_version()}-gpu",
+    # ]:
+    #    try_and_handle(f"docker push {image}", dry_run=True)
 
     # Cleanup built images
     if args.cleanup:

--- a/docker/build_upload_release.py
+++ b/docker/build_upload_release.py
@@ -21,6 +21,11 @@ if __name__ == "__main__":
         action="store_true",
         help="dry_run will print the commands that will be run without running them",
     )
+    parser.add_argument(
+        "--cleanup",
+        action="store_true",
+        help="Delete all built docker images",
+    )
     args = parser.parse_args()
     dry_run = args.dry_run
     organization = args.organization
@@ -51,4 +56,8 @@ if __name__ == "__main__":
         f"{organization}/torchserve:{check_ts_version()}-cpu",
         f"{organization}/torchserve:{check_ts_version()}-gpu",
     ]:
-        try_and_handle(f"docker push {image}")
+        try_and_handle(f"docker push {image}", dry_run=True)
+
+    # Cleanup built images
+    if args.cleanup:
+        try_and_handle(f"docker system prune --all --volumes", dry_run)

--- a/docker/build_upload_release.py
+++ b/docker/build_upload_release.py
@@ -59,5 +59,7 @@ if __name__ == "__main__":
         try_and_handle(f"docker push {image}", dry_run=True)
 
     # Cleanup built images
+    dry_run = False
     if args.cleanup:
+        try_and_handle(f"docker images", dry_run)
         try_and_handle(f"docker system prune --all --volumes", dry_run)

--- a/docker/build_upload_release.py
+++ b/docker/build_upload_release.py
@@ -56,10 +56,8 @@ if __name__ == "__main__":
         f"{organization}/torchserve:{check_ts_version()}-cpu",
         f"{organization}/torchserve:{check_ts_version()}-gpu",
     ]:
-        try_and_handle(f"docker push {image}", dry_run=True)
+        os.system(f"docker push {image}")
 
     # Cleanup built images
-    dry_run = False
     if args.cleanup:
-        try_and_handle(f"docker images", dry_run)
         try_and_handle(f"docker system prune --all --volumes -f", dry_run)

--- a/docker/build_upload_release.py
+++ b/docker/build_upload_release.py
@@ -63,4 +63,3 @@ if __name__ == "__main__":
     if args.cleanup:
         try_and_handle(f"docker images", dry_run)
         try_and_handle(f"docker system prune --all --volumes -f", dry_run)
-        try_and_handle(f"docker images", dry_run)

--- a/docker/build_upload_release.py
+++ b/docker/build_upload_release.py
@@ -62,4 +62,5 @@ if __name__ == "__main__":
     dry_run = False
     if args.cleanup:
         try_and_handle(f"docker images", dry_run)
-        try_and_handle(f"docker system prune --all --volumes", dry_run)
+        try_and_handle(f"docker system prune --all --volumes -f", dry_run)
+        try_and_handle(f"docker images", dry_run)

--- a/docker/build_upload_release.py
+++ b/docker/build_upload_release.py
@@ -49,14 +49,14 @@ if __name__ == "__main__":
         dry_run,
     )
 
-    # for image in [
-    #    f"{organization}/torchserve:latest",
-    #    f"{organization}/torchserve:latest-cpu",
-    #    f"{organization}/torchserve:latest-gpu",
-    #    f"{organization}/torchserve:{check_ts_version()}-cpu",
-    #    f"{organization}/torchserve:{check_ts_version()}-gpu",
-    # ]:
-    #    try_and_handle(f"docker push {image}", dry_run=True)
+    for image in [
+        f"{organization}/torchserve:latest",
+        f"{organization}/torchserve:latest-cpu",
+        f"{organization}/torchserve:latest-gpu",
+        f"{organization}/torchserve:{check_ts_version()}-cpu",
+        f"{organization}/torchserve:{check_ts_version()}-gpu",
+    ]:
+        try_and_handle(f"docker push {image}", dry_run=True)
 
     # Cleanup built images
     if args.cleanup:

--- a/docker/docker_nightly.py
+++ b/docker/docker_nightly.py
@@ -44,8 +44,8 @@ if __name__ == "__main__":
     )
 
     # Push Nightly images to official PyTorch Dockerhub account
-    try_and_handle(f"docker push {organization}/{cpu_version}", dry_run)
-    try_and_handle(f"docker push {organization}/{gpu_version}", dry_run)
+    os.system(f"docker push {organization}/{cpu_version}")
+    os.system(f"docker push {organization}/{gpu_version}")
 
     # Tag nightly images with latest
     try_and_handle(
@@ -58,8 +58,8 @@ if __name__ == "__main__":
     )
 
     # Push images with latest tag
-    try_and_handle(f"docker push {organization}/{project}:latest-cpu", dry_run)
-    try_and_handle(f"docker push {organization}/{project}:latest-gpu", dry_run)
+    os.system(f"docker push {organization}/{project}:latest-cpu")
+    os.system(f"docker push {organization}/{project}:latest-gpu")
 
     # Cleanup built images
     if args.cleanup:

--- a/docker/docker_nightly.py
+++ b/docker/docker_nightly.py
@@ -63,4 +63,4 @@ if __name__ == "__main__":
 
     # Cleanup built images
     if args.cleanup:
-        try_and_handle(f"docker system prune --all --volumes", dry_run)
+        try_and_handle(f"docker system prune --all --volumes -f", dry_run)

--- a/docker/docker_nightly.py
+++ b/docker/docker_nightly.py
@@ -44,8 +44,8 @@ if __name__ == "__main__":
     )
 
     # Push Nightly images to official PyTorch Dockerhub account
-    os.system(f"docker push {organization}/{cpu_version}")
-    os.system(f"docker push {organization}/{gpu_version}")
+    try_and_handle(f"docker push {organization}/{cpu_version}", dry_run)
+    try_and_handle(f"docker push {organization}/{gpu_version}", dry_run)
 
     # Tag nightly images with latest
     try_and_handle(
@@ -58,8 +58,8 @@ if __name__ == "__main__":
     )
 
     # Push images with latest tag
-    os.system(f"docker push {organization}/{project}:latest-cpu")
-    os.system(f"docker push {organization}/{project}:latest-gpu")
+    try_and_handle(f"docker push {organization}/{project}:latest-cpu", dry_run)
+    try_and_handle(f"docker push {organization}/{project}:latest-gpu", dry_run)
 
     # Cleanup built images
     if args.cleanup:

--- a/kubernetes/kserve/build_upload_release.py
+++ b/kubernetes/kserve/build_upload_release.py
@@ -39,11 +39,11 @@ if __name__ == "__main__":
         dry_run,
     )
 
-    for image in [
-        f"{organization}/torchserve-kfs:{check_ts_version()}",
-        f"{organization}/torchserve-kfs:{check_ts_version()}-gpu",
-    ]:
-        try_and_handle(f"docker push {image}", dry_run=True)
+    # for image in [
+    #    f"{organization}/torchserve-kfs:{check_ts_version()}",
+    #    f"{organization}/torchserve-kfs:{check_ts_version()}-gpu",
+    # ]:
+    #    try_and_handle(f"docker push {image}", dry_run=True)
 
     # Cleanup built images
     if args.cleanup:

--- a/kubernetes/kserve/build_upload_release.py
+++ b/kubernetes/kserve/build_upload_release.py
@@ -21,6 +21,11 @@ if __name__ == "__main__":
         action="store_true",
         help="dry_run will print the commands that will be run without running them",
     )
+    parser.add_argument(
+        "--cleanup",
+        action="store_true",
+        help="Delete all built docker images",
+    )
     args = parser.parse_args()
     dry_run = args.dry_run
     organization = args.organization
@@ -38,4 +43,8 @@ if __name__ == "__main__":
         f"{organization}/torchserve-kfs:{check_ts_version()}",
         f"{organization}/torchserve-kfs:{check_ts_version()}-gpu",
     ]:
-        try_and_handle(f"docker push {image}", dry_run)
+        try_and_handle(f"docker push {image}", dry_run=True)
+
+    # Cleanup built images
+    if args.cleanup:
+        try_and_handle(f"docker system prune --all --volumes", dry_run)

--- a/kubernetes/kserve/build_upload_release.py
+++ b/kubernetes/kserve/build_upload_release.py
@@ -3,7 +3,7 @@ import sys
 from argparse import ArgumentParser
 
 # To help discover local modules
-REPO_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..")
+REPO_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../..")
 sys.path.append(REPO_ROOT)
 
 from ts_scripts.utils import check_ts_version, try_and_handle
@@ -47,4 +47,6 @@ if __name__ == "__main__":
 
     # Cleanup built images
     if args.cleanup:
+        dry_run = False
+        try_and_handle(f"docker images", dry_run)
         try_and_handle(f"docker system prune --all --volumes", dry_run)

--- a/kubernetes/kserve/build_upload_release.py
+++ b/kubernetes/kserve/build_upload_release.py
@@ -43,10 +43,8 @@ if __name__ == "__main__":
         f"{organization}/torchserve-kfs:{check_ts_version()}",
         f"{organization}/torchserve-kfs:{check_ts_version()}-gpu",
     ]:
-        try_and_handle(f"docker push {image}", dry_run=True)
+        os.system(f"docker push {image}")
 
     # Cleanup built images
     if args.cleanup:
-        dry_run = False
-        try_and_handle(f"docker images", dry_run)
         try_and_handle(f"docker system prune --all --volumes -f", dry_run)

--- a/kubernetes/kserve/build_upload_release.py
+++ b/kubernetes/kserve/build_upload_release.py
@@ -50,5 +50,3 @@ if __name__ == "__main__":
         dry_run = False
         try_and_handle(f"docker images", dry_run)
         try_and_handle(f"docker system prune --all --volumes -f", dry_run)
-        try_and_handle(f"docker images", dry_run)
-        try_and_handle(f"docker images", dry_run)

--- a/kubernetes/kserve/build_upload_release.py
+++ b/kubernetes/kserve/build_upload_release.py
@@ -39,11 +39,11 @@ if __name__ == "__main__":
         dry_run,
     )
 
-    # for image in [
-    #    f"{organization}/torchserve-kfs:{check_ts_version()}",
-    #    f"{organization}/torchserve-kfs:{check_ts_version()}-gpu",
-    # ]:
-    #    try_and_handle(f"docker push {image}", dry_run=True)
+    for image in [
+        f"{organization}/torchserve-kfs:{check_ts_version()}",
+        f"{organization}/torchserve-kfs:{check_ts_version()}-gpu",
+    ]:
+        try_and_handle(f"docker push {image}", dry_run=True)
 
     # Cleanup built images
     if args.cleanup:

--- a/kubernetes/kserve/build_upload_release.py
+++ b/kubernetes/kserve/build_upload_release.py
@@ -51,3 +51,4 @@ if __name__ == "__main__":
         try_and_handle(f"docker images", dry_run)
         try_and_handle(f"docker system prune --all --volumes -f", dry_run)
         try_and_handle(f"docker images", dry_run)
+        try_and_handle(f"docker images", dry_run)

--- a/kubernetes/kserve/build_upload_release.py
+++ b/kubernetes/kserve/build_upload_release.py
@@ -49,4 +49,5 @@ if __name__ == "__main__":
     if args.cleanup:
         dry_run = False
         try_and_handle(f"docker images", dry_run)
-        try_and_handle(f"docker system prune --all --volumes", dry_run)
+        try_and_handle(f"docker system prune --all --volumes -f", dry_run)
+        try_and_handle(f"docker images", dry_run)

--- a/kubernetes/kserve/docker_nightly.py
+++ b/kubernetes/kserve/docker_nightly.py
@@ -44,8 +44,8 @@ if __name__ == "__main__":
     )
 
     # Push Nightly images to official PyTorch Dockerhub account
-    try_and_handle(f"docker push {organization}/{cpu_version}", dry_run)
-    try_and_handle(f"docker push {organization}/{gpu_version}", dry_run)
+    os.system(f"docker push {organization}/{cpu_version}")
+    os.system(f"docker push {organization}/{gpu_version}")
 
     # Tag nightly images with latest
     try_and_handle(
@@ -58,8 +58,8 @@ if __name__ == "__main__":
     )
 
     # Push images with latest tag
-    try_and_handle(f"docker push {organization}/{project}:latest-cpu", dry_run)
-    try_and_handle(f"docker push {organization}/{project}:latest-gpu", dry_run)
+    os.system(f"docker push {organization}/{project}:latest-cpu")
+    os.system(f"docker push {organization}/{project}:latest-gpu")
 
     # Cleanup built images
     if args.cleanup:

--- a/kubernetes/kserve/docker_nightly.py
+++ b/kubernetes/kserve/docker_nightly.py
@@ -63,4 +63,4 @@ if __name__ == "__main__":
 
     # Cleanup built images
     if args.cleanup:
-        try_and_handle(f"docker system prune --all --volumes", dry_run)
+        try_and_handle(f"docker system prune --all --volumes -f", dry_run)

--- a/kubernetes/kserve/docker_nightly.py
+++ b/kubernetes/kserve/docker_nightly.py
@@ -44,8 +44,8 @@ if __name__ == "__main__":
     )
 
     # Push Nightly images to official PyTorch Dockerhub account
-    os.system(f"docker push {organization}/{cpu_version}")
-    os.system(f"docker push {organization}/{gpu_version}")
+    try_and_handle(f"docker push {organization}/{cpu_version}", dry_run)
+    try_and_handle(f"docker push {organization}/{gpu_version}", dry_run)
 
     # Tag nightly images with latest
     try_and_handle(
@@ -58,8 +58,8 @@ if __name__ == "__main__":
     )
 
     # Push images with latest tag
-    os.system(f"docker push {organization}/{project}:latest-cpu")
-    os.system(f"docker push {organization}/{project}:latest-gpu")
+    try_and_handle(f"docker push {organization}/{project}:latest-cpu", dry_run)
+    try_and_handle(f"docker push {organization}/{project}:latest-gpu", dry_run)
 
     # Cleanup built images
     if args.cleanup:


### PR DESCRIPTION
## Description

This PR splits the official release workflow into 2 parts
  - The original workflow will only publish binaries
  - Added a second workflow for publishing docker images
    - This is using the CI_GPU runner as self hosted runners have more disk space
    -  This will also ensure that, we can publish docker images once we confirm that PyPI indices are updated with the latest version of TorchServe

Also changed the `docker push` commands to use `os.system` calls as we want this to execute first and be blocking.

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

[Test run of Docker workflow](https://github.com/pytorch/serve/actions/runs/6486104508/job/17613580328)


## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?