### PR TITLE
Disabling inf2 benchmarks as they are failing

### DIFF
--- a/.github/workflows/benchmark_nightly.yml
+++ b/.github/workflows/benchmark_nightly.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        hardware: [cpu, gpu, inf1, inf2]
+        hardware: [cpu, gpu, inf1]
     runs-on:
       - self-hosted
       - ${{ matrix.hardware }}


### PR DESCRIPTION
## Description

Inf2 benchmark runs have been failing for the last few days.
Disabling till issue is resolved.

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

N/A


## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?