### PR TITLE
Build torchserve nightly GPU image with torchserve nightly

### DIFF
--- a/docker/docker_nightly.py
+++ b/docker/docker_nightly.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
     # Build Nightly images and append the date in the name
     try_and_handle(f"./build_image.sh -n -t {organization}/{cpu_version}", dry_run)
     try_and_handle(
-        f"./build_image.sh -g -cv cu121 -t {organization}/{gpu_version}",
+        f"./build_image.sh -g -cv cu121 -n -t {organization}/{gpu_version}",
         dry_run,
     )
 


### PR DESCRIPTION
## Description

There is a bug in the nightly docker build script where torchserve nightly is being used only for CPU and not GPU images.

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing


- Before
![Screenshot 2024-01-08 at 3 03 56 PM](https://github.com/pytorch/serve/assets/16617092/7dcab72e-3ee2-4aab-bfa6-ee3f12dff5ea)

- After
![Screenshot 2024-01-08 at 3 23 02 PM](https://github.com/pytorch/serve/assets/16617092/50d6b4c8-e0be-47ba-a5d7-90915232f9de)


## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?