### PR TITLE
Create nightly job for torch.compile benchmarks

### DIFF
--- a/.github/workflows/benchmark_torch_compile_nightly.yml
+++ b/.github/workflows/benchmark_torch_compile_nightly.yml
@@ -1,13 +1,6 @@
 name: Benchmark torch.compile models nightly
 
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
-  merge_group:
   # run every day at 9:15pm
   schedule:
     - cron:  '15 21 * * *'

--- a/.github/workflows/benchmark_torch_compile_nightly.yml
+++ b/.github/workflows/benchmark_torch_compile_nightly.yml
@@ -1,0 +1,78 @@
+name: Benchmark torch.compile models nightly
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  merge_group:
+  # run every day at 9:15pm
+  schedule:
+    - cron:  '15 21 * * *'
+
+jobs:
+  nightly:
+    strategy:
+      fail-fast: false
+      matrix:
+        hardware: [gpu]
+    runs-on:
+      - self-hosted
+    timeout-minutes: 1320
+    steps:
+      - name: Clean up previous run
+        run: |
+          echo "Cleaning up previous run"
+          cd $RUNNER_WORKSPACE
+          pwd
+          cd ..
+          pwd
+          rm -rf _tool
+      - name: Setup Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+          architecture: x64
+      - name: Setup Java 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+      - name: Checkout TorchServe
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y apache2-utils
+          pip install -r benchmarks/requirements-ab.txt
+          pip uninstall torchtext torchdata torch torchvision torchaudio -y
+          pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu121 --ignore-installed
+      - name: Benchmark gpu nightly
+        if: ${{ matrix.hardware == 'gpu' }}
+        run: python benchmarks/auto_benchmark.py --input benchmarks/benchmark_config_torch_compile_gpu.yaml --skip false
+      - name: Save benchmark artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: nightly ${{ matrix.hardware }} torch compile artifact
+          path: /tmp/ts_benchmark
+      - name: Download benchmark artifacts for auto validation
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          workflow_conclusion: success
+          if_no_artifact_found: ignore
+          path: /tmp/ts_artifacts
+          name: ${{ matrix.hardware }}_torch_compile_benchmark_validation
+      - name: Validate Benchmark result
+        run: python benchmarks/validate_report.py --input-artifacts-dir /tmp/ts_artifacts/${{ matrix.hardware }}_torch_compile_benchmark_validation
+      - name: Update benchmark artifacts for auto validation
+        run: python benchmarks/utils/update_artifacts.py --output /tmp/ts_artifacts/${{ matrix.hardware }}_torch_compile_benchmark_validation
+      - name: Upload the updated benchmark artifacts for auto validation
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.hardware }}_torch_compile_benchmark_validation
+          path: /tmp/ts_artifacts

--- a/.github/workflows/benchmark_torch_compile_nightly.yml
+++ b/.github/workflows/benchmark_torch_compile_nightly.yml
@@ -48,25 +48,3 @@ jobs:
           pip install -r benchmarks/requirements-ab.txt
       - name: Benchmark gpu nightly
         run: python benchmarks/auto_benchmark.py --input benchmarks/benchmark_config_torch_compile_gpu.yaml --skip false --nightly True
-      - name: Save benchmark artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: nightly gpu torch compile artifact
-          path: /tmp/ts_benchmark
-      - name: Download benchmark artifacts for auto validation
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow: ${{ github.event.workflow_run.workflow_id }}
-          workflow_conclusion: success
-          if_no_artifact_found: ignore
-          path: /tmp/ts_artifacts
-          name: gpu_torch_compile_benchmark_validation
-      - name: Validate Benchmark result
-        run: python benchmarks/validate_report.py --input-artifacts-dir /tmp/ts_artifacts/gpu_torch_compile_benchmark_validation
-      - name: Update benchmark artifacts for auto validation
-        run: python benchmarks/utils/update_artifacts.py --output /tmp/ts_artifacts/gpu_torch_compile_benchmark_validation
-      - name: Upload the updated benchmark artifacts for auto validation
-        uses: actions/upload-artifact@v2
-        with:
-          name: gpu_torch_compile_benchmark_validation
-          path: /tmp/ts_artifacts

