### PR TITLE
disabling venv test from docker regression

### DIFF
--- a/test/pytest/test_model_custom_dependencies.py
+++ b/test/pytest/test_model_custom_dependencies.py
@@ -141,6 +141,10 @@ def register_model_and_make_inference_request(expect_model_load_failure=False):
         resp.raise_for_status()
 
 
+@pytest.mark.skipif(
+    os.environ.get("TS_RUN_IN_DOCKER", False),
+    reason="Test to be run outside docker",
+)
 def test_install_dependencies_to_target_directory_with_requirements():
     # Torchserve cleanup
     test_utils.stop_torchserve()
@@ -167,6 +171,10 @@ def test_install_dependencies_to_target_directory_with_requirements():
         test_utils.delete_all_snapshots()
 
 
+@pytest.mark.skipif(
+    os.environ.get("TS_RUN_IN_DOCKER", False),
+    reason="Test to be run outside docker",
+)
 def test_install_dependencies_to_target_directory_without_requirements():
     # Torchserve cleanup
     test_utils.stop_torchserve()
@@ -193,6 +201,10 @@ def test_install_dependencies_to_target_directory_without_requirements():
         test_utils.delete_all_snapshots()
 
 
+@pytest.mark.skipif(
+    os.environ.get("TS_RUN_IN_DOCKER", False),
+    reason="Test to be run outside docker",
+)
 def test_disable_install_dependencies_to_target_directory_with_requirements():
     # Torchserve cleanup
     test_utils.stop_torchserve()
@@ -212,6 +224,10 @@ def test_disable_install_dependencies_to_target_directory_with_requirements():
         test_utils.delete_all_snapshots()
 
 
+@pytest.mark.skipif(
+    os.environ.get("TS_RUN_IN_DOCKER", False),
+    reason="Test to be run outside docker",
+)
 def test_disable_install_dependencies_to_target_directory_without_requirements():
     # Torchserve cleanup
     test_utils.stop_torchserve()
@@ -261,6 +277,10 @@ def test_install_dependencies_to_venv_with_requirements():
         test_utils.delete_all_snapshots()
 
 
+@pytest.mark.skipif(
+    os.environ.get("TS_RUN_IN_DOCKER", False),
+    reason="Test to be run outside docker",
+)
 def test_install_dependencies_to_venv_without_requirements():
     # Torchserve cleanup
     test_utils.stop_torchserve()
@@ -287,6 +307,10 @@ def test_install_dependencies_to_venv_without_requirements():
         test_utils.delete_all_snapshots()
 
 
+@pytest.mark.skipif(
+    os.environ.get("TS_RUN_IN_DOCKER", False),
+    reason="Test to be run outside docker",
+)
 def test_disable_install_dependencies_to_venv_with_requirements():
     # Torchserve cleanup
     test_utils.stop_torchserve()
@@ -306,6 +330,10 @@ def test_disable_install_dependencies_to_venv_with_requirements():
         test_utils.delete_all_snapshots()
 
 
+@pytest.mark.skipif(
+    os.environ.get("TS_RUN_IN_DOCKER", False),
+    reason="Test to be run outside docker",
+)
 def test_disable_install_dependencies_to_venv_without_requirements():
     # Torchserve cleanup
     test_utils.stop_torchserve()

--- a/test/pytest/test_model_custom_dependencies.py
+++ b/test/pytest/test_model_custom_dependencies.py
@@ -2,6 +2,7 @@ import os
 import pathlib
 import subprocess
 
+import pytest
 import requests
 import test_utils
 from model_archiver import ModelArchiver, ModelArchiverConfig
@@ -230,6 +231,10 @@ def test_disable_install_dependencies_to_target_directory_without_requirements()
         test_utils.delete_all_snapshots()
 
 
+@pytest.mark.skipif(
+    os.environ.get("TS_RUN_IN_DOCKER", False),
+    reason="Test to be run outside docker",
+)
 def test_install_dependencies_to_venv_with_requirements():
     # Torchserve cleanup
     test_utils.stop_torchserve()


### PR DESCRIPTION
## Description

Failing regression run: https://github.com/pytorch/serve/actions/runs/7852861004

Created this issue to track disabling of test_install_dependencies_to_venv_with_requirements from docker regression
https://github.com/pytorch/serve/issues/2942

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

- [Regression run](https://github.com/pytorch/serve/actions/runs/7876393441)


## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?