### PR TITLE
Changing the command to clean up docker images

### DIFF
--- a/.github/workflows/regression_tests_docker.yml
+++ b/.github/workflows/regression_tests_docker.yml
@@ -26,7 +26,7 @@ jobs:
           sudo rm -rf ./* || true
           sudo rm -rf ./.??* || true
           ls -la ./
-          docker system prune -f
+          docker system prune --all --volumes -f
       - name: Checkout TorchServe
         uses: actions/checkout@v3
       - name: Branch name


### PR DESCRIPTION
## Description

It seems like we were not cleaning up the older images in the regression run correctly.


Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

[Docker regression Run](https://github.com/pytorch/serve/actions/runs/6579846118)


## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?