### PR TITLE
Include torch-tensorrt in dev container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -225,6 +225,7 @@ WORKDIR "serve"
 RUN python -m pip install -U pip setuptools \
     && python -m pip install --no-cache-dir -r requirements/developer.txt \
     && python ts_scripts/install_from_src.py \
+    && if [ -n "$CUDA_VERSION" ]; then python -m pip install --no-cache-dir tensorrt==8.5.3.1 torch-tensorrt==1.4.0; fi \
     && useradd -m model-server \
     && mkdir -p /home/model-server/tmp \
     && cp docker/dockerd-entrypoint.sh /usr/local/bin/dockerd-entrypoint.sh \

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -48,7 +48,7 @@ do
           MACHINE=gpu
           DOCKER_TAG="pytorch/torchserve:latest-gpu"
           BASE_IMAGE="nvidia/cuda:11.8.0-base-ubuntu20.04"
-          CUDA_VERSION="cu117"
+          CUDA_VERSION="cu118"
           shift
           ;;
         -bi|--baseimage)
@@ -105,10 +105,10 @@ do
             BASE_IMAGE="nvidia/cuda:11.7.1-base-ubuntu20.04"
           elif [ "${CUDA_VERSION}" == "cu116" ];
           then
-            BASE_IMAGE="nvidia/cuda:11.6.0-cudnn8-runtime-ubuntu20.04"
+            BASE_IMAGE="nvidia/cuda:11.6.2-cudnn8-runtime-ubuntu20.04"
           elif [ "${CUDA_VERSION}" == "cu113" ];
           then
-            BASE_IMAGE="nvidia/cuda:11.3.0-cudnn8-runtime-ubuntu20.04"
+            BASE_IMAGE="nvidia/cuda:11.3.1-cudnn8-runtime-ubuntu20.04"
           elif [ "${CUDA_VERSION}" == "cu111" ];
           then
             BASE_IMAGE="nvidia/cuda:11.1.1-cudnn8-runtime-ubuntu20.04"

--- a/test/pytest/test_example_torch_tensorrt.py
+++ b/test/pytest/test_example_torch_tensorrt.py
@@ -1,0 +1,102 @@
+import os
+import subprocess
+import requests
+from shutil import copy
+import json
+import torch
+import test_utils
+import pytest
+
+CURR_FILE_PATH = os.path.dirname(os.path.realpath(__file__))
+REPO_ROOT_DIR = os.path.normpath(os.path.join(CURR_FILE_PATH, "..", ".."))
+MODEL_STORE_DIR = os.path.join(REPO_ROOT_DIR, "model_store")
+TORCH_TENSORRT_EXAMPLE_DIR = os.path.join(REPO_ROOT_DIR, "examples", "torch_tensorrt")
+TORCH_TENSORRT_MAR_FILE = os.path.join(REPO_ROOT_DIR, "res50-trt-fp16.mar")
+EXPECTED_RESULTS = ['tabby', 'tiger_cat', 'Egyptian_cat', 'lynx', 'lens_cap']
+
+tensorrt_available = False
+cmd = ["python", "-c", "import tensorrt"]
+r = subprocess.run(cmd)
+tensorrt_available = r.returncode == 0
+
+torch_tensorrt_available = False
+cmd = ["python", "-c", "import torch_tensorrt"]
+r = subprocess.run(cmd)
+torch_tensorrt_available = r.returncode == 0
+
+tensorrt_and_torch_tensorrt_available = tensorrt_available and torch_tensorrt_available
+
+
+def setup_module():
+    test_utils.torchserve_cleanup()
+    create_example_mar()
+
+    os.makedirs(MODEL_STORE_DIR, exist_ok=True)
+    copy(TORCH_TENSORRT_MAR_FILE, MODEL_STORE_DIR)
+
+    test_utils.start_torchserve(model_store=MODEL_STORE_DIR)
+
+
+def teardown_module():
+    test_utils.torchserve_cleanup()
+
+    test_utils.delete_model_store(MODEL_STORE_DIR)
+    os.rmdir(MODEL_STORE_DIR)
+
+    delete_example_mar()
+
+
+def create_example_mar():
+    if not os.path.exists(TORCH_TENSORRT_MAR_FILE):
+        create_serialized_file_cmd = f"cd {REPO_ROOT_DIR};python {os.path.join(TORCH_TENSORRT_EXAMPLE_DIR, 'resnet_tensorrt.py')}"
+        subprocess.check_call(create_serialized_file_cmd, shell=True)
+        create_mar_cmd = (
+            f"torch-model-archiver --model-name res50-trt-fp16 --handler image_classifier --version 1.0 --serialized-file res50_trt_fp16.pt --extra-files "
+            f"{os.path.join(REPO_ROOT_DIR, 'examples', 'image_classifier', 'index_to_name.json')}"
+        )
+        subprocess.check_call(create_mar_cmd, shell=True)
+
+
+def delete_example_mar():
+    try:
+        os.remove(TORCH_TENSORRT_MAR_FILE)
+    except OSError:
+        pass
+
+
+@pytest.mark.skipif(
+    not (tensorrt_and_torch_tensorrt_available and torch.cuda.is_available()),
+    reason="Make sure tensorrt and torch-tensorrt are installed and torch.cuda is available",
+)
+def test_model_archive_creation():
+    assert os.path.exists(TORCH_TENSORRT_MAR_FILE), "Failed to create torch tensorrt mar file"
+
+
+@pytest.mark.skipif(
+    not (tensorrt_and_torch_tensorrt_available and torch.cuda.is_available()),
+    reason="Make sure tensorrt and torch-tensorrt are installed and torch.cuda is available",
+)
+def test_model_register_unregister():
+    reg_resp = test_utils.register_model("res50-trt-fp16", "res50-trt-fp16.mar")
+    assert reg_resp.status_code == 200, "Model Registration Failed"
+
+    unreg_resp = test_utils.unregister_model("res50-trt-fp16")
+    assert unreg_resp.status_code == 200, "Model Unregistration Failed"
+
+
+@pytest.mark.skipif(
+    not (tensorrt_and_torch_tensorrt_available and torch.cuda.is_available()),
+    reason="Make sure tensorrt and torch-tensorrt are installed and torch.cuda is available"
+)
+def test_run_inference_torch_tensorrt():
+    test_utils.register_model("res50-trt-fp16", "res50-trt-fp16.mar")
+    image_path = os.path.join(REPO_ROOT_DIR, "examples/image_classifier/kitten.jpg")
+    with open(image_path, 'rb') as file:
+        image_data = file.read()
+    payload = {"data": image_data}
+    response = requests.post(url="http://localhost:8080/predictions/res50-trt-fp16", files=payload)
+    assert response.status_code == 200, "Image prediction failed"
+    result_dict = json.loads(response.content.decode('utf-8'))
+    labels = list(result_dict.keys())
+    assert labels == EXPECTED_RESULTS, "Image prediction labels do not match"
+    test_utils.unregister_model("res50-trt-fp16")


