### PR TITLE
Include queue time in benchmark report

### DIFF
--- a/benchmarks/benchmark-ab.py
+++ b/benchmarks/benchmark-ab.py
@@ -555,6 +555,19 @@ def generate_csv_output():
         artifacts["Model_p90"] = lines[line90].strip()
         artifacts["Model_p99"] = lines[line99].strip()
 
+    with open(
+        os.path.join(execution_params["tmp_dir"], "benchmark", "waiting_time.txt")
+    ) as f:
+        lines = f.readlines()
+        lines.sort(key=float)
+        num_requests = len(lines)
+        line50 = int(num_requests / 2)
+        line90 = int(num_requests * 9 / 10)
+        line99 = int(num_requests * 99 / 100)
+        artifacts["Queue time p50"] = lines[line50].strip()
+        artifacts["Queue time p90"] = lines[line90].strip()
+        artifacts["Queue time p99"] = lines[line99].strip()
+
     for m in metrics:
         df = pd.read_csv(
             os.path.join(*(execution_params["tmp_dir"], "benchmark", m)),

--- a/benchmarks/utils/gen_metrics_json.py
+++ b/benchmarks/utils/gen_metrics_json.py
@@ -65,6 +65,18 @@ STATS_METRICS_CONFIG = {
         "name": "model_latency_P99",
         "unit": 'Milliseconds'
     },
+    "Queue time p50" : {
+        "name": "queue_time_P50",
+        "unit": 'Milliseconds'
+    },
+    "Queue time p90" : {
+        "name": "queue_time_P90",
+        "unit": 'Milliseconds'
+    },
+    "Queue time p99" : {
+        "name": "queue_time_P99",
+        "unit": 'Milliseconds'
+    },
     "memory_percentage_mean" : {
         "name": "memory_percentage_mean",
         "unit": 'Percent'

--- a/benchmarks/utils/gen_metrics_json.py
+++ b/benchmarks/utils/gen_metrics_json.py
@@ -6,17 +6,17 @@ import re
 # Ref valid unit:
 # https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html
 UNIT_MAP = {
-    "Count" : 'Count',
-    "Milliseconds" : 'Milliseconds',
-    "ms" : "Milliseconds",
-    "Megabytes" : 'Megabytes',
-    "MB" : 'Megabytes',
-    "Gigabytes" : 'Gigabytes',
-    "GB" : 'Gigabytes',
-    'Bytes' : 'Bytes',
-    "B" : 'Bytes',
-    "Percent" : 'Percent',
-    "s" : 'Seconds'
+    "Count": "Count",
+    "Milliseconds": "Milliseconds",
+    "ms": "Milliseconds",
+    "Megabytes": "Megabytes",
+    "MB": "Megabytes",
+    "Gigabytes": "Gigabytes",
+    "GB": "Gigabytes",
+    "Bytes": "Bytes",
+    "B": "Bytes",
+    "Percent": "Percent",
+    "s": "Seconds",
 }
 
 METRICS_NAME_SET = {
@@ -37,66 +37,21 @@ METRICS_NAME_SET = {
 }
 
 STATS_METRICS_CONFIG = {
-    "TS throughput" : {
-        "name" : "throughput",
-        "unit" : 'Count/Second'
-    },
-    "TS latency P50" : {
-        "name" : "total_latency_P50",
-        "unit" : 'Milliseconds'
-    },
-    "TS latency P90" : {
-        "name" : "total_latency_P90",
-        "unit" : 'Milliseconds'
-    },
-    "TS latency P99": {
-        "name": "total_latency_P99",
-        "unit": 'Milliseconds'
-    },
-    "Model_p50" : {
-        "name": "model_latency_P50",
-        "unit": 'Milliseconds'
-    },
-    "Model_p90" : {
-        "name": "model_latency_P90",
-        "unit": 'Milliseconds'
-    },
-    "Model_p99" : {
-        "name": "model_latency_P99",
-        "unit": 'Milliseconds'
-    },
-    "Queue time p50" : {
-        "name": "queue_time_P50",
-        "unit": 'Milliseconds'
-    },
-    "Queue time p90" : {
-        "name": "queue_time_P90",
-        "unit": 'Milliseconds'
-    },
-    "Queue time p99" : {
-        "name": "queue_time_P99",
-        "unit": 'Milliseconds'
-    },
-    "memory_percentage_mean" : {
-        "name": "memory_percentage_mean",
-        "unit": 'Percent'
-    },
-    "cpu_percentage_mean" : {
-        "name": "cpu_percentage_mean",
-        "unit": 'Percent'
-    },
-    "gpu_percentage_mean" : {
-        "name": "gpu_percentage_mean",
-        "unit": 'Percent'
-    },
-    "gpu_percentage_mean" : {
-        "name": "gpu_percentage_mean",
-        "unit": 'Percent'
-    },
-    "gpu_memory_used_mean" : {
-        "name": "gpu_memory_used_mean",
-        "unit": 'Megabytes'
-    }
+    "TS throughput": {"name": "throughput", "unit": "Count/Second"},
+    "TS latency P50": {"name": "total_latency_P50", "unit": "Milliseconds"},
+    "TS latency P90": {"name": "total_latency_P90", "unit": "Milliseconds"},
+    "TS latency P99": {"name": "total_latency_P99", "unit": "Milliseconds"},
+    "Model_p50": {"name": "model_latency_P50", "unit": "Milliseconds"},
+    "Model_p90": {"name": "model_latency_P90", "unit": "Milliseconds"},
+    "Model_p99": {"name": "model_latency_P99", "unit": "Milliseconds"},
+    "Queue time p50": {"name": "queue_time_P50", "unit": "Milliseconds"},
+    "Queue time p90": {"name": "queue_time_P90", "unit": "Milliseconds"},
+    "Queue time p99": {"name": "queue_time_P99", "unit": "Milliseconds"},
+    "memory_percentage_mean": {"name": "memory_percentage_mean", "unit": "Percent"},
+    "cpu_percentage_mean": {"name": "cpu_percentage_mean", "unit": "Percent"},
+    "gpu_percentage_mean": {"name": "gpu_percentage_mean", "unit": "Percent"},
+    "gpu_percentage_mean": {"name": "gpu_percentage_mean", "unit": "Percent"},
+    "gpu_memory_used_mean": {"name": "gpu_memory_used_mean", "unit": "Megabytes"},
 }
 
 
@@ -110,34 +65,40 @@ def gen_metrics_from_csv(csv_dict, stats_file_path):
     for k, v in csv_dict.items():
         if k in STATS_METRICS_CONFIG:
             metric_config = STATS_METRICS_CONFIG[k]
-            metrics_dict_list.append({
-                "MetricName": '{}_{}'.
-                    format(csv_dict["Model"], metric_config["name"]),
-                "Dimensions": [
-                    {"Name": "batch_size", "Value": csv_dict["Batch size"]}
-                ],
-                "Unit": metric_config['unit'],
-                "Value": float(v)})
+            metrics_dict_list.append(
+                {
+                    "MetricName": "{}_{}".format(
+                        csv_dict["Model"], metric_config["name"]
+                    ),
+                    "Dimensions": [
+                        {"Name": "batch_size", "Value": csv_dict["Batch size"]}
+                    ],
+                    "Unit": metric_config["unit"],
+                    "Value": float(v),
+                }
+            )
 
-    with open(stats_file_path, 'w') as stats_file:
-        json.dump(metrics_dict_list, stats_file, indent = 4)
+    with open(stats_file_path, "w") as stats_file:
+        json.dump(metrics_dict_list, stats_file, indent=4)
+
 
 def extract_metrics_from_csv(csv_file_path):
-    with open(csv_file_path, 'r') as csvfile:
-        csv_reader = csv.DictReader(csvfile, delimiter=',')
+    with open(csv_file_path, "r") as csvfile:
+        csv_reader = csv.DictReader(csvfile, delimiter=",")
         for row in csv_reader:
             model = row["Model"]
-            index = model.rfind('/') + 1
+            index = model.rfind("/") + 1
             row["Model"] = model[index:-4]
             return row
 
     return None
 
+
 def gen_metrics_from_log(csv_dict, metrics_log_file_path, raw_metrics_file_path):
     if metrics_log_file_path is None or raw_metrics_file_path is None:
         return
 
-    with open(metrics_log_file_path, 'r') as logfile:
+    with open(metrics_log_file_path, "r") as logfile:
         lines = logfile.readlines()
 
     metrics_dict_list = []
@@ -150,22 +111,25 @@ def gen_metrics_from_log(csv_dict, metrics_log_file_path, raw_metrics_file_path)
                 continue
             dimensions = parse_segments_1(csv_dict, segments[1])
             timestamp = parse_segments_2(segments[2])
-            metrics_dict_list.append({
-                "MetricName": '{}_{}'.format(csv_dict["Model"], name),
-                "Dimensions": dimensions,
-                "Unit": unit,
-                "Value": float(value),
-                "Timestamp": timestamp
-            })
+            metrics_dict_list.append(
+                {
+                    "MetricName": "{}_{}".format(csv_dict["Model"], name),
+                    "Dimensions": dimensions,
+                    "Unit": unit,
+                    "Value": float(value),
+                    "Timestamp": timestamp,
+                }
+            )
 
-    with open(raw_metrics_file_path, 'w') as raw_file:
+    with open(raw_metrics_file_path, "w") as raw_file:
         json.dump(metrics_dict_list, raw_file, indent=4)
+
 
 def parse_segments_0(segment):
     index = segment.rfind(" ") + 1
     data = segment[index:].split(":")
     value = data[1]
-    name_unit = data[0].split('.')
+    name_unit = data[0].split(".")
     if name_unit[0] in METRICS_NAME_SET:
         name = name_unit[0]
         unit = UNIT_MAP[name_unit[1]]
@@ -175,23 +139,27 @@ def parse_segments_0(segment):
 
     return name, unit, value
 
+
 def parse_segments_1(csv_dict, segment):
-    data = segment[1:].split(',')
+    data = segment[1:].split(",")
     dimensions = [{"Name": "batch_size", "Value": csv_dict["Batch size"]}]
     for d in data:
-        dimension = d.split(':')
+        dimension = d.split(":")
         dimensions.append({"Name": dimension[0], "Value": dimension[1]})
 
     return dimensions
 
+
 def parse_segments_2(segment):
-    index = segment.rfind(',') + 1
-    data = segment[index:].split(':')
+    index = segment.rfind(",") + 1
+    data = segment[index:].split(":")
     return int(data[1])
+
 
 def gen_metric(csv_file, stats_metrics_file):
     csv_dict = extract_metrics_from_csv(csv_file)
     gen_metrics_from_csv(csv_dict, stats_metrics_file)
+
 
 def main():
     parser = argparse.ArgumentParser()
@@ -225,13 +193,6 @@ def main():
     gen_metrics_from_csv(csv_dict, arguments.stats)
     gen_metrics_from_log(csv_dict, arguments.log, arguments.raw)
 
+
 if __name__ == "__main__":
     main()
-
-
-
-
-
-
-
-


### PR DESCRIPTION
## Description

Please read our [CONTRIBUTING.md](https://github.com/pytorch/serve/blob/master/CONTRIBUTING.md) prior to creating your first pull request.

Creating PR to include queue time in the benchmark report.

Tests run:

Ran benchmark locally with `resnet50.yaml` with batch sizes 1, 2, 4, 8, 16 and concurrency 4. 10000 requests are used for inference. 
```
---
---
resnet50:
    scripted_mode:
        benchmark_engine: "ab"
        url: "file:///home/model-server/torch_compile_ab_benchmarks/resnet50/resnet-50-scripted.mar"
        workers:
            - 4
        batch_delay: 100
        batch_size:
            - 1
            - 2
            - 4
            - 8
            - 16
        requests: 10000
        concurrency: 100
        input: "/serve/examples/image_classifier/kitten.jpg"
        handler_profiling: True
        backend_profiling: True
        exec_env: "local"
        processors:
            - "cpu"
            - "gpus": "all"
```
The AB report and metrics can be found be in this tar file: 
[resnet_reports.tar.gz](https://github.com/pytorch/serve/files/13679868/resnet_reports.tar.gz)

As evident from the reports, the P50, P90 and P99 of the queue times can be found in the `ab_report.csv` and `stats_metrics.json` files.