### PR TITLE
Create temporary directory using uuid

### DIFF
--- a/model-archiver/model_archiver/model_packaging_utils.py
+++ b/model-archiver/model_archiver/model_packaging_utils.py
@@ -9,6 +9,7 @@ import re
 import shutil
 import tarfile
 import tempfile
+import uuid
 import zipfile
 from io import BytesIO
 from pathlib import Path
@@ -152,7 +153,7 @@ class ModelExportUtils(object):
         :param kwargs: key value pair of files to be copied in archive
         :return:
         """
-        model_path = os.path.join(tempfile.gettempdir(), model_name)
+        model_path = os.path.join(tempfile.gettempdir(), model_name, uuid.uuid4().hex)
         if os.path.exists(model_path):
             shutil.rmtree(model_path)
         ModelExportUtils.make_dir(model_path)


### PR DESCRIPTION
## Description

I suggest creating a temporary directory using a unique hash(UUID) for robustness.
There was an issue where the build didn't complete successfully when storing artifacts in the `/tmp/{model_name}` path and building the archive.
So, upon reviewing the code, I found that the folder was being deleted by the model_packaging_utils. To address this issue, I'm looking to uniquely designate the temporary folder path for the archive.
Furthermore, As mentioned previously in [this issue](https://github.com/pytorch/serve/issues/1532), accessing the temporary path simultaneously by multiple accounts can lead to permission issues. I also hope that it will be resolved along with this PR.