### PR TITLE
Fix k8s image BASE_IMAGE

### DIFF
--- a/kubernetes/kserve/build_image.sh
+++ b/kubernetes/kserve/build_image.sh
@@ -2,7 +2,7 @@
 
 MACHINE=cpu
 DOCKER_TAG="pytorch/torchserve-kfs:latest"
-BASE_IMAGE="pytorch/torchserve:latest"
+BASE_IMAGE="pytorch/torchserve:latest-cpu"
 DOCKER_FILE="Dockerfile"
 BUILD_NIGHTLY=false
 USE_CUSTOM_TAG=false


### PR DESCRIPTION
## Description

`docker/build_image.sh` creates a CPU image with tag 'latest-cpu'.  Use that tag when building the k8s kserve image.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Feature/Issue validation/testing

Build several containers using this fix.

## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?