--- a/.github/workflows/benchmark_torch_compile_nightly.yml
+++ b/.github/workflows/benchmark_torch_compile_nightly.yml
@@ -51,7 +51,7 @@ jobs:
           pip install -r benchmarks/requirements-ab.txt
       - name: Benchmark gpu nightly
         if: ${{ matrix.hardware == 'gpu' }}
-        run: python benchmarks/auto_benchmark.py --input benchmarks/benchmark_config_torch_compile_gpu.yaml --skip false --nightly
+        run: python benchmarks/auto_benchmark.py --input benchmarks/benchmark_config_torch_compile_gpu.yaml --skip false --nightly True
       - name: Save benchmark artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/benchmark_torch_compile_nightly.yml
+++ b/.github/workflows/benchmark_torch_compile_nightly.yml
@@ -20,6 +20,7 @@ jobs:
         hardware: [gpu]
     runs-on:
       - self-hosted
+      - ${{ matrix.hardware }}
     timeout-minutes: 1320
     steps:
       - name: Clean up previous run

--- a/.github/workflows/benchmark_torch_compile_nightly.yml
+++ b/.github/workflows/benchmark_torch_compile_nightly.yml
@@ -47,12 +47,11 @@ jobs:
           sudo apt-get install -y apache2-utils
           pip install -r benchmarks/requirements-ab.txt
       - name: Benchmark gpu nightly
-        if: ${{ matrix.hardware == 'gpu' }}
         run: python benchmarks/auto_benchmark.py --input benchmarks/benchmark_config_torch_compile_gpu.yaml --skip false --nightly True
       - name: Save benchmark artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: nightly ${{ matrix.hardware }} torch compile artifact
+          name: nightly gpu torch compile artifact
           path: /tmp/ts_benchmark
       - name: Download benchmark artifacts for auto validation
         uses: dawidd6/action-download-artifact@v2
@@ -61,13 +60,13 @@ jobs:
           workflow_conclusion: success
           if_no_artifact_found: ignore
           path: /tmp/ts_artifacts
-          name: ${{ matrix.hardware }}_torch_compile_benchmark_validation
+          name: gpu_torch_compile_benchmark_validation
       - name: Validate Benchmark result
-        run: python benchmarks/validate_report.py --input-artifacts-dir /tmp/ts_artifacts/${{ matrix.hardware }}_torch_compile_benchmark_validation
+        run: python benchmarks/validate_report.py --input-artifacts-dir /tmp/ts_artifacts/gpu_torch_compile_benchmark_validation
       - name: Update benchmark artifacts for auto validation
-        run: python benchmarks/utils/update_artifacts.py --output /tmp/ts_artifacts/${{ matrix.hardware }}_torch_compile_benchmark_validation
+        run: python benchmarks/utils/update_artifacts.py --output /tmp/ts_artifacts/gpu_torch_compile_benchmark_validation
       - name: Upload the updated benchmark artifacts for auto validation
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.hardware }}_torch_compile_benchmark_validation
+          name: gpu_torch_compile_benchmark_validation
           path: /tmp/ts_artifacts

--- a/.github/workflows/benchmark_torch_compile_nightly.yml
+++ b/.github/workflows/benchmark_torch_compile_nightly.yml
@@ -51,7 +51,7 @@ jobs:
           pip install -r benchmarks/requirements-ab.txt
       - name: Benchmark gpu nightly
         if: ${{ matrix.hardware == 'gpu' }}
-        run: python benchmarks/auto_benchmark.py --input benchmarks/benchmark_config_torch_compile_gpu.yaml --skip false
+        run: python benchmarks/auto_benchmark.py --input benchmarks/benchmark_config_torch_compile_gpu.yaml --skip false --nightly
       - name: Save benchmark artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/benchmark_torch_compile_nightly.yml
+++ b/.github/workflows/benchmark_torch_compile_nightly.yml
@@ -49,8 +49,6 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y apache2-utils
           pip install -r benchmarks/requirements-ab.txt
-          pip uninstall torchtext torchdata torch torchvision torchaudio -y
-          pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu121 --ignore-installed
       - name: Benchmark gpu nightly
         if: ${{ matrix.hardware == 'gpu' }}
         run: python benchmarks/auto_benchmark.py --input benchmarks/benchmark_config_torch_compile_gpu.yaml --skip false

