### PR TITLE
Fixed workflow store pathing issue #2792

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -25,7 +25,7 @@ To try out TorchServe serving now, you can load the custom MNIST model, with thi
 After this deep dive, you might also be interested in:
 * [Logging](logging.md): logging options that are available
 
-* [Metrics](metrics.md): details on metrics collection 
+* [Metrics](metrics.md): details on metrics collection
 
 * [REST API Description](rest_api.md): more detail about the server's endpoints
 
@@ -68,7 +68,7 @@ optional arguments:
                         MODEL_STORE.
   --log-config LOG_CONFIG
                         Log4j configuration file for TorchServe
-  --ncs, --no-config-snapshots         
+  --ncs, --no-config-snapshots
                         Disable snapshot feature
   --workflow-store WORKFLOW_STORE
                         Workflow store location where workflow can be loaded. Defaults to model-store
@@ -106,6 +106,14 @@ There are no default required arguments to start the server
 1. **log-config**: optional, This parameter will override default log4j2.xml, present within the server.
 1. **start**: optional, A more descriptive way to start the server.
 1. **stop**: optional, Stop the server if it is already running.
+
+#### Argument Priority:
+Arguments can be set in multiple locations (ex: command line, config.properties). The following is the priority:
+1. Command line
+2. Config properties
+3. Default settings
+
+Example: Setting `model-store` in config.properties and through command line will result in the the command line location being used and overriding the config.properties.
 
 ## Advanced Features
 

--- a/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
@@ -211,7 +211,7 @@ public final class ConfigManager {
         if (workflowStore != null) {
             prop.setProperty(TS_WORKFLOW_STORE, workflowStore);
         } else if (prop.getProperty(TS_WORKFLOW_STORE) == null) {
-            prop.setProperty(TS_WORKFLOW_STORE, modelStore);
+            prop.setProperty(TS_WORKFLOW_STORE, prop.getProperty(TS_MODEL_STORE));
         }
 
         String[] models = args.getModels();

--- a/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
@@ -210,6 +210,8 @@ public final class ConfigManager {
         String workflowStore = args.getWorkflowStore();
         if (workflowStore != null) {
             prop.setProperty(TS_WORKFLOW_STORE, workflowStore);
+        } else if (prop.getProperty(TS_WORKFLOW_STORE) == null) {
+            prop.setProperty(TS_WORKFLOW_STORE, modelStore);
         }
 
         String[] models = args.getModels();

--- a/frontend/server/src/test/java/org/pytorch/serve/util/ConfigManagerTest.java
+++ b/frontend/server/src/test/java/org/pytorch/serve/util/ConfigManagerTest.java
@@ -86,8 +86,9 @@ public class ConfigManagerTest {
         args.setSnapshotDisabled(true);
         ConfigManager.init(args);
         ConfigManager configManager = ConfigManager.getInstance();
+        String workingDir = configManager.getModelServerHome();
         Assert.assertEquals(
-                "/home/ubuntu/serve/frontend/archive/src/test/resources/workflows",
+                workingDir + "/frontend/archive/src/test/resources/workflows",
                 configManager.getWorkflowStore());
     }
 }

--- a/frontend/server/src/test/java/org/pytorch/serve/util/ConfigManagerTest.java
+++ b/frontend/server/src/test/java/org/pytorch/serve/util/ConfigManagerTest.java
@@ -91,4 +91,18 @@ public class ConfigManagerTest {
                 workingDir + "/frontend/archive/src/test/resources/workflows",
                 configManager.getWorkflowStore());
     }
+
+    @Test
+    public void testNoWorkflowState() throws ReflectiveOperationException, IOException {
+        System.setProperty("tsConfigFile", "src/test/resources/config_test_workflow.properties");
+        ConfigManager.Arguments args = new ConfigManager.Arguments();
+        args.setModels(new String[] {"noop_v0.1"});
+        args.setSnapshotDisabled(true);
+        ConfigManager.init(args);
+        ConfigManager configManager = ConfigManager.getInstance();
+        String workingDir = configManager.getModelServerHome();
+        Assert.assertEquals(
+                workingDir + "/frontend/archive/src/test/resources/models",
+                configManager.getWorkflowStore());
+    }
 }

--- a/frontend/server/src/test/java/org/pytorch/serve/util/ConfigManagerTest.java
+++ b/frontend/server/src/test/java/org/pytorch/serve/util/ConfigManagerTest.java
@@ -77,4 +77,17 @@ public class ConfigManagerTest {
         Assert.assertEquals(4, configManager.getJsonIntValue("noop", "1.0", "batchSize", 1));
         Assert.assertEquals(4, configManager.getJsonIntValue("vgg16", "1.0", "maxWorkers", 1));
     }
