### PR TITLE
Add support for torch exported model

### DIFF
--- a/examples/pt2/torch_export/README.md
+++ b/examples/pt2/torch_export/README.md
@@ -1,6 +1,18 @@
-# TorchServe inference with torch export program
+# TorchServe inference with torch export model
 
-This example shows how to run TorchServe a Torch exported program
+This example shows how to run TorchServe a Torch exported model
+
+`torch.export.export()` produces the traced graph representing only the Tensor computation of the function in an Ahead-of-Time fashion. This can then be serialized.
+
+`torch.export.export()` takes a `torch.nn.Module` or a method along with sample inputs, and captures the computation graph into an `torch.export.ExportedProgram`
+
+`torch.export` differs from `torch.compile` is a few ways
+- JIT vs AOT
+- `torch.export` expects the model to not have an graph breaks
+
+You can find more details [here](https://pytorch.org/docs/stable/export.html)
+
+
 
 ### Pre-requisites
 

--- a/examples/pt2/torch_export/README.md
+++ b/examples/pt2/torch_export/README.md
@@ -1,0 +1,50 @@
+# TorchServe inference with torch export program
+
+This example shows how to run TorchServe a Torch exported program
+
+### Pre-requisites
+
+- `PyTorch >= 2.1.0`
+
+Change directory to the root of `serve`
+Ex: if `serve` is under `/home/ubuntu`, change directory to `/home/ubuntu/serve`
+
+
+### Create a Torch exported program
+
+The model is saved with `.pt2` extension
+
+```
+python examples/pt2/torch_export/resnet18_torch_export.py
+```
+
+### Create model archive
+
+```
+torch-model-archiver --model-name res18-pt2 --handler image_classifier --version 1.0 --serialized-file resnet18.pt2 --extra-files ./examples/image_classifier/index_to_name.json
+mkdir model_store
+mv res18-pt2.mar model_store/.
+```
+
+#### Start TorchServe
+```
+torchserve --start --model-store model_store --models res18-pt2=res18-pt2.mar --ncs
+```
+
+#### Run Inference
+
+```
+curl http://127.0.0.1:8080/predictions/res18-pt2 -T ./examples/image_classifier/kitten.jpg
+```
+
+produces the output
+
+```
+{
+  "tabby": 0.40966305136680603,
+  "tiger_cat": 0.34670504927635193,
+  "Egyptian_cat": 0.1300286501646042,
+  "lynx": 0.023919589817523956,
+  "bucket": 0.011532178148627281
+}
+```

--- a/examples/pt2/torch_export/resnet18_torch_export.py
+++ b/examples/pt2/torch_export/resnet18_torch_export.py
@@ -1,0 +1,16 @@
+import torch
+from torch.export import export
+from torchvision.models import ResNet18_Weights, resnet18
+
+# Load the model in eager
+model = resnet18(weights=ResNet18_Weights.DEFAULT)
+model.eval()
+
+# Need to use pytorch nightlies for using dynamic shapes for dynamic batch sizes
+input_data = torch.randn((1, 3, 224, 224))
+
+# Create a torch exported program
+exported_program: torch.export.ExportedProgram = export(model, (input_data,))
+
+# Save the exported program in .pt2 format
+torch.export.save(exported_program, "resnet18.pt2")

--- a/test/pytest/test_torch_export.py
+++ b/test/pytest/test_torch_export.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+
+import torch
+from pkg_resources import packaging
+
+from ts.torch_handler.image_classifier import ImageClassifier
+from ts.torch_handler.unit_tests.test_utils.mock_context import MockContext
+from ts.utils.util import load_label_mapping
+from ts_scripts.utils import try_and_handle
+
+CURR_FILE_PATH = Path(__file__).parent.absolute()
+REPO_ROOT_DIR = CURR_FILE_PATH.parents[1]
+EXAMPLE_ROOT_DIR = REPO_ROOT_DIR.joinpath("examples", "pt2", "torch_export")
+TEST_DATA = REPO_ROOT_DIR.joinpath("examples", "image_classifier", "kitten.jpg")
+MAPPING_DATA = REPO_ROOT_DIR.joinpath(
+    "examples", "image_classifier", "index_to_name.json"
+)
+MODEL_PT_FILE = "resnet18.pt2"
+
+
+PT_210_AVAILABLE = (
+    True
+    if packaging.version.parse(torch.__version__) >= packaging.version.parse("2.1.0")
+    else False
+)
+
+EXPECTED_RESULTS = ["tabby", "tiger_cat", "Egyptian_cat", "lynx", "bucket"]
+TEST_CASES = [
+    ("kitten.jpg", EXPECTED_RESULTS[0]),
+]
+
+
+import os
+
+import pytest
+
+
+@pytest.fixture
+def custom_working_directory(tmp_path):
+    # Set the custom working directory
+    custom_dir = tmp_path / "model_dir"
+    custom_dir.mkdir()
+    os.chdir(custom_dir)
+    yield custom_dir
+    # Clean up and return to the original working directory
+    os.chdir(tmp_path)
+
+
+@pytest.mark.skipif(PT_210_AVAILABLE == False, reason="torch version is < 2.1.0")
+def test_execute_script_in_custom_directory(custom_working_directory):
+    # Get the path to the custom working directory
+    model_dir = custom_working_directory
+
+    # Construct the path to the Python script to execute
+    script_path = os.path.join(EXAMPLE_ROOT_DIR, "resnet18_torch_export.py")
+
+    # Get the .pt2 file from torch.export
+    cmd = "python " + script_path
+    try_and_handle(cmd)
+
+    # Handler for Image classification
+    handler = ImageClassifier()
+
+    # Context definition
+    ctx = MockContext(
+        model_pt_file=MODEL_PT_FILE,
+        model_dir=model_dir.as_posix(),
+        model_file=None,
+    )
+
+    torch.manual_seed(42 * 42)
+    handler.initialize(ctx)
+    handler.context = ctx
+    handler.mapping = load_label_mapping(MAPPING_DATA)
+
+    data = {}
+    with open(TEST_DATA, "rb") as image:
+        image_file = image.read()
+        byte_array_type = bytearray(image_file)
+        data["body"] = byte_array_type
+
+    result = handler.handle([data], ctx)
+
+    labels = list(result[0].keys())
+
+    assert labels == EXPECTED_RESULTS

--- a/ts/torch_handler/base_handler.py
+++ b/ts/torch_handler/base_handler.py
@@ -180,6 +180,17 @@ class BaseHandler(abc.ABC):
             self.model = setup_ort_session(self.model_pt_path, self.map_location)
             logger.info("Succesfully setup ort session")
 
+        # Convert your model by following instructions: https://pytorch.org/docs/stable/export.html
+        elif self.model_pt_path.endswith(".pt2"):
+            # Check if PyTorch version > 2.1.0
+            assert packaging.version.parse(
+                torch.__version__
+            ) >= packaging.version.parse(
+                "2.1.0"
+            ), "torch.export needs PyTorch version >= 2.1.0"
+
+            self.model = self._load_torch_export_program(self.model_pt_path)
+
         else:
             raise RuntimeError("No model weights could be loaded")
 
@@ -244,6 +255,17 @@ class BaseHandler(abc.ABC):
             (NN Model Object) : Loads the model object.
         """
         return torch.jit.load(model_pt_path, map_location=self.device)
+
+    def _load_torch_export_program(self, model_pt_path):
+        """Loads the saved PyTorch exported program and returns the model object.
+
+        Args:
+            model_pt_path (str): denotes the path of the model file.
+
+        Returns:
+            (NN Model Object) : Loads the model object.
+        """
+        return torch.export.load(model_pt_path)
 
     def _load_pickled_model(self, model_dir, model_file, model_pt_path):
         """


### PR DESCRIPTION
## Description

This PR adds support for 
- Loading torch.export model
- Includes an example of ResNet 18
- Adds a pytest for torch.export

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

```
================================================================================== test session starts ===================================================================================
platform linux -- Python 3.8.18, pytest-7.3.1, pluggy-1.0.0 -- /home/ubuntu/anaconda3/envs/torchserve/bin/python
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/home/ubuntu/serve/test/pytest/.hypothesis/examples')
rootdir: /home/ubuntu/serve
plugins: mock-3.10.0, anyio-3.6.1, cov-4.1.0, hypothesis-6.54.3
collected 1 item                                                                                                                                                                         

test_torch_export.py::test_execute_script_in_custom_directory PASSED                                                                                                               [100%]

==================================================================================== warnings summary ====================================================================================
test_torch_export.py:3
  /home/ubuntu/serve/test/pytest/test_torch_export.py:3: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    from pkg_resources import packaging

../../../anaconda3/envs/torchserve/lib/python3.8/site-packages/pkg_resources/__init__.py:2871
  /home/ubuntu/anaconda3/envs/torchserve/lib/python3.8/site-packages/pkg_resources/__init__.py:2871: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('mpl_toolkits')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

../../../anaconda3/envs/torchserve/lib/python3.8/site-packages/pkg_resources/__init__.py:2871
../../../anaconda3/envs/torchserve/lib/python3.8/site-packages/pkg_resources/__init__.py:2871
  /home/ubuntu/anaconda3/envs/torchserve/lib/python3.8/site-packages/pkg_resources/__init__.py:2871: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('ruamel')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

../../../anaconda3/envs/torchserve/lib/python3.8/site-packages/torchvision/transforms/_functional_pil.py:242
  /home/ubuntu/anaconda3/envs/torchserve/lib/python3.8/site-packages/torchvision/transforms/_functional_pil.py:242: DeprecationWarning: BILINEAR is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.BILINEAR instead.
    interpolation: int = Image.BILINEAR,

../../../anaconda3/envs/torchserve/lib/python3.8/site-packages/torchvision/transforms/_functional_pil.py:288
  /home/ubuntu/anaconda3/envs/torchserve/lib/python3.8/site-packages/torchvision/transforms/_functional_pil.py:288: DeprecationWarning: NEAREST is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.NEAREST or Dither.NONE instead.
    interpolation: int = Image.NEAREST,

../../../anaconda3/envs/torchserve/lib/python3.8/site-packages/torchvision/transforms/_functional_pil.py:304
  /home/ubuntu/anaconda3/envs/torchserve/lib/python3.8/site-packages/torchvision/transforms/_functional_pil.py:304: DeprecationWarning: NEAREST is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.NEAREST or Dither.NONE instead.
    interpolation: int = Image.NEAREST,

../../../anaconda3/envs/torchserve/lib/python3.8/site-packages/torchvision/transforms/_functional_pil.py:321
  /home/ubuntu/anaconda3/envs/torchserve/lib/python3.8/site-packages/torchvision/transforms/_functional_pil.py:321: DeprecationWarning: BICUBIC is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.BICUBIC instead.
    interpolation: int = Image.BICUBIC,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================= 1 passed, 8 warnings in 8.73s ============================================================================
```


## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?