--- a/.github/workflows/benchmark_torch_compile_nightly.yml
+++ b/.github/workflows/benchmark_torch_compile_nightly.yml
@@ -16,11 +16,7 @@ jobs:
   nightly:
     strategy:
       fail-fast: false
-      matrix:
-        hardware: [gpu]
-    runs-on:
-      - self-hosted
-      - ${{ matrix.hardware }}
+    runs-on: [self-hosted, gpu]
     timeout-minutes: 1320
     steps:
       - name: Clean up previous run

--- a/benchmarks/auto_benchmark.py
+++ b/benchmarks/auto_benchmark.py
@@ -136,8 +136,8 @@ def install_torchserve(skip_ts_install, hw, ts_version, nightly):
         return
 
     # git checkout branch if it is needed
-    # cmd = "git checkout master && git reset --hard && git clean -dffx . && git pull --rebase"
-    # execute(cmd, wait=True)
+    cmd = "git checkout master && git reset --hard && git clean -dffx . && git pull --rebase"
+    execute(cmd, wait=True)
     print("successfully reset git")
 
     ts_install_cmd = None

--- a/benchmarks/auto_benchmark.py
+++ b/benchmarks/auto_benchmark.py
@@ -123,7 +123,9 @@ def load_benchmark_config(bm_config_path, skip_ts_install, skip_upload):
 
 
 def benchmark_env_setup(bm_config, skip_ts_install, nightly):
-    install_torchserve(skip_ts_install, bm_config["hardware"], bm_config["version"], nightly)
+    install_torchserve(
+        skip_ts_install, bm_config["hardware"], bm_config["version"], nightly
+    )
     setup_benchmark_path(bm_config["model_config_path"])
     build_model_json_config(bm_config["models"])
     enable_launcher_with_logical_core(bm_config["hardware"])
@@ -134,8 +136,8 @@ def install_torchserve(skip_ts_install, hw, ts_version, nightly):
         return
 
     # git checkout branch if it is needed
-    cmd = "git checkout master && git reset --hard && git clean -dffx . && git pull --rebase"
-    execute(cmd, wait=True)
+    # cmd = "git checkout master && git reset --hard && git clean -dffx . && git pull --rebase"
+    # execute(cmd, wait=True)
     print("successfully reset git")
 
     ts_install_cmd = None
