### PR TITLE
Use `inference_mode` instead of `no_grad`

### DIFF
--- a/ts/torch_handler/base_handler.py
+++ b/ts/torch_handler/base_handler.py
@@ -313,7 +313,7 @@ class BaseHandler(abc.ABC):
         Returns:
             Torch Tensor : The Predicted Torch Tensor is returned in this function.
         """
-        with torch.no_grad():
+        with torch.inference_mode():
             marshalled_data = data.to(self.device)
             results = self.model(marshalled_data, *args, **kwargs)
         return results


### PR DESCRIPTION
Use `inference_mode` instead of `no_grad` for `BaseHandler`. It should bring a (small?) performance boost.

Though, I have 2 questions:
* What's the min supported PyTorch version? Because `inference_mode` is supported since PT 1.9.
* Should other handlers (including example ones) be changed as well?