+
+    @Test
+    public void testWorkflowState() throws ReflectiveOperationException, IOException {
+        System.setProperty("tsConfigFile", "src/test/resources/config_test_env.properties");
+        ConfigManager.Arguments args = new ConfigManager.Arguments();
+        args.setModels(new String[] {"noop_v0.1"});
+        args.setSnapshotDisabled(true);
+        ConfigManager.init(args);
+        ConfigManager configManager = ConfigManager.getInstance();
+        Assert.assertEquals(
+                "/home/ubuntu/serve/frontend/archive/src/test/resources/workflows",
+                configManager.getWorkflowStore());
+    }
 }

--- a/frontend/server/src/test/resources/config_test_workflow.properties
+++ b/frontend/server/src/test/resources/config_test_workflow.properties
@@ -1,0 +1,55 @@
+# debug=true
+# vmargs=-Xmx128m -XX:-UseLargePages -XX:+UseG1GC -XX:MaxMetaspaceSize=32M -XX:MaxDirectMemorySize=10m -XX:+ExitOnOutOfMemoryError
+inference_address=https://127.0.0.1:8443
+management_address=unix:/tmp/management.sock
+metrics_address=https://127.0.0.1:8445
+# model_server_home=../..
+model_store=../archive/src/test/resources/models
+load_models=noop-v0.1,noop-v1.0
+# number_of_netty_threads=0
+# netty_client_threads=0
+# default_workers_per_model=0
+# job_queue_size=100
+async_logging=true
+default_response_timeout=120
+unregister_model_timeout=120
+# number_of_gpu=1
+# cors_allowed_origin
+# cors_allowed_methods
+# cors_allowed_headers
+# keystore=src/test/resources/keystore.p12
+# keystore_pass=changeit
+# keystore_type=PKCS12
+private_key_file=src/test/resources/key.pem
+certificate_file=src/test/resources/certs.pem
+# max_response_size=6553500
+max_request_size=10485760
+# blacklist_env_vars=.*USERNAME.*|.*PASSWORD.*
+# enable_envvars_config=false
+# decode_input_request=true
+workflow_store=../archive/src/test/resources/workflows
+models={\
+  "noop": {\
+    "1.0": {\
+        "defaultVersion": true,\
+        "marName": "noop.mar",\
+        "minWorkers": 1,\
+        "maxWorkers": 1,\
+        "batchSize": 4,\
+        "maxBatchDelay": 100,\
+        "responseTimeout": 120\
+    }\
+  },\
+  "vgg16": {\
+    "1.0": {\
+        "defaultVersion": true,\
+        "marName": "vgg16.mar",\
+        "minWorkers": 1,\
+        "maxWorkers": 4,\
+        "batchSize": 8,\
+        "maxBatchDelay": 100,\
+        "responseTimeout": 120\
+    }\
+  }\
+}
+metrics_config=src/test/resources/metrics_default.yaml

--- a/frontend/server/src/test/resources/config_test_workflow.properties
+++ b/frontend/server/src/test/resources/config_test_workflow.properties
@@ -5,6 +5,7 @@ management_address=unix:/tmp/management.sock
 metrics_address=https://127.0.0.1:8445
 # model_server_home=../..
 model_store=../archive/src/test/resources/models
+# workflow_store=../archive/src/test/resources/workflows
 load_models=noop-v0.1,noop-v1.0
 # number_of_netty_threads=0
 # netty_client_threads=0
@@ -27,7 +28,6 @@ max_request_size=10485760
 # blacklist_env_vars=.*USERNAME.*|.*PASSWORD.*
 # enable_envvars_config=false
 # decode_input_request=true