@@ -296,7 +298,7 @@ def main():
     )
     parser.add_argument(
         "--nightly",
-        help="true: install nightly version of torch package. default: false"
+        help="true: install nightly version of torch package. default: false",
     )
     arguments = parser.parse_args()
     skip_ts_config = (

--- a/benchmarks/benchmark-ab.py
+++ b/benchmarks/benchmark-ab.py
@@ -229,7 +229,7 @@ def warm_up():
     click.secho("\n\nExecuting warm-up ...", fg="green")
 
     ab_cmd = (
-        f"ab -c {execution_params['concurrency']}  -n {execution_params['requests']/10} -k -p "
+        f"ab -c {execution_params['concurrency']} -s 300 -n {execution_params['requests']/10} -k -p "
         f"{execution_params['tmp_dir']}/benchmark/input -T  {execution_params['content_type']} "
         f"{execution_params['inference_url']}/{execution_params['inference_model_url']} > "
         f"{execution_params['result_file']}"
@@ -247,7 +247,7 @@ def run_benchmark():
 
     click.secho("\n\nExecuting inference performance tests ...", fg="green")
     ab_cmd = (
-        f"ab -c {execution_params['concurrency']}  -n {execution_params['requests']} -k -p "
+        f"ab -c {execution_params['concurrency']} -s 300 -n {execution_params['requests']} -k -p "
         f"{execution_params['tmp_dir']}/benchmark/input -T  {execution_params['content_type']} "
         f"{execution_params['inference_url']}/{execution_params['inference_model_url']} > "
         f"{execution_params['result_file']}"

--- a/benchmarks/benchmark_config_torch_compile_gpu.yaml
+++ b/benchmarks/benchmark_config_torch_compile_gpu.yaml
@@ -1,0 +1,48 @@
+# Torchserve version is to be installed. It can be one of the options
+#  - branch : "master"
+#  - nightly: "2022.3.16"
+#  - release: "0.5.3"
+# Nightly build will be installed if "ts_version" is not specifiged
+#ts_version:
+#    branch: &ts_version "master"
+
+# a list of model configure yaml files defined in benchmarks/models_config
+# or a list of model configure yaml files with full path
+models:
+    - "bert_torch_compile_gpu.yaml"
+    - "resnet50_torch_compile_gpu.yaml"
+    - "vgg16_torch_compile_gpu.yaml"
+
+# benchmark on "cpu" or "gpu".
+# "cpu" is set if "hardware" is not specified
+hardware: &hardware "gpu"
+
+# load prometheus metrics report to remote storage or local different path if "metrics_cmd" is set.
+# the command line to load prometheus metrics report to remote system.
+# Here is an example of AWS cloudwatch command:
+# Note:
+#    - keep the values order as the same as the command definition.
+#    - set up the command before enabling `metrics_cmd`.
+#      For example, aws client and AWS credentials need to be setup before trying this example.
+metrics_cmd:
+    - "cmd": "aws cloudwatch put-metric-data"
+    - "--namespace": ["torchserve_benchmark_nightly_torch_compile_", *hardware]
+    - "--region": "us-east-2"
+    - "--metric-data": 'file:///tmp/benchmark/logs/stats_metrics.json'
+
+# load report to remote storage or local different path if "report_cmd" is set.
+# the command line to load report to remote storage.
+# Here is an example of AWS cloudwatch command:
+# Note:
+#    - keep the values order as the same as the command.
+#    - set up the command before enabling `report_cmd`.
+#      For example, aws client, AWS credentials and S3 bucket
+#      need to be setup before trying this example.
+#    - "today()" is a keyword to apply current date in the path
+#      For example, the dest path in the following example is
+#      s3://torchserve-model-serving/benchmark/2022-03-18/gpu
+report_cmd:
+    - "cmd": "aws s3 cp --recursive"
+    - "source": '/tmp/ts_benchmark/'
+    - "dest": ['s3://torchserve-benchmark/torch-compile-nightly', "today()", *hardware]
+

--- a/benchmarks/models_config/bert_torch_compile_gpu.yaml
+++ b/benchmarks/models_config/bert_torch_compile_gpu.yaml
@@ -1,0 +1,42 @@
+---
+bert:
+    scripted_mode:
+        benchmark_engine: "ab"
+        url: https://torchserve.pytorch.org/mar_files/bert-scripted.mar
+        workers:
+            - 4
+        batch_delay: 100
+        batch_size:
+            - 1
+            - 2
+            - 4
+            - 8
+            - 16
+        input: "./examples/Huggingface_Transformers/Seq_classification_artifacts/sample_text_captum_input.txt"
+        requests: 50000
+        concurrency: 100
+        backend_profiling: False
+        exec_env: "local"
+        processors:
+            - "cpu"
+            - "gpus": "all"
+    torch_compile_default_mode:
+        benchmark_engine: "ab"
+        url: https://torchserve.pytorch.org/mar_files/bert-default.mar
+        workers:
+            - 4
+        batch_delay: 100
+        batch_size:
+            - 1
+            - 2
+            - 4
+            - 8
+            - 16
+        input: "./examples/Huggingface_Transformers/Seq_classification_artifacts/sample_text_captum_input.txt"
+        requests: 50000
+        concurrency: 100
+        backend_profiling: False
+        exec_env: "local"
+        processors:
+            - "cpu"
+            - "gpus": "all"

--- a/benchmarks/models_config/resnet50_torch_compile_gpu.yaml
+++ b/benchmarks/models_config/resnet50_torch_compile_gpu.yaml
@@ -1,0 +1,42 @@
+---
+resnet50:
+    scripted_mode:
+        benchmark_engine: "ab"
+        url: https://torchserve.pytorch.org/mar_files/resnet-50-scripted.mar
+        workers:
+            - 4
+        batch_delay: 100
+        batch_size:
+            - 1
+            - 2
+            - 4
+            - 8
+            - 16
+        input: "./examples/image_classifier/kitten.jpg"
+        requests: 10000
+        concurrency: 100
+        backend_profiling: False
+        exec_env: "local"
+        processors:
+            - "cpu"
+            - "gpus": "all"
+    torch_compile_default_mode:
+        benchmark_engine: "ab"
+        url: https://torchserve.pytorch.org/mar_files/resnet-50-default.mar
+        workers:
+            - 4
+        batch_delay: 100
+        batch_size:
+            - 1
+            - 2
+            - 4
+            - 8
+            - 16
+        input: "./examples/image_classifier/kitten.jpg"
+        requests: 10000
+        concurrency: 100
+        backend_profiling: False
+        exec_env: "local"
+        processors:
+            - "cpu"
+            - "gpus": "all"

--- a/benchmarks/models_config/vgg16_torch_compile_gpu.yaml
+++ b/benchmarks/models_config/vgg16_torch_compile_gpu.yaml
@@ -1,0 +1,42 @@
+---
+vgg16:
+    scripted_mode:
+        benchmark_engine: "ab"
+        url: https://torchserve.pytorch.org/mar_files/vgg-16-scripted.mar
+        workers:
+            - 4
+        batch_delay: 100
+        batch_size:
+            - 1
+            - 2
+            - 4
+            - 8
+            - 16
+        input: "./examples/image_classifier/kitten.jpg"
+        requests: 10000
+        concurrency: 100
+        backend_profiling: False
+        exec_env: "local"
+        processors:
+            - "cpu"
+            - "gpus": "all"
+    torch_compile_default_mode:
+        benchmark_engine: "ab"
+        url: https://torchserve.pytorch.org/mar_files/vgg-16-default.mar
+        workers:
+            - 4
+        batch_delay: 100
+        batch_size:
+            - 1
+            - 2
+            - 4
+            - 8
+            - 16
+        input: "./examples/image_classifier/kitten.jpg"
+        requests: 10000
+        concurrency: 100
+        backend_profiling: False
+        exec_env: "local"
+        processors:
+            - "cpu"
+            - "gpus": "all"


### PR DESCRIPTION
## Description

Please read our [CONTRIBUTING.md](https://github.com/pytorch/serve/blob/master/CONTRIBUTING.md) prior to creating your first pull request.

Creating PR to enable nightly benchmarks to compare torch.compile default mode and TorchScript for the following models:
- BERT Sequence Classification without Better Transformer. Please note that the BERT model artifacts will be updated again later to choose the one with the best performance (eg. with Better Transformer etc)
- VGG-16
- ResNet-50

Added new model artifacts for each of the above mentioned models:
- https://torchserve.pytorch.org/mar_files/bert-scripted.mar
- https://torchserve.pytorch.org/mar_files/bert-default.mar
- https://torchserve.pytorch.org/mar_files/vgg-16-scripted.mar 
- https://torchserve.pytorch.org/mar_files/vgg-16-default.mar
- https://torchserve.pytorch.org/mar_files/resnet-50-scripted.mar
- https://torchserve.pytorch.org/mar_files/resnet-50-default.mar

Created Cloudwatch dashboard for the above mentioned models: https://cloudwatch.amazonaws.com/dashboard.html?dashboard=TorchServe-Benchmark-Torch-Compile-Nightly-GPU&context=eyJSIjoidXMtZWFzdC0xIiwiRCI6ImN3LWRiLTA4NDQ5NTcyODMxMSIsIlUiOiJ1cy1lYXN0LTFfdTlGeElpOXh1IiwiQyI6IjRjMm52MzFlZGN2MWFvdjY3Z2hoYmJjMTF2IiwiSSI6InVzLWVhc3QtMTozNzk2MDVjMC0xNDM5LTQzMTEtOWE4Ny03YTUwY2E0ODVmMjAiLCJPIjoiYXJuOmF3czppYW06OjA4NDQ5NTcyODMxMTpyb2xlL3NlcnZpY2Utcm9sZS9DV0RCU2hhcmluZy1QdWJsaWNSZWFkT25seUFjY2Vzcy1QQjRaVEo2QiIsIk0iOiJQdWJsaWMifQ==
