### PR TITLE
Update GPT Fast handler to add option to get GPU ID from context

### DIFF
--- a/examples/large_models/gpt_fast/handler.py
+++ b/examples/large_models/gpt_fast/handler.py
@@ -50,10 +50,13 @@ class GptHandler(BaseHandler):
         self.local_rank = rank if rank is not None else 0
 
         if torch.cuda.is_available():
-            if "torchrun" not in ctx.model_yaml_config and properties.get("gpu_id") is not None:
+            if (
+                "torchrun" not in ctx.model_yaml_config
+                and properties.get("gpu_id") is not None
+            ):
                 gpu_id = properties.get("gpu_id")
             else:
-                gpu_id = self.local_rank 
+                gpu_id = self.local_rank
             self.map_location = "cuda"
             self.device = torch.device(self.map_location + ":" + str(gpu_id))
 

--- a/examples/large_models/gpt_fast/handler.py
+++ b/examples/large_models/gpt_fast/handler.py
@@ -44,15 +44,20 @@ class GptHandler(BaseHandler):
 
     def initialize(self, ctx):
         self.context = ctx
+        properties = self.context.system_properties
         rank = maybe_init_dist()
 
         self.local_rank = rank if rank is not None else 0
 
         if torch.cuda.is_available():
+            if "torchrun" not in ctx.model_yaml_config and properties.get("gpu_id") is not None:
+                gpu_id = properties.get("gpu_id")
+            else:
+                gpu_id = self.local_rank 
             self.map_location = "cuda"
-            self.device = torch.device(self.map_location + ":" + str(self.local_rank))
+            self.device = torch.device(self.map_location + ":" + str(gpu_id))
 
-            torch.cuda.set_device(self.local_rank)
+            torch.cuda.set_device(gpu_id)
 
         checkpoint_path = Path(ctx.model_yaml_config["handler"]["converted_ckpt_dir"])
         assert checkpoint_path.is_file(), checkpoint_path


### PR DESCRIPTION
## Description

Please read our [CONTRIBUTING.md](https://github.com/pytorch/serve/blob/master/CONTRIBUTING.md) prior to creating your first pull request.

Creating PR to update the handler for the GPT Fast example to support obtaining the GPU ID from context. 

**Testing:**

Created two model artifacts i.e. `gpt_fast_7b.mar` (4 workers without tensor parallelism) and `gpt_fast_7b_tp.mar` (1 worker with tensor parallelism and parallel level 4) with modified handler. Performed inference with both models:

- **Case 1**: `gpt_fast_7b.mar`

    - Command to start TorchServe and perform inference with curl:
```
torchserve --start --ncs --model-store model_store --models gpt_fast_7b.mar
curl "http://localhost:8080/predictions/gpt_fast_7b" -T request.json
``` 

Output:

```
is Paris. It is located in the northern central part of the country and is known for its stunning architecture, art museums, fashion, and historical landmarks. The city is home to many famous landmarks such as the Eiffel Tower
``` 

`nvidia-smi` output:

```
Tue Jan  2 20:36:01 2024       
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.104.12             Driver Version: 535.104.12   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA A10G                    On  | 00000000:00:1B.0 Off |                    0 |
|  0%   22C    P0              55W / 300W |  13110MiB / 23028MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+
|   1  NVIDIA A10G                    On  | 00000000:00:1C.0 Off |                    0 |
|  0%   22C    P0              56W / 300W |  13110MiB / 23028MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+
|   2  NVIDIA A10G                    On  | 00000000:00:1D.0 Off |                    0 |
|  0%   24C    P0              57W / 300W |  13492MiB / 23028MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+
|   3  NVIDIA A10G                    On  | 00000000:00:1E.0 Off |                    0 |
|  0%   22C    P0              54W / 300W |  13186MiB / 23028MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+
                                                                                         
+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|    0   N/A  N/A   1092205      C   .../envs/ts_aot_compile/bin/python3.10    13102MiB |
|    1   N/A  N/A   1092203      C   .../envs/ts_aot_compile/bin/python3.10    13102MiB |
|    2   N/A  N/A   1092206      C   .../envs/ts_aot_compile/bin/python3.10    13484MiB |
|    3   N/A  N/A   1092204      C   .../envs/ts_aot_compile/bin/python3.10    13178MiB |
+---------------------------------------------------------------------------------------+
```
Tar file with model artifact MAR file and TorchServe logs: [gpt_fast_7b.tar.gz](https://github.com/pytorch/serve/files/13813792/gpt_fast_7b.tar.gz)


- **Case 2**: `gpt_fast_7b_tp.mar`

    - Command to start TorchServe and perform inference with curl:
```
torchserve --start --ncs --model-store model_store --models gpt_fast_7b_tp.mar
curl "http://localhost:8080/predictions/gpt_fast_7b_tp" -T request.json
``` 

Output:

```
is Paris. It is located in the northern central part of the country and is known for its stunning architecture, art museums, fashion, and historical landmarks. The city is home to many famous landmarks such as the Eiffel Tower
``` 

`nvidia-smi` output:

```
Tue Jan  2 20:42:18 2024       
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.104.12             Driver Version: 535.104.12   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA A10G                    On  | 00000000:00:1B.0 Off |                    0 |
|  0%   21C    P0              55W / 300W |   2298MiB / 23028MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+
|   1  NVIDIA A10G                    On  | 00000000:00:1C.0 Off |                    0 |
|  0%   21C    P0              56W / 300W |   2298MiB / 23028MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+
|   2  NVIDIA A10G                    On  | 00000000:00:1D.0 Off |                    0 |
|  0%   22C    P0              56W / 300W |   2298MiB / 23028MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+
|   3  NVIDIA A10G                    On  | 00000000:00:1E.0 Off |                    0 |
|  0%   21C    P0              54W / 300W |   2298MiB / 23028MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+
                                                                                         
+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|    0   N/A  N/A   1094722      C   .../envs/ts_aot_compile/bin/python3.10     2290MiB |
|    1   N/A  N/A   1094723      C   .../envs/ts_aot_compile/bin/python3.10     2290MiB |
|    2   N/A  N/A   1094724      C   .../envs/ts_aot_compile/bin/python3.10     2290MiB |
|    3   N/A  N/A   1094725      C   .../envs/ts_aot_compile/bin/python3.10     2290MiB |
+---------------------------------------------------------------------------------------+
```
Tar file with model artifact MAR file and TorchServe logs: [gpt_fast_7b_tp.tar.gz](https://github.com/pytorch/serve/files/13813818/gpt_fast_7b_tp.tar.gz)

