### PR TITLE
Docker official build workflow: replace os.system call with subprocess.run

### DIFF
--- a/docker/build_upload_release.py
+++ b/docker/build_upload_release.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
         f"{organization}/torchserve:{check_ts_version()}-cpu",
         f"{organization}/torchserve:{check_ts_version()}-gpu",
     ]:
-        os.system(f"docker push {image}")
+        try_and_handle(f"docker push {image}", dry_run)
 
     # Cleanup built images
     if args.cleanup:

--- a/kubernetes/kserve/build_upload_release.py
+++ b/kubernetes/kserve/build_upload_release.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
         f"{organization}/torchserve-kfs:{check_ts_version()}",
         f"{organization}/torchserve-kfs:{check_ts_version()}-gpu",
     ]:
-        os.system(f"docker push {image}")
+        try_and_handle(f"docker push {image}", dry_run)
 
     # Cleanup built images
     if args.cleanup:


### PR DESCRIPTION
## Description

Based on the docker nightly run, https://github.com/pytorch/serve/actions/runs/6496259741

`subprocess.run` is confirmed to execute as a blocking call. The print statements were misleading.

So, replacing `os.system` with `subprocess.run`

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Nightly docker build


## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?