### PR TITLE
skipping macos regression for python 3.8

### DIFF
--- a/.github/workflows/regression_tests_cpu_binaries.yml
+++ b/.github/workflows/regression_tests_cpu_binaries.yml
@@ -2,8 +2,9 @@ name: Run Regression Tests for CPU nightly binaries
 
 on:
   # run every day at 6:15am
-  schedule:
-    - cron:  '15 6 * * *'
+  #schedule:
+  #  - cron:  '15 6 * * *'
+  push:
 
 concurrency:
   group: ci-cpu-${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_number || github.ref }}

--- a/.github/workflows/regression_tests_cpu_binaries.yml
+++ b/.github/workflows/regression_tests_cpu_binaries.yml
@@ -25,13 +25,16 @@ jobs:
         with:
           submodules: recursive
       - name: Setup conda with Python ${{ matrix.python-version }}
-        uses: s-weigand/setup-conda@v1
-        with:
-          update-conda: true
-          python-version: ${{ matrix.python-version }}
-          conda-channels: anaconda, conda-forge
-        condition: |
-          matrix.os == 'macOS-latest' && matrix.python-version == '3.8'
+        run: |
+          if [ "${{ matrix.os }}" == "macOS-latest" ] && [ "${{ matrix.python-version }}" == "3.8" ]; then
+            echo "Skipping setup of conda with Python 3.8 on macOS-latest"
+          else
+            uses: s-weigand/setup-conda@v1
+            with:
+              update-conda: true
+              python-version: ${{ matrix.python-version }}
+              conda-channels: anaconda, conda-forge
+          fi
       - run: conda --version
       - run: python --version
       - name: Setup Java 17
@@ -46,6 +49,8 @@ jobs:
           python ts_scripts/install_dependencies.py --environment=dev
       - name: Validate Torchserve CPU Regression
         run: |
-          python test/regression_tests.py --binaries --${{ matrix.binaries }} --nightly
-        condition: |
-          matrix.os == 'macOS-latest' && matrix.python-version == '3.8'
+          if [ "${{ matrix.os }}" == "macOS-latest" ] && [ "${{ matrix.python-version }}" == "3.8" ]; then
+            echo "Skipping validation for macOS-latest with Python 3.8"
+          else
+            python test/regression_tests.py --binaries --${{ matrix.binaries }} --nightly
+          fi

--- a/.github/workflows/regression_tests_cpu_binaries.yml
+++ b/.github/workflows/regression_tests_cpu_binaries.yml
@@ -29,6 +29,8 @@ jobs:
           update-conda: true
           python-version: ${{ matrix.python-version }}
           conda-channels: anaconda, conda-forge
+        condition: |
+          matrix.os == 'macOS-latest' && matrix.python-version == '3.8'
       - run: conda --version
       - run: python --version
       - name: Setup Java 17
@@ -44,3 +46,5 @@ jobs:
       - name: Validate Torchserve CPU Regression
         run: |
           python test/regression_tests.py --binaries --${{ matrix.binaries }} --nightly
+        condition: |
+          matrix.os == 'macOS-latest' && matrix.python-version == '3.8'

--- a/.github/workflows/regression_tests_cpu_binaries.yml
+++ b/.github/workflows/regression_tests_cpu_binaries.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10"]
         binaries: ["pypi", "conda"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
         with:
           submodules: recursive
       - name: Setup conda with Python ${{ matrix.python-version }}

--- a/.github/workflows/regression_tests_cpu_binaries.yml
+++ b/.github/workflows/regression_tests_cpu_binaries.yml
@@ -20,7 +20,6 @@ jobs:
         python-version: ["3.8", "3.9", "3.10"]
         binaries: ["pypi", "conda"]
         exclude:
-      # excludes node 8 on macOS
         - os: macos-latest
           python-version: 3.8
     steps:

--- a/.github/workflows/regression_tests_cpu_binaries.yml
+++ b/.github/workflows/regression_tests_cpu_binaries.yml
@@ -20,21 +20,20 @@ jobs:
         os: [ubuntu-20.04, macOS-latest]
         python-version: ["3.8", "3.9", "3.10"]
         binaries: ["pypi", "conda"]
+        exclude:
+      # excludes node 8 on macOS
+        - os: macos-latest
+          python-version: 3.8
     steps:
       - uses: actions/checkout@v4.1.1
         with:
           submodules: recursive
       - name: Setup conda with Python ${{ matrix.python-version }}
-        run: |
-          if [ "${{ matrix.os }}" == "macOS-latest" ] && [ "${{ matrix.python-version }}" == "3.8" ]; then
-            echo "Skipping setup of conda with Python 3.8 on macOS-latest"
-          else
-            uses: s-weigand/setup-conda@v1
-            with:
-              update-conda: true
-              python-version: ${{ matrix.python-version }}
-              conda-channels: anaconda, conda-forge
-          fi
+        uses: s-weigand/setup-conda@v1
+        with:
+          update-conda: true
+          python-version: ${{ matrix.python-version }}
+          conda-channels: anaconda, conda-forge
       - run: conda --version
       - run: python --version
       - name: Setup Java 17
@@ -49,8 +48,4 @@ jobs:
           python ts_scripts/install_dependencies.py --environment=dev
       - name: Validate Torchserve CPU Regression
         run: |
-          if [ "${{ matrix.os }}" == "macOS-latest" ] && [ "${{ matrix.python-version }}" == "3.8" ]; then
-            echo "Skipping validation for macOS-latest with Python 3.8"
-          else
-            python test/regression_tests.py --binaries --${{ matrix.binaries }} --nightly
-          fi
+          python test/regression_tests.py --binaries --${{ matrix.binaries }} --nightly

--- a/.github/workflows/regression_tests_cpu_binaries.yml
+++ b/.github/workflows/regression_tests_cpu_binaries.yml
@@ -2,9 +2,8 @@ name: Run Regression Tests for CPU nightly binaries
 
 on:
   # run every day at 6:15am
-  #schedule:
-  #  - cron:  '15 6 * * *'
-  push:
+  schedule:
+    - cron:  '15 6 * * *'
 
 concurrency:
   group: ci-cpu-${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_number || github.ref }}
@@ -25,7 +24,7 @@ jobs:
         - os: macos-latest
           python-version: 3.8
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Setup conda with Python ${{ matrix.python-version }}


### PR DESCRIPTION
## Description

Skip running regressions on mac-OS for python 3.8 as onnxruntime has stopped supporting this.

TODO: Need a better system to handle these dependencies
Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Passing Run
https://github.com/pytorch/serve/actions/runs/8009451504



## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?