### PR TITLE
Fix CUDA_VERSION env var conflict

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,7 +62,7 @@ RUN python -m pip install -U pip setuptools
 # This is only useful for cuda env
 RUN export USE_CUDA=1
 
-ARG CUDA_VERSION=""
+ARG USE_CUDA_VERSION=""
 
 RUN git clone --depth 1 --recursive https://github.com/pytorch/serve.git
 
@@ -71,8 +71,8 @@ WORKDIR "serve"
 RUN \
     if echo "$BASE_IMAGE" | grep -q "cuda:"; then \
         # Install CUDA version specific binary when CUDA version is specified as a build arg
-        if [ "$CUDA_VERSION" ]; then \
-            python ./ts_scripts/install_dependencies.py --cuda $CUDA_VERSION; \
+        if [ "USE_CUDA_VERSION" ]; then \
+            python ./ts_scripts/install_dependencies.py --cuda $USE_CUDA_VERSION; \
         # Install the binary with the latest CPU image on a CUDA base image
         else \
             python ./ts_scripts/install_dependencies.py; \

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -155,10 +155,10 @@ fi
 
 if [ "${BUILD_TYPE}" == "production" ]
 then
-  DOCKER_BUILDKIT=1 docker build --file Dockerfile --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg CUDA_VERSION="${CUDA_VERSION}"  --build-arg PYTHON_VERSION="${PYTHON_VERSION}" --build-arg BUILD_NIGHTLY="${BUILD_NIGHTLY}" -t "${DOCKER_TAG}" --target production-image  .
+  DOCKER_BUILDKIT=1 docker build --file Dockerfile --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg USE_CUDA_VERSION="${CUDA_VERSION}"  --build-arg PYTHON_VERSION="${PYTHON_VERSION}" --build-arg BUILD_NIGHTLY="${BUILD_NIGHTLY}" -t "${DOCKER_TAG}" --target production-image  .
 elif [ "${BUILD_TYPE}" == "ci" ]
 then
-  DOCKER_BUILDKIT=1 docker build --file Dockerfile --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg CUDA_VERSION="${CUDA_VERSION}"  --build-arg PYTHON_VERSION="${PYTHON_VERSION}" --build-arg BUILD_NIGHTLY="${BUILD_NIGHTLY}" --build-arg BRANCH_NAME="${BRANCH_NAME}"  -t "${DOCKER_TAG}" --target ci-image  .
+  DOCKER_BUILDKIT=1 docker build --file Dockerfile --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg USE_CUDA_VERSION="${CUDA_VERSION}"  --build-arg PYTHON_VERSION="${PYTHON_VERSION}" --build-arg BUILD_NIGHTLY="${BUILD_NIGHTLY}" --build-arg BRANCH_NAME="${BRANCH_NAME}"  -t "${DOCKER_TAG}" --target ci-image  .
 else
-  DOCKER_BUILDKIT=1 docker build --file Dockerfile --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg CUDA_VERSION="${CUDA_VERSION}"  --build-arg PYTHON_VERSION="${PYTHON_VERSION}" --build-arg BUILD_NIGHTLY="${BUILD_NIGHTLY}" --build-arg BRANCH_NAME="${BRANCH_NAME}" --build-arg BUILD_WITH_IPEX="${BUILD_WITH_IPEX}"  -t "${DOCKER_TAG}" --target dev-image  .
+  DOCKER_BUILDKIT=1 docker build --file Dockerfile --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg USE_CUDA_VERSION="${CUDA_VERSION}"  --build-arg PYTHON_VERSION="${PYTHON_VERSION}" --build-arg BUILD_NIGHTLY="${BUILD_NIGHTLY}" --build-arg BRANCH_NAME="${BRANCH_NAME}" --build-arg BUILD_WITH_IPEX="${BUILD_WITH_IPEX}"  -t "${DOCKER_TAG}" --target dev-image  .
 fi


### PR DESCRIPTION

## Description

`CUDA_VERSION` may be set in the container to the dot separated CUDA version number.  This conflicts with the docker build arg `CUDA_VERSION` used to select which CUDA version to use and results in an error like this when building the image:

```
....
[1/2] STEP 14/15: RUN     if echo "$BASE_IMAGE" | grep -q "cuda:"; then         if [ "$CUDA_VERSION" ]; then             python ./ts_scripts/install_dependencies.py --cuda $CUDA_VERSION;         else             python ./ts_scripts/install_dependencies.py;         fi;     else         python ./ts_scripts/install_dependencies.py;     fi
usage: install_dependencies.py [-h]
                               [--cuda {cu92,cu101,cu102,cu111,cu113,cu116,cu117,cu118,cu121}]
                               [--neuronx] [--environment {prod,dev}]
                               [--nightly_torch] [--force]
install_dependencies.py: error: argument --cuda: invalid choice: '12.1.1' (choose from 'cu92', 'cu101', 'cu102', 'cu111', 'cu113', 'cu116', 'cu117', 'cu118', 'cu121')
Error: building at STEP "RUN if echo "$BASE_IMAGE" | grep -q "cuda:"; then         if [ "$CUDA_VERSION" ]; then             python ./ts_scripts/install_dependencies.py --cuda $CUDA_VERSION;         else             python ./ts_scripts/install_dependencies.py;         fi;     else         python ./ts_scripts/install_dependencies.py;     fi": while running runtime: exit status 2
```

Rename the docker build arg to `USE_CUDA_VERSION` to avoid the conflict.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Feature/Issue validation/testing

This was tested by building several images with the `build_image.sh` script.

## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?