### PR TITLE
Flag to disable collection of system gpu metrics

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -297,6 +297,7 @@ e.g. : To allow base URLs `https://s3.amazonaws.com/` and `https://torchserve.py
   * For security reason, `use_env_allowed_urls=true` is required in config.properties to read `allowed_urls` from environment variable.
 * `workflow_store` : Path of workflow store directory. Defaults to model store directory.
 * `disable_system_metrics` : Disable collection of system metrics when set to "true". Default value is "false".
+* `disable_system_gpu_metrics` : Disable collection of system GPU metrics when set to "true". Default value is "false".
 
 **NOTE**
 

--- a/frontend/server/src/main/java/org/pytorch/serve/metrics/MetricCollector.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/metrics/MetricCollector.java
@@ -36,11 +36,10 @@ public class MetricCollector implements Runnable {
             args[0] = configManager.getPythonExecutable();
             args[1] = "ts/metrics/metric_collector.py";
             args[2] = "--gpu";
-            if (this.configManager.isSystemGPUMetricsDisabled()){
-                args[3] = String.valueOf(0);
-            } else{
-                args[3] = String.valueOf(ConfigManager.getInstance().getNumberOfGpu());
-            }
+
+            // Disable System GPU metrics collection based on config
+            args[3] = String.valueOf(this.configManager.isSystemGPUMetricsDisabled() ? 0 : ConfigManager.getInstance().getNumberOfGpu());
+
             File workingDir = new File(configManager.getModelServerHome());
 
             String[] envp = EnvironmentUtils.getEnvString(workingDir.getAbsolutePath(), null, null);

--- a/frontend/server/src/main/java/org/pytorch/serve/metrics/MetricCollector.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/metrics/MetricCollector.java
@@ -38,7 +38,11 @@ public class MetricCollector implements Runnable {
             args[2] = "--gpu";
 
             // Disable System GPU metrics collection based on config
-            args[3] = String.valueOf(this.configManager.isSystemGPUMetricsDisabled() ? 0 : ConfigManager.getInstance().getNumberOfGpu());
+            args[3] =
+                    String.valueOf(
+                            this.configManager.isSystemGPUMetricsDisabled()
+                                    ? 0
+                                    : ConfigManager.getInstance().getNumberOfGpu());
 
             File workingDir = new File(configManager.getModelServerHome());
 

--- a/frontend/server/src/main/java/org/pytorch/serve/metrics/MetricCollector.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/metrics/MetricCollector.java
@@ -36,7 +36,11 @@ public class MetricCollector implements Runnable {
             args[0] = configManager.getPythonExecutable();
             args[1] = "ts/metrics/metric_collector.py";
             args[2] = "--gpu";
-            args[3] = String.valueOf(ConfigManager.getInstance().getNumberOfGpu());
+            if (this.configManager.isSystemGPUMetricsDisabled()){
+                args[3] = String.valueOf(0);
+            } else{
+                args[3] = String.valueOf(ConfigManager.getInstance().getNumberOfGpu());
+            }
             File workingDir = new File(configManager.getModelServerHome());
 
             String[] envp = EnvironmentUtils.getEnvString(workingDir.getAbsolutePath(), null, null);

--- a/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
@@ -72,6 +72,7 @@ public final class ConfigManager {
     private static final String TS_METRICS_MODE = "metrics_mode";
     private static final String TS_MODEL_METRICS_AUTO_DETECT = "model_metrics_auto_detect";
     private static final String TS_DISABLE_SYSTEM_METRICS = "disable_system_metrics";
+    private static final String TS_DISABLE_SYSTEM_GPU_METRICS = "disable_system_gpu_metrics";
 
     // IPEX config option that can be set at config.properties
     private static final String TS_IPEX_ENABLE = "ipex_enable";
@@ -454,6 +455,10 @@ public final class ConfigManager {
         return Boolean.parseBoolean(getProperty(TS_DISABLE_SYSTEM_METRICS, "false"));
     }
 
+    public boolean isSystemGPUMetricsDisabled() {
+        return Boolean.parseBoolean(getProperty(TS_DISABLE_SYSTEM_GPU_METRICS, "false"));
+    }
+
     public String getTsDefaultServiceHandler() {
         return getProperty(TS_DEFAULT_SERVICE_HANDLER, null);
     }
@@ -729,6 +734,8 @@ public final class ConfigManager {
                 + getMetricsMode()
                 + "\nDisable system metrics: "
                 + isSystemMetricsDisabled()
+                + "\nDisable system GPU metrics: "
+                + isSystemGPUMetricsDisabled()
                 + "\nWorkflow Store: "
                 + (getWorkflowStore() == null ? "N/A" : getWorkflowStore())
                 + "\nCPP log config: "

--- a/ts_scripts/install_dependencies.py
+++ b/ts_scripts/install_dependencies.py
@@ -131,7 +131,7 @@ class Common:
         if nightly:
             pt_nightly = "cpu" if not cuda_version else cuda_version
             os.system(
-                f"pip3 install numpy --pre torch torchvision torchtext torchaudio --force-reinstall --extra-index-url https://download.pytorch.org/whl/nightly/{pt_nightly}"
+                f"pip3 install numpy --pre torch torchvision torchtext torchaudio --force-reinstall --index-url https://download.pytorch.org/whl/nightly/{pt_nightly}"
             )
         else:
             self.install_torch_packages(cuda_version)


### PR DESCRIPTION
## Description

This PR introduces a flag to disable collection of gpu metrics

The flag can be set using 2 ways
-  `disable_system_gpu_metrics=true` in `config.properties`
-  set env variable `TS_DISABLE_SYSTEM_GPU_METRICS=true`  and `enable_envvars_config=true` in `config.properties`

Expected behavior

With
```
disable_system_gpu_metrics=false
disable_system_metrics=false
```
we see the following
```
2024-02-28T20:44:08,893 [INFO ] pool-3-thread-1 TS_METRICS - DiskAvailable.Gigabytes:254.97389221191406|#Level:Host|#hostname:ip-172-31-12-209,timestamp:1709153048
2024-02-28T20:44:08,893 [INFO ] pool-3-thread-1 TS_METRICS - DiskUsage.Gigabytes:35.57705307006836|#Level:Host|#hostname:ip-172-31-12-209,timestamp:1709153048
2024-02-28T20:44:08,894 [INFO ] pool-3-thread-1 TS_METRICS - DiskUtilization.Percent:12.2|#Level:Host|#hostname:ip-172-31-12-209,timestamp:1709153048
2024-02-28T20:44:08,894 [INFO ] pool-3-thread-1 TS_METRICS - GPUMemoryUtilization.Percent:3.4914017717561228|#Level:Host,DeviceId:0|#hostname:ip-172-31-12-209,timestamp:1709153048
2024-02-28T20:44:08,894 [INFO ] pool-3-thread-1 TS_METRICS - GPUMemoryUsed.Megabytes:804.0|#Level:Host,DeviceId:0|#hostname:ip-172-31-12-209,timestamp:1709153048
2024-02-28T20:44:08,894 [INFO ] pool-3-thread-1 TS_METRICS - GPUUtilization.Percent:0.0|#Level:Host,DeviceId:0|#hostname:ip-172-31-12-209,timestamp:1709153048
2024-02-28T20:44:08,894 [INFO ] pool-3-thread-1 TS_METRICS - MemoryAvailable.Megabytes:27680.22265625|#Level:Host|#hostname:ip-172-31-12-209,timestamp:1709153048
2024-02-28T20:44:08,895 [INFO ] pool-3-thread-1 TS_METRICS - MemoryUsed.Megabytes:3580.03515625|#Level:Host|#hostname:ip-172-31-12-209,timestamp:1709153048
2024-02-28T20:44:08,895 [INFO ] pool-3-thread-1 TS_METRICS - MemoryUtilization.Percent:12.8|#Level:Host|#hostname:ip-172-31-12-209,timestamp:1709153048
```

With
```
disable_system_gpu_metrics=true
disable_system_metrics=false
```
we see
```
2024-02-28T20:44:43,686 [INFO ] pool-3-thread-1 TS_METRICS - CPUUtilization.Percent:0.0|#Level:Host|#hostname:ip-172-31-12-209,timestamp:1709153083
2024-02-28T20:44:43,687 [INFO ] pool-3-thread-1 TS_METRICS - DiskAvailable.Gigabytes:254.97388076782227|#Level:Host|#hostname:ip-172-31-12-209,timestamp:1709153083
2024-02-28T20:44:43,687 [INFO ] pool-3-thread-1 TS_METRICS - DiskUsage.Gigabytes:35.577064514160156|#Level:Host|#hostname:ip-172-31-12-209,timestamp:1709153083
2024-02-28T20:44:43,688 [INFO ] pool-3-thread-1 TS_METRICS - DiskUtilization.Percent:12.2|#Level:Host|#hostname:ip-172-31-12-209,timestamp:1709153083
2024-02-28T20:44:43,688 [INFO ] pool-3-thread-1 TS_METRICS - MemoryAvailable.Megabytes:29957.375|#Level:Host|#hostname:ip-172-31-12-209,timestamp:1709153083
2024-02-28T20:44:43,688 [INFO ] pool-3-thread-1 TS_METRICS - MemoryUsed.Megabytes:1313.07421875|#Level:Host|#hostname:ip-172-31-12-209,timestamp:1709153083
2024-02-28T20:44:43,689 [INFO ] pool-3-thread-1 TS_METRICS - MemoryUtilization.Percent:5.6|#Level:Host|#hostname:ip-172-31-12-209,timestamp:1709153083
```

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

PyTest
```
test_metrics.py::test_collect_system_metrics_when_not_disabled PASSED    [ 41%]
test_metrics.py::test_disable_system_metrics_using_config_properties PASSED [ 42%]
test_metrics.py::test_disable_system_metrics_using_environment_variable PASSED [ 43%]
test_metrics.py::test_disable_system_gpu_metrics_using_config_properties PASSED [ 43%]
test_metrics.py::test_disable_system_gpu_metrics_using_environment_variable PASSED [ 44%]
```


## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?