### PR TITLE
support system_metrics_cmd in config.properties

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -297,7 +297,7 @@ e.g. : To allow base URLs `https://s3.amazonaws.com/` and `https://torchserve.py
   * For security reason, `use_env_allowed_urls=true` is required in config.properties to read `allowed_urls` from environment variable.
 * `workflow_store` : Path of workflow store directory. Defaults to model store directory.
 * `disable_system_metrics` : Disable collection of system metrics when set to "true". Default value is "false".
-* `system_metrics_cmd`: Command of the execution of a customized system metrics. Default value is "ts/metrics/metric_collector.py --gpu $CUDA_VISIBLE_DEVICES".
+* `system_metrics_cmd`: The customized system metrics python script name with arguments. Default value is "ts/metrics/metric_collector.py --gpu $CUDA_VISIBLE_DEVICES".
 
 **NOTE**
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -297,6 +297,7 @@ e.g. : To allow base URLs `https://s3.amazonaws.com/` and `https://torchserve.py
   * For security reason, `use_env_allowed_urls=true` is required in config.properties to read `allowed_urls` from environment variable.
 * `workflow_store` : Path of workflow store directory. Defaults to model store directory.
 * `disable_system_metrics` : Disable collection of system metrics when set to "true". Default value is "false".
+* `system_metrics_cmd`: Command of the execution of a customized system metrics. Default value is "ts/metrics/metric_collector.py --gpu $CUDA_VISIBLE_DEVICES".
 
 **NOTE**
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -297,7 +297,7 @@ e.g. : To allow base URLs `https://s3.amazonaws.com/` and `https://torchserve.py
   * For security reason, `use_env_allowed_urls=true` is required in config.properties to read `allowed_urls` from environment variable.
 * `workflow_store` : Path of workflow store directory. Defaults to model store directory.
 * `disable_system_metrics` : Disable collection of system metrics when set to "true". Default value is "false".
-* `system_metrics_cmd`: The customized system metrics python script name with arguments. Default value is "ts/metrics/metric_collector.py --gpu $CUDA_VISIBLE_DEVICES".
+* `system_metrics_cmd`: The customized system metrics python script name with arguments. For example:`ts/metrics/metric_collector.py --gpu 0`. Default: empty which means TorchServe collects system metrics via "ts/metrics/metric_collector.py --gpu $CUDA_VISIBLE_DEVICES".
 
 **NOTE**
 

--- a/frontend/server/src/main/java/org/pytorch/serve/metrics/MetricCollector.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/metrics/MetricCollector.java
@@ -34,9 +34,7 @@ public class MetricCollector implements Runnable {
             // Collect System level Metrics
             String[] args = new String[4];
             args[0] = configManager.getPythonExecutable();
-            args[1] = "ts/metrics/metric_collector.py";
-            args[2] = "--gpu";
-            args[3] = String.valueOf(ConfigManager.getInstance().getNumberOfGpu());
+            args[1] = configManager.getSystemMetricsCmd();
             File workingDir = new File(configManager.getModelServerHome());
 
             String[] envp = EnvironmentUtils.getEnvString(workingDir.getAbsolutePath(), null, null);

--- a/frontend/server/src/main/java/org/pytorch/serve/metrics/MetricCollector.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/metrics/MetricCollector.java
@@ -7,6 +7,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.IOUtils;
@@ -32,14 +33,23 @@ public class MetricCollector implements Runnable {
     public void run() {
         try {
             // Collect System level Metrics
-            String[] args = new String[4];
-            args[0] = configManager.getPythonExecutable();
-            args[1] = configManager.getSystemMetricsCmd();
+            List<String> args = new ArrayList<>();
+            args.add(configManager.getPythonExecutable());
+            String systemMetricsCmd = configManager.getSystemMetricsCmd();
+            if (systemMetricsCmd.isEmpty()) {
+                systemMetricsCmd =
+                        String.format(
+                                "%s --gpu %s",
+                                "ts/metrics/metric_collector.py",
+                                String.valueOf(configManager.getNumberOfGpu()));
+            }
+            args.addAll(Arrays.asList(systemMetricsCmd.split("\\s+")));
             File workingDir = new File(configManager.getModelServerHome());
 
             String[] envp = EnvironmentUtils.getEnvString(workingDir.getAbsolutePath(), null, null);
-
-            final Process p = Runtime.getRuntime().exec(args, envp, workingDir); // NOPMD
+            final Process p =
+                    Runtime.getRuntime()
+                            .exec(args.toArray(new String[0]), envp, workingDir); // NOPMD
             ModelManager modelManager = ModelManager.getInstance();
             Map<Integer, WorkerThread> workerMap = modelManager.getWorkers();
             try (OutputStream os = p.getOutputStream()) {

--- a/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
@@ -1,5 +1,6 @@
 package org.pytorch.serve.util;
 
+import com.google.common.base.Strings;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 import io.netty.handler.ssl.SslContext;
@@ -117,6 +118,7 @@ public final class ConfigManager {
     private static final String MODEL_SNAPSHOT = "model_snapshot";
     private static final String MODEL_CONFIG = "models";
     private static final String VERSION = "version";
+    private static final String SYSTEM_METRICS_CMD = "system_metrics_cmd";
 
     // Configuration default values
     private static final String DEFAULT_TS_ALLOWED_URLS = "file://.*|http(s)?://.*";
@@ -557,6 +559,12 @@ public final class ConfigManager {
 
     public String getCertificateFile() {
         return prop.getProperty(TS_CERTIFICATE_FILE);
+    }
+
+    public String getSystemMetricsCmd() {
+        String defaultCmd = String.format("%s --gpu %s",
+                "ts/metrics/metric_collector.py", String.valueOf(getNumberOfGpu()));
+        return prop.getProperty(SYSTEM_METRICS_CMD, defaultCmd);
     }
 
     public SslContext getSslContext() throws IOException, GeneralSecurityException {

--- a/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
@@ -1,6 +1,5 @@
 package org.pytorch.serve.util;
 
-import com.google.common.base.Strings;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 import io.netty.handler.ssl.SslContext;
@@ -562,9 +561,7 @@ public final class ConfigManager {
     }
 
     public String getSystemMetricsCmd() {
-        String defaultCmd = String.format("%s --gpu %s",
-                "ts/metrics/metric_collector.py", String.valueOf(getNumberOfGpu()));
-        return prop.getProperty(SYSTEM_METRICS_CMD, defaultCmd);
+        return prop.getProperty(SYSTEM_METRICS_CMD, "");
     }
 
     public SslContext getSslContext() throws IOException, GeneralSecurityException {

--- a/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
@@ -739,7 +739,9 @@ public final class ConfigManager {
                 + "\nCPP log config: "
                 + (getTsCppLogConfig() == null ? "N/A" : getTsCppLogConfig())
                 + "\nModel config: "
-                + prop.getProperty(MODEL_CONFIG, "N/A");
+                + prop.getProperty(MODEL_CONFIG, "N/A")
+                + "\nSystem metrics command: "
+                + (getSystemMetricsCmd().isEmpty() ? "default" : getSystemMetricsCmd());
     }
 
     public boolean useNativeIo() {


### PR DESCRIPTION
## Description

Please read our [CONTRIBUTING.md](https://github.com/pytorch/serve/blob/master/CONTRIBUTING.md) prior to creating your first pull request.

Please include a summary of the feature or issue being fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- Test case1: use TorchServe default system metrics cmd
```
torchserve --ncs --start --model-store model_store

