### PR TITLE
Update TorchServe dev container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,7 +64,7 @@ RUN export USE_CUDA=1
 
 ARG CUDA_VERSION=""
 
-RUN git clone --depth 1 https://github.com/pytorch/serve.git
+RUN git clone --depth 1 --recursive https://github.com/pytorch/serve.git
 
 WORKDIR "serve"
 
@@ -181,3 +181,61 @@ ENV TS_RUN_IN_DOCKER True
 
 WORKDIR /home/serve
 CMD ["python", "test/regression_tests.py"]
+
+#Final image for developer Docker image
+FROM ${BASE_IMAGE} as dev-image
+# Re-state ARG PYTHON_VERSION to make it active in this build-stage (uses default define at the top)
+ARG PYTHON_VERSION
+ARG BRANCH_NAME
+ARG BUILD_WITH_IPEX
+ARG IPEX_VERSION=1.11.0
+ARG IPEX_URL=https://software.intel.com/ipex-whl-stable
+ENV PYTHONUNBUFFERED TRUE
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install software-properties-common -y && \
+    add-apt-repository -y ppa:deadsnakes/ppa && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    fakeroot \
+    ca-certificates \
+    dpkg-dev \
+    sudo \
+    g++ \
+    git \
+    python$PYTHON_VERSION \
+    python$PYTHON_VERSION-dev \
+    python3-distutils \
+    python$PYTHON_VERSION-venv \
+    # using openjdk-17-jdk due to circular dependency(ca-certificates) bug in openjdk-17-jre-headless debian package
+    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1009905
+    openjdk-17-jdk \
+    build-essential \
+    curl \
+    vim \
+    numactl \
+    && if [ "$BUILD_WITH_IPEX" = "true" ]; then apt-get update && apt-get install -y libjemalloc-dev libgoogle-perftools-dev libomp-dev && ln -s /usr/lib/x86_64-linux-gnu/libjemalloc.so /usr/lib/libjemalloc.so && ln -s /usr/lib/x86_64-linux-gnu/libtcmalloc.so /usr/lib/libtcmalloc.so && ln -s /usr/lib/x86_64-linux-gnu/libiomp5.so /usr/lib/libiomp5.so; fi \
+    && rm -rf /var/lib/apt/lists/*
+RUN git clone --recursive https://github.com/pytorch/serve.git \
+    && cd serve \
+    && git checkout ${BRANCH_NAME}
+COPY --from=compile-image /home/venv /home/venv
+ENV PATH="/home/venv/bin:$PATH"
+WORKDIR "serve"
+RUN python -m pip install -U pip setuptools \
+    && python -m pip install --no-cache-dir -r requirements/developer.txt \
+    && python ts_scripts/install_from_src.py \
+    && useradd -m model-server \
+    && mkdir -p /home/model-server/tmp \
+    && cp docker/dockerd-entrypoint.sh /usr/local/bin/dockerd-entrypoint.sh \
+    && chmod +x /usr/local/bin/dockerd-entrypoint.sh \
+    && chown -R model-server /home/model-server \
+    && cp docker/config.properties /home/model-server/config.properties \
+    && mkdir /home/model-server/model-store && chown -R model-server /home/model-server/model-store \
+    && chown -R model-server /home/venv
+EXPOSE 8080 8081 8082 7070 7071
+USER model-server
+WORKDIR /home/model-server
+ENV TEMP=/home/model-server/tmp
+ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh"]
+CMD ["serve"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,8 @@
 ### Deprecation notice:
 [Dockerfile.neuron.dev](https://github.com/pytorch/serve/blob/master/docker/Dockerfile.neuron.dev) has been deprecated. Please refer to [deep learning containers](https://github.com/aws/deep-learning-containers/blob/master/available_images.md) repository for neuron torchserve containers.
 
+[Dockerfile.dev](https://github.com/sachanub/serve/blob/master/docker/Dockerfile.dev) has been deprecated. Please refer to [Dockerfile](https://github.com/sachanub/serve/blob/master/docker/Dockerfile) for dev torchserve containers.
+
 ## Contents of this Document
 
 * [Prerequisites](#prerequisites)
@@ -28,19 +30,18 @@ cd serve/docker
 
 # Create TorchServe docker image
 
-Use `build_image.sh` script to build the docker images. The script builds the `production`, `dev` , `ci` and `codebuild` docker images.
+Use `build_image.sh` script to build the docker images. The script builds the `production`, `dev` and `ci` docker images.
 | Parameter | Description |
 |------|------|
 |-h, --help|Show script help|
 |-b, --branch_name|Specify a branch name to use. Default: master |
 |-g, --gpu|Build image with GPU based ubuntu base image|
 |-bi, --baseimage specify base docker image. Example: nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu20.04|
-|-bt, --buildtype|Which type of docker image to build. Can be one of : production, dev, ci, codebuild|
+|-bt, --buildtype|Which type of docker image to build. Can be one of : production, dev, ci|
 |-t, --tag|Tag name for image. If not specified, script uses torchserve default tag names.|
 |-cv, --cudaversion| Specify to cuda version to use. Supported values `cu92`, `cu101`, `cu102`, `cu111`, `cu113`, `cu116`, `cu117`, `cu118`. `cu121`, Default `cu121`|
 |-ipex, --build-with-ipex| Specify to build with intel_extension_for_pytorch. If not specified, script builds without intel_extension_for_pytorch.|
 |-n, --nightly| Specify to build with TorchServe nightly.|
-|--codebuild| Set if you need [AWS CodeBuild](https://aws.amazon.com/codebuild/)|
 |-py, --pythonversion| Specify the python version to use. Supported values `3.8`, `3.9`, `3.10`, `3.11`. Default `3.9`|
 
 
@@ -144,44 +145,6 @@ Creates a docker image with `torchserve` and `torch-model-archiver` installed fr
 
 ```bash
 ./build_image.sh -bt dev -ipex -t torchserve-ipex:1.0
-```
-
-**CODEBUILD ENVIRONMENT IMAGES**
-
-Creates a docker image for codebuild environment
-
-- For creating CPU based image :
-
-```bash
-./build_image.sh -bt codebuild
-```
-
-- For creating GPU based image with cuda version 11.1:
-
-```bash
-./build_image.sh -bt codebuild -g -cv cu113
-```
-
-```bash
-./build_image.sh -bt codebuild -g -cv cu111
-```
-
- - For creating GPU based image with cuda version 10.1:
-
-```bash
-./build_image.sh -bt codebuild -g -cv cu101
-```
-
- - For creating GPU based image with cuda version 9.2:
-
-```bash
-./build_image.sh -bt codebuild -g -cv cu92
-```
-
- - For creating image with a custom tag:
-
-```bash
-./build_image.sh -bt codebuild -t torchserve-codebuild:1.0
 ```
 
 

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -24,7 +24,7 @@ do
           echo "-b, --branch_name=BRANCH_NAME specify a branch_name to use"
           echo "-g, --gpu specify to use gpu"
           echo "-bi, --baseimage specify base docker image. Example: nvidia/cuda:11.7.0-cudnn8-runtime-ubuntu20.04 "
-          echo "-bt, --buildtype specify to created image for codebuild. Possible values: production, dev, codebuild."
+          echo "-bt, --buildtype specify for type of created image. Possible values: production, dev, ci."
           echo "-cv, --cudaversion specify to cuda version to use"
           echo "-t, --tag specify tag name for docker image"
           echo "-lf, --use-local-serve-folder specify this option for the benchmark image if the current 'serve' folder should be used during automated benchmarks"
@@ -142,11 +142,6 @@ then
   DOCKER_TAG="pytorch/torchserve:dev-$MACHINE"
 fi
 
-if [ "${BUILD_TYPE}" == "codebuild" ] && ! $USE_CUSTOM_TAG ;
-then
-  DOCKER_TAG="pytorch/torchserve:codebuild-$MACHINE"
-fi
-
 if [ "$USE_CUSTOM_TAG" = true ]
 then
   DOCKER_TAG=${CUSTOM_TAG}
@@ -164,9 +159,6 @@ then
 elif [ "${BUILD_TYPE}" == "ci" ]
 then
   DOCKER_BUILDKIT=1 docker build --file Dockerfile --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg CUDA_VERSION="${CUDA_VERSION}"  --build-arg PYTHON_VERSION="${PYTHON_VERSION}" --build-arg BUILD_NIGHTLY="${BUILD_NIGHTLY}" --build-arg BRANCH_NAME="${BRANCH_NAME}"  -t "${DOCKER_TAG}" --target ci-image  .
-elif [ "${BUILD_TYPE}" == "benchmark" ]
-then
-  DOCKER_BUILDKIT=1 docker build --pull --no-cache --file Dockerfile.benchmark --build-arg USE_LOCAL_SERVE_FOLDER=$USE_LOCAL_SERVE_FOLDER --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg BRANCH_NAME="${BRANCH_NAME}" --build-arg CUDA_VERSION="${CUDA_VERSION}" --build-arg MACHINE_TYPE="${MACHINE}" --build-arg PYTHON_VERSION="${PYTHON_VERSION}" -t "${DOCKER_TAG}" .
 else
-  DOCKER_BUILDKIT=1 docker build --pull --no-cache --file Dockerfile.dev -t "${DOCKER_TAG}" --build-arg BUILD_TYPE="${BUILD_TYPE}" --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg BRANCH_NAME="${BRANCH_NAME}" --build-arg CUDA_VERSION="${CUDA_VERSION}" --build-arg MACHINE_TYPE="${MACHINE}" --build-arg BUILD_WITH_IPEX="${BUILD_WITH_IPEX}" --build-arg PYTHON_VERSION="${PYTHON_VERSION}" .
+  DOCKER_BUILDKIT=1 docker build --file Dockerfile --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg CUDA_VERSION="${CUDA_VERSION}"  --build-arg PYTHON_VERSION="${PYTHON_VERSION}" --build-arg BUILD_NIGHTLY="${BUILD_NIGHTLY}" --build-arg BRANCH_NAME="${BRANCH_NAME}" --build-arg BUILD_WITH_IPEX="${BUILD_WITH_IPEX}"  -t "${DOCKER_TAG}" --target dev-image  .
 fi

--- a/requirements/developer.txt
+++ b/requirements/developer.txt
@@ -14,7 +14,7 @@ pre-commit==3.3.2
 twine==4.0.2
 mypy==1.3.0
 torchpippy==0.1.1
-intel_extension_for_pytorch==2.0.100; sys_platform != 'win32' and sys_platform != 'darwin'
+intel_extension_for_pytorch==2.1.0; sys_platform != 'win32' and sys_platform != 'darwin'
 onnxruntime==1.15.0
 googleapis-common-protos
 onnx==1.14.1


### PR DESCRIPTION
## Description

Please read our [CONTRIBUTING.md](https://github.com/pytorch/serve/blob/master/CONTRIBUTING.md) prior to creating your first pull request.

Please include a summary of the feature or issue being fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #(issue)

The following changes have been made in this PR:
- Moved the dev container stage to [Dockerfile](https://github.com/sachanub/serve/blob/master/docker/Dockerfile) from [Dockerfile.dev](https://github.com/sachanub/serve/blob/master/docker/Dockerfile.dev)
- While cloning the TorchServe repo in the Docker container, added the `--recursive` option to also pull the third party [googleapis](https://github.com/googleapis/googleapis) repository. If this is not done, running the regression tests inside the container will fail with this error:
```
0.377 google/rpc/status.proto: File not found.
0.377 inference.proto:6:1: Import "google/rpc/status.proto" was not found or had errors.
0.377 inference.proto:32:14: "google.rpc.Status" is not defined.
```
- Update the `build_image.sh` script to build the dev container using `Dockerfile` instead of `Dockerfile.dev`. 
- Removed any `codebuild` and `Dockerfile.benchmark` related code from the `build_image.sh` script.
- Updated the version of `intel_extension_for_pytorch` to `2.1.0`.
- Remove the section related to `codebuild` images from the `README.md` file. 
- Add a deprecation notice for `Dockerfile.dev` in the `README.md` file.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

Tested the dev container by running the regression tests in it. Followed these steps to build and test the dev container:
```
./build_image.sh -g -bt dev
docker run -it --rm --gpus=all --user root pytorch/torchserve:dev-gpu /bin/bash
apt-get update 
DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y wget nodejs npm zip unzip
npm install -g newman@5.3.2 newman-reporter-htmlextra markdown-link-check
cd /serve
python test/regression_tests.py
```

The logs of the test run can be found here [regression_tests_logs.txt](https://github.com/pytorch/serve/files/13313030/regression_tests_logs.txt)

Tested the dev IPEX container by running https://github.com/pytorch/serve/blob/master/test/pytest/test_example_intel_extension_for_pytorch.py in it. Followed these steps to build and test the dev IPEX container:
```
./build_image.sh -bt dev -ipex -t pytorch/torchserve:dev-ipex
docker run -it --rm --privileged --user root pytorch/torchserve:dev-ipex /bin/bash
mkdir -p /home/model-server/tmp/workspace/model_store
cd /home/model-server/tmp/workspace/model_store/
curl -O https://torchserve.pytorch.org/mar_files/resnet-18.mar
cd /serve/test/pytest
pytest -rA test_example_intel_extension_for_pytorch.py
```
The logs of the IPEX tests can be found here [regression_test_ipex_logs.txt](https://github.com/pytorch/serve/files/13314125/regression_test_ipex_logs.txt)
