### PR TITLE
Add support for metrics legacy mode

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -7,7 +7,7 @@
 * [Metric Types](#metric-types)
 * [Metrics Formatting](#metrics-formatting)
 * [Custom Metrics API](#custom-metrics-api)
-* [Logging custom metrics](#log-custom-metrics)
+* [Emitting custom metrics](#emitting-custom-metrics)
 * [Metrics YAML Parsing and Metrics API example](#Metrics-YAML-File-Parsing-and-Metrics-API-Custom-Handler-Example)
 * [Backwards compatibility warnings and upgrade guide](#backwards-compatibility-warnings-and-upgrade-guide)
 
@@ -20,7 +20,7 @@ Frontend metrics include system level metrics. The host resource utilization fro
 
 Torchserve provides [an API](#custom-metrics-api) to collect custom backend metrics. Metrics defined by a custom service or handler code can be collected per request or per a batch of requests.
 
-Two metric modes are supported, i.e `log` and `prometheus` with the default mode being `log`.
+Three metric modes are supported, i.e `log`, `prometheus` and `legacy` with the default mode being `log`.
 The metrics mode can be configured using the `metrics_mode` configuration option in `config.properties` or `TS_METRICS_MODE` environment variable.
 For further details on `config.properties` and environment variable based configuration, refer [Torchserve config](configuration.md) docs.
 
@@ -37,6 +37,15 @@ The location of log files and metric files can be configured in the [log4j2.xml]
 **Prometheus Mode**
 
 In `prometheus` mode, metrics are made available in prometheus format via the [metrics API endpoint](metrics_api.md).
+
+**Legacy Mode**
+
+`legacy` mode enables backwards compatibility with Torchserve releases `<v0.8.0`, where:
+* `ts_inference_requests_total`, `ts_inference_latency_microseconds` and `ts_queue_latency_microseconds` are only available via the [metrics API endpoint](metrics_api.md) in prometheus format.
+* Frontend metrics are logged to `log_directory/ts_metrics.log`
+* Backend metrics are logged to `log_directory/model_metrics.log`
+
+`Note: To enable full backwards compatibility with releases <v0.8.0, use legacy metrics mode with `[model metrics auto-detection](#getting-started-with-torchserve-metrics)` enabled.`
 
 ## Getting Started with TorchServe Metrics
 
@@ -632,9 +641,9 @@ metrics.get_metric("GaugeMetricName", MetricTypes.GAUGE)
 ```
 
 
-## Logging custom metrics
+## Emitting custom metrics
 
-Following sample code can be used to log the custom metrics created in the model's custom handler:
+Following sample code can be used to emit the custom metrics created in the model's custom handler:
 
 ```python
 # In Custom Handler
@@ -736,3 +745,5 @@ class CustomHandlerExample:
    **Upgrade paths**:
    - **[< v0.8.0] to [v0.8.0 - v0.9.0]**\
      Specify all the custom metrics added to the custom handler in the metrics configuration file as shown [above](#getting-started-with-torchserve-metrics).
+   - **[< v0.8.0] to [> v0.9.0]**\
+     Set `metrics_mode` to `legacy` and enable [model metrics auto-detection](#getting-started-with-torchserve-metrics).

--- a/frontend/server/src/main/java/org/pytorch/serve/metrics/MetricBuilder.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/metrics/MetricBuilder.java
@@ -47,7 +47,6 @@ public final class MetricBuilder {
             if (legacyPrometheusMetrics.contains(name)) {
                 return new PrometheusCounter(MetricType.COUNTER, name, unit, dimensionNames);
             }
-
             return new LogMetric(type, name, unit, dimensionNames);
         } else {
             return new LogMetric(type, name, unit, dimensionNames);

--- a/frontend/server/src/main/java/org/pytorch/serve/metrics/MetricBuilder.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/metrics/MetricBuilder.java
@@ -1,14 +1,24 @@
 package org.pytorch.serve.metrics;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import org.pytorch.serve.metrics.format.prometheous.PrometheusCounter;
 import org.pytorch.serve.metrics.format.prometheous.PrometheusGauge;
 import org.pytorch.serve.metrics.format.prometheous.PrometheusHistogram;
 
 public final class MetricBuilder {
+    private static final HashSet<String> legacyPrometheusMetrics =
+            new HashSet<String>(
+                    Arrays.asList(
+                            "ts_inference_requests_total",
+                            "ts_inference_latency_microseconds",
+                            "ts_queue_latency_microseconds"));
+
     public enum MetricMode {
         PROMETHEUS,
-        LOG
+        LOG,
+        LEGACY
     }
 
     public enum MetricType {
@@ -33,6 +43,12 @@ public final class MetricBuilder {
                     return new PrometheusHistogram(type, name, unit, dimensionNames);
                 default:
             }
+        } else if (mode == MetricMode.LEGACY) {
+            if (legacyPrometheusMetrics.contains(name)) {
+                return new PrometheusCounter(MetricType.COUNTER, name, unit, dimensionNames);
+            }
+
+            return new LogMetric(type, name, unit, dimensionNames);
         } else {
             return new LogMetric(type, name, unit, dimensionNames);
         }

--- a/test/pytest/test_metrics.py
+++ b/test/pytest/test_metrics.py
@@ -699,6 +699,14 @@ def test_metrics_legacy_mode():
         f.write("enable_envvars_config=true")
 
     os.environ["TS_METRICS_MODE"] = "legacy"
+    os.environ["TS_METRICS_CONFIG"] = os.path.join(
+        test_utils.REPO_ROOT,
+        "test",
+        "pytest",
+        "test_data",
+        "metrics",
+        "metrics_auto_detect.yaml",
+    )
     os.environ["TS_MODEL_METRICS_AUTO_DETECT"] = "true"
 
     try:
@@ -748,6 +756,7 @@ def test_metrics_legacy_mode():
         test_utils.stop_torchserve()
         test_utils.delete_all_snapshots()
         del os.environ["TS_METRICS_MODE"]
+        del os.environ["TS_METRICS_CONFIG"]
         del os.environ["TS_MODEL_METRICS_AUTO_DETECT"]
         os.remove(config_file)
 


### PR DESCRIPTION
## Description
Add support for metrics legacy mode, where:
- `ts_inference_requests_total`, `ts_inference_latency_microseconds` and `ts_queue_latency_microseconds` are only available via the metrics API endpoint in prometheus format.
- All other metrics inclusive of auto detected backend metrics are only logged to `ts_metrics.log` and `model_metrics.log`

Fixes #2795 

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Feature/Issue validation/testing
- [ ] Unit and integration tests included in this PR
- [ ] Manual testing using the [custom metrics example](https://github.com/pytorch/serve/tree/master/examples/custom_metrics)
```
$ cat examples/custom_metrics/config.properties 
metrics_mode=legacy
metrics_config=examples/custom_metrics/metrics.yaml
model_metrics_auto_detect=true
models={\
  "mnist": {\
    "1.0": {\
        "defaultVersion": true,\
        "marName": "mnist.mar",\
        "minWorkers": 1,\
        "maxWorkers": 1\
    }\
  }\
}

$ curl http://127.0.0.1:8080/predictions/mnist -T examples/image_classifier/mnist/test_data/0.png
0                                                                                                                                                                                                                    

$ curl http://127.0.0.1:8082/metrics
# HELP ts_inference_latency_microseconds Torchserve prometheus counter metric with unit: Microseconds
# TYPE ts_inference_latency_microseconds counter
ts_inference_latency_microseconds{model_name="mnist",model_version="default",hostname="88665a372f4b.ant.amazon.com",} 76988.864
# HELP ts_inference_requests_total Torchserve prometheus counter metric with unit: Count
# TYPE ts_inference_requests_total counter
ts_inference_requests_total{model_name="mnist",model_version="default",hostname="88665a372f4b.ant.amazon.com",} 1.0
# HELP ts_queue_latency_microseconds Torchserve prometheus counter metric with unit: Microseconds
# TYPE ts_queue_latency_microseconds counter
ts_queue_latency_microseconds{model_name="mnist",model_version="default",hostname="88665a372f4b.ant.amazon.com",} 144.148

$ cat logs/model_metrics.log
2023-12-01T08:37:25,446 - InitializeCallCount.count:1.0|#ModelName:mnist,Level:Model|#hostname:88665a372f4b.ant.amazon.com,requestID:b430fc75-6b7c-4c5b-bb20-c4ddcec8af1c,timestamp:1701400045
2023-12-01T08:38:12,530 - InferenceRequestCount.count:1.0|#|#hostname:88665a372f4b.ant.amazon.com,requestID:null,timestamp:1701400092
2023-12-01T08:38:12,530 - PreprocessCallCount.count:1.0|#ModelName:mnist|#hostname:88665a372f4b.ant.amazon.com,requestID:null,timestamp:1701400092
2023-12-01T08:38:12,530 - RequestBatchSize.count:1.0|#ModelName:mnist|#hostname:88665a372f4b.ant.amazon.com,requestID:null,timestamp:1701400092
2023-12-01T08:38:12,531 - SizeOfImage.kB:0.265625|#ModelName:mnist,Level:Model|#hostname:88665a372f4b.ant.amazon.com,requestID:f75a9e93-622a-416a-b727-622f6ecb34f6,timestamp:1701400092
2023-12-01T08:38:12,551 - HandlerMethodTime.Milliseconds:20.53213119506836|#MethodName:preprocess,ModelName:mnist,Level:Model|#hostname:88665a372f4b.ant.amazon.com,requestID:f75a9e93-622a-416a-b727-622f6ecb34f6,timestamp:1701400092
2023-12-01T08:38:12,602 - PostprocessCallCount.CallCount:1.0|#ModelName:mnist,Level:Model|#hostname:88665a372f4b.ant.amazon.com,requestID:f75a9e93-622a-416a-b727-622f6ecb34f6,timestamp:1701400092
2023-12-01T08:38:12,603 - ExamplePercentMetric.Percent:50.0|#ModelName:mnist,Level:Model|#hostname:88665a372f4b.ant.amazon.com,requestID:f75a9e93-622a-416a-b727-622f6ecb34f6,timestamp:1701400092
2023-12-01T08:38:12,604 - HandlerTime.ms:74.73|#ModelName:mnist,Level:Model|#hostname:88665a372f4b.ant.amazon.com,requestID:f75a9e93-622a-416a-b727-622f6ecb34f6,timestamp:1701400092
2023-12-01T08:38:12,605 - PredictionTime.ms:74.87|#ModelName:mnist,Level:Model|#hostname:88665a372f4b.ant.amazon.com,requestID:f75a9e93-622a-416a-b727-622f6ecb34f6,timestamp:1701400092
```