Blacklist Regex: N/A
Maximum Response Size: 6553500
Maximum Request Size: 6553500
Limit Maximum Image Pixels: true
Prefer direct buffer: false
Allowed Urls: [file://.*|http(s)?://.*]
Custom python dependency for model allowed: false
Enable metrics API: true
Metrics mode: LOG
Disable system metrics: false
Workflow Store: /home/ubuntu/serve/model_store
CPP log config: N/A
Model config: N/A
System metrics command: default
2024-03-05T17:32:43,601 [INFO ] main org.pytorch.serve.servingsdk.impl.PluginsManager -  Loading snapshot serializer plugin...
2024-03-05T17:32:43,620 [INFO ] main org.pytorch.serve.ModelServer - Initialize Inference server with: EpollServerSocketChannel.
2024-03-05T17:32:43,675 [INFO ] main org.pytorch.serve.ModelServer - Inference API bind to: http://127.0.0.1:8080
2024-03-05T17:32:43,676 [INFO ] main org.pytorch.serve.ModelServer - Initialize Management server with: EpollServerSocketChannel.
2024-03-05T17:32:43,677 [INFO ] main org.pytorch.serve.ModelServer - Management API bind to: http://127.0.0.1:8081
2024-03-05T17:32:43,677 [INFO ] main org.pytorch.serve.ModelServer - Initialize Metrics server with: EpollServerSocketChannel.
2024-03-05T17:32:43,678 [INFO ] main org.pytorch.serve.ModelServer - Metrics API bind to: http://127.0.0.1:8082
Model server started.
2024-03-05T17:32:45,250 [INFO ] pool-3-thread-1 TS_METRICS - CPUUtilization.Percent:5.0|#Level:Host|#hostname:ip-172-31-8-38,timestamp:1709659965
2024-03-05T17:32:45,251 [INFO ] pool-3-thread-1 TS_METRICS - DiskAvailable.Gigabytes:261.5556411743164|#Level:Host|#hostname:ip-172-31-8-38,timestamp:1709659965
2024-03-05T17:32:45,251 [INFO ] pool-3-thread-1 TS_METRICS - DiskUsage.Gigabytes:731.0341110229492|#Level:Host|#hostname:ip-172-31-8-38,timestamp:1709659965
2024-03-05T17:32:45,251 [INFO ] pool-3-thread-1 TS_METRICS - DiskUtilization.Percent:73.6|#Level:Host|#hostname:ip-172-31-8-38,timestamp:1709659965
2024-03-05T17:32:45,252 [INFO ] pool-3-thread-1 TS_METRICS - GPUMemoryUtilization.Percent:0.00868507903421921|#Level:Host,DeviceId:0|#hostname:ip-172-31-8-38,timestamp:1709659965
2024-03-05T17:32:45,252 [INFO ] pool-3-thread-1 TS_METRICS - GPUMemoryUsed.Megabytes:2.0|#Level:Host,DeviceId:0|#hostname:ip-172-31-8-38,timestamp:1709659965
2024-03-05T17:32:45,252 [INFO ] pool-3-thread-1 TS_METRICS - GPUMemoryUtilization.Percent:0.00868507903421921|#Level:Host,DeviceId:1|#hostname:ip-172-31-8-38,timestamp:1709659965
2024-03-05T17:32:45,252 [INFO ] pool-3-thread-1 TS_METRICS - GPUMemoryUsed.Megabytes:2.0|#Level:Host,DeviceId:1|#hostname:ip-172-31-8-38,timestamp:1709659965
2024-03-05T17:32:45,252 [INFO ] pool-3-thread-1 TS_METRICS - GPUMemoryUtilization.Percent:0.00868507903421921|#Level:Host,DeviceId:2|#hostname:ip-172-31-8-38,timestamp:1709659965
2024-03-05T17:32:45,253 [INFO ] pool-3-thread-1 TS_METRICS - GPUMemoryUsed.Megabytes:2.0|#Level:Host,DeviceId:2|#hostname:ip-172-31-8-38,timestamp:1709659965
2024-03-05T17:32:45,253 [INFO ] pool-3-thread-1 TS_METRICS - GPUMemoryUtilization.Percent:0.00868507903421921|#Level:Host,DeviceId:3|#hostname:ip-172-31-8-38,timestamp:1709659965
2024-03-05T17:32:45,253 [INFO ] pool-3-thread-1 TS_METRICS - GPUMemoryUsed.Megabytes:2.0|#Level:Host,DeviceId:3|#hostname:ip-172-31-8-38,timestamp:1709659965
2024-03-05T17:32:45,253 [INFO ] pool-3-thread-1 TS_METRICS - GPUUtilization.Percent:0.0|#Level:Host,DeviceId:0|#hostname:ip-172-31-8-38,timestamp:1709659965
2024-03-05T17:32:45,253 [INFO ] pool-3-thread-1 TS_METRICS - GPUUtilization.Percent:0.0|#Level:Host,DeviceId:1|#hostname:ip-172-31-8-38,timestamp:1709659965
2024-03-05T17:32:45,254 [INFO ] pool-3-thread-1 TS_METRICS - GPUUtilization.Percent:0.0|#Level:Host,DeviceId:2|#hostname:ip-172-31-8-38,timestamp:1709659965
2024-03-05T17:32:45,254 [INFO ] pool-3-thread-1 TS_METRICS - GPUUtilization.Percent:0.0|#Level:Host,DeviceId:3|#hostname:ip-172-31-8-38,timestamp:1709659965
2024-03-05T17:32:45,254 [INFO ] pool-3-thread-1 TS_METRICS - MemoryAvailable.Megabytes:375841.48828125|#Level:Host|#hostname:ip-172-31-8-38,timestamp:1709659965
2024-03-05T17:32:45,254 [INFO ] pool-3-thread-1 TS_METRICS - MemoryUsed.Megabytes:3571.5859375|#Level:Host|#hostname:ip-172-31-8-38,timestamp:1709659965
2024-03-05T17:32:45,254 [INFO ] pool-3-thread-1 TS_METRICS - MemoryUtilization.Percent:1.8|#Level:Host|#hostname:ip-172-31-8-38,timestamp:1709659965
```

- Test case2: use customized system metrics cmd
```
cat config.properties
inference_address=http://127.0.0.1:8080
management_address=http://127.0.0.1:8081

number_of_netty_threads=32
job_queue_size=1000

vmargs=-Xmx4g -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError
prefer_direct_buffer=True

default_response_timeout=300
unregister_model_timeout=300
install_py_dep_per_model=true
system_metrics_cmd=ts/metrics/metric_collector.py --gpu 0

torchserve --ncs --start --model-store model_store --ts-config config.properties

WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
2024-03-05T17:40:58,612 [WARN ] main org.pytorch.serve.util.ConfigManager - Your torchserve instance can access any URL to load models. When deploying to production, make sure to limit the set of allowed_urls in config.properties
2024-03-05T17:40:58,614 [INFO ] main org.pytorch.serve.servingsdk.impl.PluginsManager - Initializing plugins manager...
2024-03-05T17:40:58,665 [INFO ] main org.pytorch.serve.metrics.configuration.MetricConfiguration - Successfully loaded metrics configuration from /opt/conda/lib/python3.10/site-packages/ts/configs/metrics.yaml
2024-03-05T17:40:58,843 [INFO ] main org.pytorch.serve.ModelServer -
Torchserve version: 0.9.0
TS Home: /opt/conda/lib/python3.10/site-packages
Current directory: /home/ubuntu/serve
Temp directory: /tmp
Metrics config path: /opt/conda/lib/python3.10/site-packages/ts/configs/metrics.yaml
Number of GPUs: 4
Number of CPUs: 96
Max heap size: 4096 M
Python executable: /opt/conda/bin/python
Config file: config.properties
Inference address: http://127.0.0.1:8080
Management address: http://127.0.0.1:8081
Metrics address: http://127.0.0.1:8082
Model Store: /home/ubuntu/serve/model_store
Initial Models: N/A
Log dir: /home/ubuntu/serve/logs
Metrics dir: /home/ubuntu/serve/logs
Netty threads: 32
Netty client threads: 0
Default workers per model: 4
Blacklist Regex: N/A
Maximum Response Size: 6553500
Maximum Request Size: 6553500
Limit Maximum Image Pixels: true
Prefer direct buffer: True
Allowed Urls: [file://.*|http(s)?://.*]
Custom python dependency for model allowed: true
Enable metrics API: true
Metrics mode: LOG
Disable system metrics: false
Workflow Store: /home/ubuntu/serve/model_store
CPP log config: N/A
Model config: N/A
System metrics command: ts/metrics/metric_collector.py --gpu 0
2024-03-05T17:40:58,849 [INFO ] main org.pytorch.serve.servingsdk.impl.PluginsManager -  Loading snapshot serializer plugin...
2024-03-05T17:40:58,868 [INFO ] main org.pytorch.serve.ModelServer - Initialize Inference server with: EpollServerSocketChannel.
2024-03-05T17:40:58,918 [INFO ] main org.pytorch.serve.ModelServer - Inference API bind to: http://127.0.0.1:8080
2024-03-05T17:40:58,919 [INFO ] main org.pytorch.serve.ModelServer - Initialize Management server with: EpollServerSocketChannel.
2024-03-05T17:40:58,920 [INFO ] main org.pytorch.serve.ModelServer - Management API bind to: http://127.0.0.1:8081
2024-03-05T17:40:58,920 [INFO ] main org.pytorch.serve.ModelServer - Initialize Metrics server with: EpollServerSocketChannel.
2024-03-05T17:40:58,921 [INFO ] main org.pytorch.serve.ModelServer - Metrics API bind to: http://127.0.0.1:8082
Model server started.
2024-03-05T17:40:59,144 [INFO ] pool-3-thread-1 TS_METRICS - CPUUtilization.Percent:0.0|#Level:Host|#hostname:ip-172-31-8-38,timestamp:1709660459
2024-03-05T17:40:59,146 [INFO ] pool-3-thread-1 TS_METRICS - DiskAvailable.Gigabytes:261.55556869506836|#Level:Host|#hostname:ip-172-31-8-38,timestamp:1709660459
2024-03-05T17:40:59,146 [INFO ] pool-3-thread-1 TS_METRICS - DiskUsage.Gigabytes:731.0341835021973|#Level:Host|#hostname:ip-172-31-8-38,timestamp:1709660459
2024-03-05T17:40:59,146 [INFO ] pool-3-thread-1 TS_METRICS - DiskUtilization.Percent:73.6|#Level:Host|#hostname:ip-172-31-8-38,timestamp:1709660459
2024-03-05T17:40:59,147 [INFO ] pool-3-thread-1 TS_METRICS - MemoryAvailable.Megabytes:375894.63671875|#Level:Host|#hostname:ip-172-31-8-38,timestamp:1709660459
2024-03-05T17:40:59,147 [INFO ] pool-3-thread-1 TS_METRICS - MemoryUsed.Megabytes:3518.4375|#Level:Host|#hostname:ip-172-31-8-38,timestamp:1709660459
2024-03-05T17:40:59,147 [INFO ] pool-3-thread-1 TS_METRICS - MemoryUtilization.Percent:1.8|#Level:Host|#hostname:ip-172-31-8-38,timestamp:1709660459
2024-03-05T17:41:59,140 [INFO ] pool-3-thread-1 TS_METRICS - CPUUtilization.Percent:0.0|#Level:Host|#hostname:ip-172-31-8-38,timestamp:1709660519
2024-03-05T17:41:59,141 [INFO ] pool-3-thread-1 TS_METRICS - DiskAvailable.Gigabytes:261.55555725097656|#Level:Host|#hostname:ip-172-31-8-38,timestamp:1709660519
2024-03-05T17:41:59,141 [INFO ] pool-3-thread-1 TS_METRICS - DiskUsage.Gigabytes:731.0341949462891|#Level:Host|#hostname:ip-172-31-8-38,timestamp:1709660519
2024-03-05T17:41:59,141 [INFO ] pool-3-thread-1 TS_METRICS - DiskUtilization.Percent:73.6|#Level:Host|#hostname:ip-172-31-8-38,timestamp:1709660519
2024-03-05T17:41:59,141 [INFO ] pool-3-thread-1 TS_METRICS - MemoryAvailable.Megabytes:375890.171875|#Level:Host|#hostname:ip-172-31-8-38,timestamp:1709660519
2024-03-05T17:41:59,142 [INFO ] pool-3-thread-1 TS_METRICS - MemoryUsed.Megabytes:3523.39453125|#Level:Host|#hostname:ip-172-31-8-38,timestamp:1709660519
2024-03-05T17:41:59,142 [INFO ] pool-3-thread-1 TS_METRICS - MemoryUtilization.Percent:1.8|#Level:Host|#hostname:ip-172-31-8-38,timestamp:1709660519
```

## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

cc @namannandan