### PR TITLE
fix Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,7 +71,7 @@ WORKDIR "serve"
 RUN \
     if echo "$BASE_IMAGE" | grep -q "cuda:"; then \
         # Install CUDA version specific binary when CUDA version is specified as a build arg
-        if [ "USE_CUDA_VERSION" ]; then \
+        if [ "$USE_CUDA_VERSION" ]; then \
             python ./ts_scripts/install_dependencies.py --cuda $USE_CUDA_VERSION; \
         # Install the binary with the latest CPU image on a CUDA base image
         else \


### PR DESCRIPTION
## Description

On L74, `if [ "USE_CUDA_VERSION" ];` is fixed to `if [ "$USE_CUDA_VERSION" ];`.
No dependencies are required for this change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Feature/Issue validation/testing

Run `./build_image.sh -cv cu118 -py 3.9 -t torchserve:dev-base &> build.log`.
Without the fix, you may find `[compile-image 8/9] RUN ... if [ "USE_CUDA_VERSION" ]; then ...` in build.log, after the fix, the log would be `[compile-image 8/9] RUN ... if [ "cu118" ]; then ...` which is the original author's intention in my understanding.

## Checklist:

- [x] Did you have fun?
- [x] Have you added tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?