### PR TITLE
Set request ID for load model requests

### DIFF
--- a/ts/model_service_worker.py
+++ b/ts/model_service_worker.py
@@ -10,6 +10,7 @@ import os
 import platform
 import socket
 import sys
+import uuid
 from typing import Optional
 
 from ts.arg_parser import ArgParser
@@ -127,6 +128,11 @@ class TorchModelServiceWorker(object):
                 limit_max_image_pixels = bool(load_model_request["limitMaxImagePixels"])
 
             self.metrics_cache.model_name = model_name
+            # Backwards Compatibility with releases <=0.6.0
+            # Request ID is not set for model load requests
+            # TODO: UUID serves as a temporary request ID for model load requests
+            self.metrics_cache.set_request_ids(str(uuid.uuid4()))
+
             model_loader = ModelLoaderFactory.get_model_loader()
             service = model_loader.load(
                 model_name,


### PR DESCRIPTION
## Description
In versions up to `0.6.0`, the `request_id` for model load requests are generated at random. Therefore, metrics updated in the `initialize` function of the handler have both `ModelName` and `Level` dimensions
https://github.com/pytorch/serve/blob/4236a86dc0a018198ecd3fe261e835b416df739e/ts/model_loader.py#L90-L91

In versions `0.6.1` onward, the `request_ids` is not set, therefore, metrics updated in the `initialize` function only have the `Level` dimension set to `Level:Error`.
https://github.com/pytorch/serve/blob/0510772a8490fc3e3ea394c21d36858234900287/ts/model_service_worker.py#L65-L67

This PR fixes this issue by setting the request ID for load model reqeusts.

Fixes #2772 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)