-workflow_store=../archive/src/test/resources/workflows
 models={\
   "noop": {\
     "1.0": {\

--- a/ts/model_server.py
+++ b/ts/model_server.py
@@ -177,9 +177,6 @@ def start() -> None:
 
             cmd.append("-w")
             cmd.append(args.workflow_store)
-        else:
-            cmd.append("-w")
-            cmd.append(args.model_store)
 
         if args.no_config_snapshots:
             cmd.append("-ncs")

--- a/ts/model_server.py
+++ b/ts/model_server.py
@@ -10,6 +10,7 @@ import sys
 import tempfile
 from builtins import str
 from typing import Dict
+
 import psutil
 
 from ts.arg_parser import ArgParser
@@ -104,8 +105,7 @@ def start() -> None:
                 sys.exit(1)
             ts_conf_file = ts_config
 
-        platform_path_separator = {
-            "Windows": "", "Darwin": ".:", "Linux": ".:"}
+        platform_path_separator = {"Windows": "", "Darwin": ".:", "Linux": ".:"}
         class_path = "{}{}".format(
             platform_path_separator[platform.system()],
             os.path.join(ts_home, "ts", "frontend", "*"),


### PR DESCRIPTION
https://github.com/pytorch/serve/issues/2792

Issue is that workflow store pathing in config.properties is being overwritten by the default workflow store location. 
Fixed this so that default path is only set if config.properties and cmd line are both empty. 


## Feature/Issue validation/testing:

- **Test Case 1:**
    - Created test in configManagerTest suite -  testWorkflowState()
    - Checks if `getWorkflowStore()` returns the same path as provided in `config_test_env.properties`


- **Test Case 2:**
    - Created test in configManagerTest suite - testNoWorkflowState
    - Checks if `getWorkflowStore()` returns the default path (model_store path) since `config_test_workflow.properties` has no workflow_path


- **Test Case 3: added workflow_store path to config.properties and expect it to be used.**

config.properties:
````
inference_address=http://0.0.0.0:8080
management_address=http://0.0.0.0:8081
metrics_address=http://0.0.0.0:8082
number_of_netty_threads=32
job_queue_size=1000
model_store=/home/ubuntu/serve/model_store
workflow_store=/home/ubuntu/serve/wf-store
````
Ran: 
`torchserve --start --ncs --ts-config /home/ubuntu/serve/config.properties `

Result: 
````
Torchserve version: 0.9.0
TS Home: /opt/conda/lib/python3.10/site-packages
Current directory: /home/ubuntu/serve
Temp directory: /tmp
Metrics config path: /opt/conda/lib/python3.10/site-packages/ts/configs/metrics.yaml
Number of GPUs: 1
Number of CPUs: 4
Max heap size: 3924 M
Python executable: /opt/conda/bin/python
Config file: /home/ubuntu/serve/config.properties
Inference address: http://0.0.0.0:8080
Management address: http://0.0.0.0:8081
Metrics address: http://0.0.0.0:8082
Model Store: /home/ubuntu/serve/model_store
Initial Models: N/A
Log dir: /home/ubuntu/serve/logs
Metrics dir: /home/ubuntu/serve/logs
Netty threads: 32
Netty client threads: 0
Default workers per model: 1
Blacklist Regex: N/A
Maximum Response Size: 6553500
Maximum Request Size: 6553500
Limit Maximum Image Pixels: true
Prefer direct buffer: false
Allowed Urls: [file://.*|http(s)?://.*]
Custom python dependency for model allowed: false
Enable metrics API: true
Metrics mode: log
Disable system metrics: false
Workflow Store: /home/ubuntu/serve/wf-store
Model config: N/A
````

- **Test Case 4: Config file with no workflow store and no command line input, Expect default value (model_store path)**

config.properties:
````
inference_address=http://0.0.0.0:8080
management_address=http://0.0.0.0:8081
metrics_address=http://0.0.0.0:8082
number_of_netty_threads=32
job_queue_size=1000
model_store=/home/ubuntu/serve/model_store
````
Ran: 

`torchserve --start --ncs --model-store /home/ubuntu/serve/model_store`

Result: 
````
Torchserve version: 0.9.0
TS Home: /opt/conda/lib/python3.10/site-packages
Current directory: /home/ubuntu/serve
Temp directory: /tmp
Metrics config path: /opt/conda/lib/python3.10/site-packages/ts/configs/metrics.yaml
Number of GPUs: 1
Number of CPUs: 4
Max heap size: 3924 M
Python executable: /opt/conda/bin/python
Config file: config.properties
Inference address: http://0.0.0.0:8080
Management address: http://0.0.0.0:8081
Metrics address: http://0.0.0.0:8082
Model Store: /home/ubuntu/serve/model_store
Initial Models: N/A
Log dir: /home/ubuntu/serve/logs
Metrics dir: /home/ubuntu/serve/logs
Netty threads: 32
Netty client threads: 0
Default workers per model: 1
Blacklist Regex: N/A
Maximum Response Size: 6553500
Maximum Request Size: 6553500
Limit Maximum Image Pixels: true
Prefer direct buffer: false
Allowed Urls: [file://.*|http(s)?://.*]
Custom python dependency for model allowed: false
Enable metrics API: true
Metrics mode: log
Disable system metrics: false
Workflow Store: /home/ubuntu/serve/model_store
Model config: N/A
````


