### PR TITLE
Enable fx_graph_cache in gpt-fast example

### DIFF
--- a/examples/large_models/gpt_fast/README.md
+++ b/examples/large_models/gpt_fast/README.md
@@ -9,7 +9,7 @@ It features:
 * No dependencies other than PyTorch and sentencepiece
 * int8/int4 quantization
 * Speculative decoding
-* Tensor parallelism
+* Supports multi-GPU inference through Tensor parallelism
 * Supports Nvidia and AMD GPUs
 
 More details about gpt-fast can be found in this [blog](https://pytorch.org/blog/accelerating-generative-ai-2/).

--- a/examples/large_models/gpt_fast/README.md
+++ b/examples/large_models/gpt_fast/README.md
@@ -81,6 +81,8 @@ cd ..
 At this stage we're creating the model archive which includes the configuration of our model in [model_config.yaml](./model_config.yaml).
 It's also the point where we need to decide if we want to deploy our model on a single or multiple GPUs.
 For the single GPU case we can use the default configuration that can be found in [model_config.yaml](./model_config.yaml).
+All configs enable the current prototyping feature FxGraphCache by setting fx_graph_cache to *true*.
+This feature stores the TorchInductor output in a cache to speed up torch.compile times when rerunning the handler.
 
 ```
 torch-model-archiver --model-name gpt_fast --version 1.0 --handler handler.py --config-file model_config.yaml --extra-files "gpt-fast/generate.py,gpt-fast/model.py,gpt-fast/quantize.py,gpt-fast/tp.py" --archive-format no-archive

--- a/examples/large_models/gpt_fast/handler.py
+++ b/examples/large_models/gpt_fast/handler.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import time
 from pathlib import Path
 
@@ -84,6 +85,9 @@ class GptHandler(BaseHandler):
         self.tokenizer = SentencePieceProcessor(model_file=str(tokenizer_path))
 
         if ctx.model_yaml_config["handler"]["compile"]:
+            if ctx.model_yaml_config["handler"].get("fx_graph_cache", False):
+                os.environ["TORCHINDUCTOR_FX_GRAPH_CACHE"] = "1"
+
             if self.is_speculative and use_tp:
                 torch._inductor.config.triton.cudagraph_trees = (
                     False  # Bug with cudagraph trees in this case

--- a/examples/large_models/gpt_fast/model_config.yaml
+++ b/examples/large_models/gpt_fast/model_config.yaml
@@ -8,3 +8,4 @@ handler:
     converted_ckpt_dir: "checkpoints/meta-llama/Llama-2-7b-hf/model.pth"
     max_new_tokens: 50
     compile: true
+    fx_graph_cache: True

--- a/examples/large_models/gpt_fast/model_config_speculative.yaml
+++ b/examples/large_models/gpt_fast/model_config_speculative.yaml
@@ -14,3 +14,4 @@ handler:
     max_new_tokens: 50
     compile: true
     stream: false
+    fx_graph_cache: True

--- a/examples/large_models/gpt_fast/model_config_tp.yaml
+++ b/examples/large_models/gpt_fast/model_config_tp.yaml
@@ -13,3 +13,4 @@ handler:
     max_new_tokens: 50
     compile: true
     stream: false
+    fx_graph_cache: True

--- a/test/pytest/test_example_gpt_fast.py
+++ b/test/pytest/test_example_gpt_fast.py
@@ -50,7 +50,7 @@ MAR_PARAMS = (
     {
         "nproc": 1,
         "stream": "true",
-        "compile": "false",
+        "compile": "true",
     },
     {
         "nproc": 4,
@@ -74,6 +74,7 @@ PROMPTS = [
 EXPECTED_RESULTS = [
     # ", Paris, is a city of romance, fashion, and art. The city is home to the Eiffel Tower, the Louvre, and the Arc de Triomphe. Paris is also known for its cafes, restaurants",
     " is Paris.\nThe capital of Germany is Berlin.\nThe capital of Italy is Rome.\nThe capital of Spain is Madrid.\nThe capital of the United Kingdom is London.\nThe capital of the European Union is Brussels.\n",
+    " is Paris.\n\nThe capital of Germany is Berlin.\n\nThe capital of Italy is Rome.\n\nThe capital of Spain is Madrid.\n\nThe capital of the United Kingdom is London.\n\nThe capital of the United States is",
 ]
 
 
@@ -116,7 +117,7 @@ def test_handler(tmp_path, add_paths, compile, mocker):
         ctx.model_yaml_config = config
         ctx.request_ids = {0: "0"}
 
-        torch.manual_seed(42 * 42)
+        torch.manual_seed(42)
         handler.initialize(ctx)
 
         assert ("cuda:0" if torch.cuda.is_available() else "cpu") == str(handler.device)
@@ -129,7 +130,7 @@ def test_handler(tmp_path, add_paths, compile, mocker):
 
         result = "".join(c[0][0][0] for c in send_mock.call_args_list)
 
-        assert result == EXPECTED_RESULTS[0]
+        assert result == EXPECTED_RESULTS[1 if compile == "true" else 0]
     finally:
         # free memory in case of failed test
         del handler.model
@@ -241,4 +242,4 @@ def test_gpt_fast_mar(model_name_and_stdout):
 
     assert len(prediction) > 1
 
-    assert "".join(prediction) == EXPECTED_RESULTS[0]
+    assert "".join(prediction) == EXPECTED_RESULTS[1]

--- a/ts_scripts/spellcheck_conf/wordlist.txt
+++ b/ts_scripts/spellcheck_conf/wordlist.txt
@@ -1181,3 +1181,6 @@ Karpathy's
 Maher's
 warmup
 SOTA
+FxGraphCache
+TorchInductor
+fx


### PR DESCRIPTION
## Description

This PR enables fxGraphCache in the gpt-fast example to speed up compile time.

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [X]pytest test/pytest/test_example_gpt_fast.py -k test_handler
```
===================================================================================================================== test session starts =====================================================================================================================
platform linux -- Python 3.10.12, pytest-7.3.1, pluggy-1.3.0
rootdir: /home/ubuntu/serve
plugins: mock-3.10.0, cov-4.1.0
collected 5 items / 3 deselected / 2 selected

test/pytest/test_example_gpt_fast.py ..                                                                                                                                                                                                                 [100%]

====================================================================================================================== warnings summary =======================================================================================================================
test/pytest/test_example_gpt_fast.py::test_handler[false]
  /home/ubuntu/serve/ts/torch_handler/base_handler.py:13: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    from pkg_resources import packaging

test/pytest/test_example_gpt_fast.py::test_handler[false]
test/pytest/test_example_gpt_fast.py::test_handler[false]
  /home/ubuntu/miniconda3/envs/serve/lib/python3.10/site-packages/pkg_resources/__init__.py:2871: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('zope')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

test/pytest/test_example_gpt_fast.py::test_handler[false]
test/pytest/test_example_gpt_fast.py::test_handler[true]
test/pytest/test_example_gpt_fast.py::test_handler[true]
test/pytest/test_example_gpt_fast.py::test_handler[true]
  /home/ubuntu/miniconda3/envs/serve/lib/python3.10/site-packages/torch/backends/cuda/__init__.py:321: FutureWarning: torch.backends.cuda.sdp_kernel() is deprecated. In the future, this context manager will be removed. Please see, torch.nn.attention.sdpa_
kernel() for the new context manager, with updated signature.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================================================================== 2 passed, 3 deselected, 7 warnings in 79.21s (0:01:19) ====================================================================================================
``` 
- [X] pytest test/pytest/test_example_gpt_fast.py -k test_gpt_fast_mar[mar_file_path0]
```
===================================================================================================================== test session starts =====================================================================================================================
platform linux -- Python 3.10.12, pytest-7.3.1, pluggy-1.3.0
rootdir: /home/ubuntu/serve
plugins: mock-3.10.0, cov-4.1.0
collected 5 items / 4 deselected / 1 selected

test/pytest/test_example_gpt_fast.py 2024-02-09T20:28:14,022 [INFO ] W-29500-gpt_fast_handler_1.0 TS_METRICS - ts_inference_latency_microseconds.Microseconds:6.3719938016E7|#model_name:gpt_fast_handler,model_version:default|#hostname:ip-172-31-15-101,time
stamp:1707510494
2024-02-09T20:28:14,022 [INFO ] W-29500-gpt_fast_handler_1.0 TS_METRICS - ts_queue_latency_microseconds.Microseconds:144.753|#model_name:gpt_fast_handler,model_version:default|#hostname:ip-172-31-15-101,timestamp:1707510494
2024-02-09T20:28:14,022 [INFO ] W-29500-gpt_fast_handler_1.0-stdout MODEL_METRICS - HandlerTime.ms:63717.68|#ModelName:gpt_fast_handler,Level:Model|#hostname:ip-172-31-15-101,requestID:69282a5f-3532-497e-863f-4824e81e505a,timestamp:1707510494
.                                                                                                                                                                                                                  [100%]

========================================================================================================= 1 passed, 4 deselected in 75.21s (0:01:15) ==========================================================================================================
```


## Checklist:

- [X] Did you have fun?
- [X] Have you added tests that prove your fix is effective or that this feature works?
- [X] Has code been commented, particularly in hard-to-understand areas?
- [X] Have you made corresponding changes to the documentation?