### PR DESCRIPTION
## Description

Please read our [CONTRIBUTING.md](https://github.com/pytorch/serve/blob/master/CONTRIBUTING.md) prior to creating your first pull request.

Please include a summary of the feature or issue being fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

The objective of this PR is to install `tensorrt` and `torch-tensorrt` in the TorchServe dev container. The following changes have been made:
- Included line to install `tensorrt==8.5.3.1` and `torch-tensorrt==1.4.0` if `$CUDA_VERSION` is not empty.
- Created a new regression test for the Torch TensorRT usecase. Included tests to check: 
    - Successful creation of the ResNet-50 model artifact compiled with Torch TensorRT using the `torch-model-archiver`.
    - Successful loading and unloading of the ResNet-50 model compiled with Torch TensorRT.
    - Successful inference against the ResNet-50 model compiled with Torch TensorRT.
- Minor fixes in `build_image.sh` script:
    - Changed default CUDA version to 11.8 since default base image for GPU is `nvidia/cuda:11.8.0-base-ubuntu20.04`.
    - Changed default base image for CUDA 11.6 to `nvidia/cuda:11.6.2-cudnn8-runtime-ubuntu20.04`. The old one i.e. `nvidia/cuda:11.6.0-cudnn8-runtime-ubuntu20.04` is no longer available on Docker hub.
    -  Changed default base image for CUDA 11.3 to `nvidia/cuda:11.3.1-cudnn8-runtime-ubuntu20.04`. The old one i.e. `nvidia/cuda:11.3.0-cudnn8-runtime-ubuntu20.04` is no longer available on Docker hub.

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

Ran the `test_example_torch_tensorrt.py` test on the CPU, CUDA 11.8 and CUDA 12.1 dev containers. 

- CPU dev image (expect tests to skip):
    - Test logs: [cpu_container_logs.txt](https://github.com/pytorch/serve/files/13343057/cpu_container_logs.txt)
    - Reproduction steps:
```
./build_image.sh -bt dev 
docker run -it --rm --user root -v$(pwd):/serve pytorch/torchserve:dev-cpu /bin/bash
cd /serve
pytest -rA test/pytest/test_example_torch_tensorrt.py
```
- CUDA 11.8 dev image:
    - Test logs: [cu118_container_logs.txt](https://github.com/pytorch/serve/files/13343063/cu118_container_logs.txt)
    - Reproduction steps:
```
./build_image.sh -g -cv cu118 -bt dev -t pytorch/torchserve:dev-gpu-cu118 
docker run -it --rm --user root --gpus=all -v$(pwd):/serve pytorch/torchserve:dev-gpu-cu118 /bin/bash
cd /serve
pytest -rA test/pytest/test_example_torch_tensorrt.py
```
- CUDA 12.1 dev image:
    - Test logs: [cu121_container_logs.txt](https://github.com/pytorch/serve/files/13343067/cu121_container_logs.txt)
    - Reproduction steps:
```
./build_image.sh -g -cv cu121 -bt dev -t pytorch/torchserve:dev-gpu-cu121 
docker run -it --rm --user root --gpus=all -v$(pwd):/serve pytorch/torchserve:dev-gpu-cu121 /bin/bash
cd /serve
pytest -rA test/pytest/test_example_torch_tensorrt.py
```



