### PR TITLE
Fix gRPC docs to properly clone the git submodules

### DIFF
--- a/docs/grpc_api.md
+++ b/docs/grpc_api.md
@@ -31,9 +31,8 @@ Run following commands to Register, run inference and unregister, densenet161 mo
  - Clone serve repo to run this example
 
 ```bash
-git clone https://github.com/pytorch/serve
+git clone --recurse-submodules https://github.com/pytorch/serve
 cd serve
-git submodule init
 ```
 
  - Install gRPC python dependencies


### PR DESCRIPTION
The current docs code only init the submodules but doesn't clone them. This change does both and bundles it into the main `git clone`.