### PR TITLE
Move file prep from build.sh to cmake

### DIFF
--- a/cpp/build.sh
+++ b/cpp/build.sh
@@ -82,7 +82,6 @@ function build() {
   fi
 
   make -j "$JOBS"
-  make format
   make install
   echo -e "${COLOR_GREEN}torchserve_cpp build is complete. To run unit test: \
   ./_build/test/torchserve_cpp_test ${COLOR_OFF}"

--- a/cpp/build.sh
+++ b/cpp/build.sh
@@ -20,45 +20,6 @@ function detect_platform() {
   echo -e "${COLOR_GREEN}Detected platform: $PLATFORM ${COLOR_OFF}"
 }
 
-function prepare_test_files() {
-  echo -e "${COLOR_GREEN}[ INFO ]Preparing test files ${COLOR_OFF}"
-  local EX_DIR="${TR_DIR}/examples/"
-  rsync -a --link-dest=../../test/resources/ ${BASE_DIR}/test/resources/ ${TR_DIR}/
-  if [ ! -f "${EX_DIR}/babyllama/babyllama_handler/tokenizer.bin" ]; then
-    wget -q https://github.com/karpathy/llama2.c/raw/master/tokenizer.bin -O "${EX_DIR}/babyllama/babyllama_handler/tokenizer.bin"
-  fi
-  if [ ! -f "${EX_DIR}/babyllama/babyllama_handler/stories15M.bin" ]; then
-    wget -q https://huggingface.co/karpathy/tinyllamas/resolve/main/stories15M.bin -O "${EX_DIR}/babyllama/babyllama_handler/stories15M.bin"
-  fi
-  # PT2.2 torch.expport does not support Mac
-  if [ "$PLATFORM" = "Linux" ]; then
-    if [ ! -f "${EX_DIR}/aot_inductor/llama_handler/stories15M.so" ]; then
-      local HANDLER_DIR=${EX_DIR}/aot_inductor/llama_handler/
-      if [ ! -f "${HANDLER_DIR}/stories15M.pt" ]; then
-        wget -q https://huggingface.co/karpathy/tinyllamas/resolve/main/stories15M.pt?download=true -O "${HANDLER_DIR}/stories15M.pt"
-      fi
-      local LLAMA_SO_DIR=${BASE_DIR}/third-party/llama2.so/
-      PYTHONPATH=${LLAMA_SO_DIR}:${PYTHONPATH} python ${BASE_DIR}/../examples/cpp/aot_inductor/llama2/compile.py --checkpoint ${HANDLER_DIR}/stories15M.pt ${HANDLER_DIR}/stories15M.so
-    fi
-    if [ ! -f "${EX_DIR}/aot_inductor/bert_handler/bert-seq.so" ]; then
-      pip install transformers
-      local HANDLER_DIR=${EX_DIR}/aot_inductor/bert_handler/
-      export TOKENIZERS_PARALLELISM=false
-      cd ${BASE_DIR}/../examples/cpp/aot_inductor/bert/
-      python aot_compile_export.py
-      mv bert-seq.so ${HANDLER_DIR}/bert-seq.so
-      mv Transformer_model/tokenizer.json ${HANDLER_DIR}/tokenizer.json
-      export TOKENIZERS_PARALLELISM=""
-    fi
-    if [ ! -f "${EX_DIR}/aot_inductor/resnet_handler/resnet50_pt2.so" ]; then
-      local HANDLER_DIR=${EX_DIR}/aot_inductor/resnet_handler/
-      cd ${HANDLER_DIR}
-      python ${BASE_DIR}/../examples/cpp/aot_inductor/resnet/resnet50_torch_export.py
-    fi
-  fi
-  cd "$BWD" || exit
-}
-
 function build() {
   echo -e "${COLOR_GREEN}[ INFO ]Building backend ${COLOR_OFF}"
   MAYBE_BUILD_QUIC=""
@@ -207,6 +168,5 @@ cd $BASE_DIR
 
 git submodule update --init --recursive
 
-prepare_test_files
 build
 install_torchserve_cpp

--- a/cpp/src/backends/core/backend.cc
+++ b/cpp/src/backends/core/backend.cc
@@ -22,12 +22,14 @@ bool Backend::Initialize(const std::string &model_dir) {
   // TODO: windows
   TS_LOGF(DEBUG, "Initializing from manifest: {}", manifest_file);
   if (!manifest_->Initialize(manifest_file)) {
+    TS_LOGF(ERROR, "Could not initialize from manifest: {}", manifest_file);
     return false;
   }
 
   LoadHandler(model_dir);
 
   if (!handler_) {
+    TS_LOG(ERROR, "Could not load handler");
     return false;
   }
 

--- a/cpp/src/examples/CMakeLists.txt
+++ b/cpp/src/examples/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../../test/resources/ DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/../../test/resources/)
+
 add_subdirectory("../../../examples/cpp/babyllama/" "${CMAKE_CURRENT_BINARY_DIR}/../../test/resources/examples/babyllama/babyllama_handler/")
 
 add_subdirectory("../../../examples/cpp/llamacpp/" "${CMAKE_CURRENT_BINARY_DIR}/../../test/resources/examples/llamacpp/llamacpp_handler/")
@@ -10,6 +12,6 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   add_subdirectory("../../../examples/cpp/aot_inductor/llama2/" "${CMAKE_CURRENT_BINARY_DIR}/../../test/resources/examples/aot_inductor/llama_handler/")
 
   add_subdirectory("../../../examples/cpp/aot_inductor/bert" "${CMAKE_CURRENT_BINARY_DIR}/../../test/resources/examples/aot_inductor/bert_handler/")
-  
+
   add_subdirectory("../../../examples/cpp/aot_inductor/resnet" "${CMAKE_CURRENT_BINARY_DIR}/../../test/resources/examples/aot_inductor/resnet_handler/")
 endif()

--- a/examples/cpp/aot_inductor/bert/CMakeLists.txt
+++ b/examples/cpp/aot_inductor/bert/CMakeLists.txt
@@ -1,5 +1,13 @@
+
+add_custom_command(
+    OUTPUT bert-seq.so
+    COMMAND TOKENIZERS_PARALLELISM=false python ${CMAKE_CURRENT_SOURCE_DIR}/aot_compile_export.py
+    COMMAND cp ${CMAKE_CURRENT_BINARY_DIR}/Transformer_model/tokenizer.json ${CMAKE_CURRENT_BINARY_DIR}/
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/aot_compile_export.py
+)
+
 set(TOKENZIER_CPP_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../../cpp/third-party/tokenizers-cpp)
 add_subdirectory(${TOKENZIER_CPP_PATH} tokenizers EXCLUDE_FROM_ALL)
-add_library(bert_handler SHARED src/bert_handler.cc)
+add_library(bert_handler SHARED src/bert_handler.cc bert-seq.so)
 target_include_directories(bert_handler PRIVATE ${TOKENZIER_CPP_PATH}/include)
 target_link_libraries(bert_handler PRIVATE ts_backends_core ts_utils ${TORCH_LIBRARIES} tokenizers_cpp)

--- a/examples/cpp/aot_inductor/llama2/CMakeLists.txt
+++ b/examples/cpp/aot_inductor/llama2/CMakeLists.txt
@@ -1,5 +1,23 @@
+
+FetchContent_Declare(
+  stories15M_pt
+  URL      https://huggingface.co/karpathy/tinyllamas/resolve/main/stories15M.pt?download=true
+  DOWNLOAD_NO_EXTRACT TRUE
+  DOWNLOAD_DIR ${CMAKE_CURRENT_BINARY_DIR}/
+)
+
+FetchContent_MakeAvailable(stories15M_pt)
+
+
+add_custom_command(
+    OUTPUT stories15M.so
+    COMMAND PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/../../../../cpp/third-party/llama2.so/ python ${CMAKE_CURRENT_SOURCE_DIR}/compile.py --checkpoint ${CMAKE_CURRENT_BINARY_DIR}/\'stories15M.pt?download=true\' ${CMAKE_CURRENT_BINARY_DIR}/stories15M.so
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/compile.py
+)
+
+
 add_library(llama2_so STATIC ../../../../cpp/third-party/llama2.so/run.cpp)
 target_compile_options(llama2_so PRIVATE -Wall -Wextra -Ofast -fpermissive)
 
-add_library(llama_so_handler SHARED src/llama_handler.cc)
+add_library(llama_so_handler SHARED src/llama_handler.cc stories15M.so)
 target_link_libraries(llama_so_handler PRIVATE llama2_so ts_backends_core ts_utils ${TORCH_LIBRARIES})

--- a/examples/cpp/aot_inductor/resnet/CMakeLists.txt
+++ b/examples/cpp/aot_inductor/resnet/CMakeLists.txt
@@ -1,2 +1,9 @@
-add_library(resnet_handler SHARED src/resnet_handler.cc)
+
+add_custom_command(
+    OUTPUT resnet50_pt2.so
+    COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/resnet50_torch_export.py
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/resnet50_torch_export.py
+)
+
+add_library(resnet_handler SHARED src/resnet_handler.cc resnet50_pt2.so)
 target_link_libraries(resnet_handler PRIVATE ts_backends_core ts_utils ${TORCH_LIBRARIES})

--- a/examples/cpp/babyllama/CMakeLists.txt
+++ b/examples/cpp/babyllama/CMakeLists.txt
@@ -1,3 +1,20 @@
+include(FetchContent)
+
+FetchContent_Declare(
+    stories15M_bin
+  URL      https://huggingface.co/karpathy/tinyllamas/resolve/main/stories15M.bin
+  DOWNLOAD_NO_EXTRACT TRUE
+  DOWNLOAD_DIR ${CMAKE_CURRENT_BINARY_DIR}/
+)
+
+FetchContent_Declare(
+  tokenizer_bin
+  URL      https://github.com/karpathy/llama2.c/raw/master/tokenizer.bin
+  DOWNLOAD_NO_EXTRACT TRUE
+  DOWNLOAD_DIR ${CMAKE_CURRENT_BINARY_DIR}/
+)
+
+FetchContent_MakeAvailable(tokenizer_bin stories15M_bin)
 
 add_library(llama2_c STATIC ../../../cpp/third-party/llama2.c/run.c)
 target_compile_options(llama2_c PRIVATE -Wall -Wextra -Ofast -fPIC)


### PR DESCRIPTION
## Description

This PR moves file preparation for cpp backend into cmake which will enable removal of build.sh.


## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [X] cd cpp && rm -rf _build && ./build.sh
Logs for Test A
```torchserve_cpp build is complete. To run unit test:   ./_build/test/torchserve_cpp_test
Running main() from /home/ubuntu/serve/cpp/_build/_deps/googletest-src/googletest/src/gtest_main.cc
[==========] Running 49 tests from 12 test suites.
[----------] Global test environment set-up.
[----------] 1 test from BackendIntegTest
[ RUN      ] BackendIntegTest.TestOTFProtocolAndHandler
[       OK ] BackendIntegTest.TestOTFProtocolAndHandler (117 ms)
[----------] 1 test from BackendIntegTest (117 ms total)

[----------] 8 tests from OTFMessageTest
[ RUN      ] OTFMessageTest.TestRetieveCmd
[       OK ] OTFMessageTest.TestRetieveCmd (0 ms)
[ RUN      ] OTFMessageTest.TestEncodeLoadModelResponse
[       OK ] OTFMessageTest.TestEncodeLoadModelResponse (0 ms)
[ RUN      ] OTFMessageTest.TestUTF8EncodeLoadModelResponse
[       OK ] OTFMessageTest.TestUTF8EncodeLoadModelResponse (0 ms)
[ RUN      ] OTFMessageTest.TestRetrieveMsgLoadGpu
[       OK ] OTFMessageTest.TestRetrieveMsgLoadGpu (0 ms)
[ RUN      ] OTFMessageTest.TestRetrieveMsgLoadNoGpu
[       OK ] OTFMessageTest.TestRetrieveMsgLoadNoGpu (0 ms)
[ RUN      ] OTFMessageTest.TestEncodeSuccessInferenceResponse
[       OK ] OTFMessageTest.TestEncodeSuccessInferenceResponse (0 ms)
[ RUN      ] OTFMessageTest.TestEncodeFailureInferenceResponse
[       OK ] OTFMessageTest.TestEncodeFailureInferenceResponse (0 ms)
[ RUN      ] OTFMessageTest.TestRetrieveInferenceMsg
[       OK ] OTFMessageTest.TestRetrieveInferenceMsg (0 ms)
[----------] 8 tests from OTFMessageTest (0 ms total)

[----------] 11 tests from ModelPredictTest
[ RUN      ] ModelPredictTest.TestLoadPredictBabyLlamaHandler
[----------] 11 tests from ModelPredictTest                                                                                                                                                                                                                                          [76/71365]
[ RUN      ] ModelPredictTest.TestLoadPredictBabyLlamaHandler
Total number of tokens generated: 332
Achieved tok per sec: 249.812
Generated String:  Hello my name is
The little girl, who was three years old, was playing in the garden. She saw a big, red tomato and wanted to pick it. She reached out her hand and grabbed it.
Suddenly, a voice said, "Hey! That's my tomato!"
The little girl looked up and saw a big, angry bird. She was scared and started to cry.
The bird said, "That tomato is mine! I'm going to eat it!"
The little girl was very scared and ran away. She was so sad that she didn't get to eat the tomato.
The bird flew away and the little girl was left alone in the garden. She was very sad and cried all the way home.
<s>

Generated String:  Hello my name is
The little girl, who was three years old, was playing in the garden. She saw a big, red tomato and wanted to pick it. She reached out her hand and grabbed it.
Suddenly, a voice said, "Hey! That's my tomato!"
The little girl looked up and saw a big, angry bird. She was scared and started to cry.
The bird said, "That tomato is mine! I'm going to eat it!"
The little girl was very scared and ran away. She was so sad that she didn't get to eat the tomato.
The bird flew away and the little girl was left alone in the garden. She was very sad and cried all the way home.
<s>

[       OK ] ModelPredictTest.TestLoadPredictBabyLlamaHandler (1349 ms)
[ RUN      ] ModelPredictTest.TestLoadPredictAotInductorLlamaHandler
[       OK ] ModelPredictTest.TestLoadPredictAotInductorLlamaHandler (2653 ms)
[ RUN      ] ModelPredictTest.TestLoadPredictLlamaCppHandler
/home/ubuntu/serve/cpp/test/examples/examples_test.cc:53: Skipped
Skipping TestLoadPredictLlamaCppHandler because of missing file: _build/test/resources/examples/llamacpp/llamacpp_handler/llama-2-7b-chat.Q5_0.gguf
[  SKIPPED ] ModelPredictTest.TestLoadPredictLlamaCppHandler (0 ms)
[ RUN      ] ModelPredictTest.TestLoadPredictAotInductorBertHandler
[       OK ] ModelPredictTest.TestLoadPredictAotInductorBertHandler (268 ms)
[ RUN      ] ModelPredictTest.TestLoadPredictAotInductorResnetHandler
[       OK ] ModelPredictTest.TestLoadPredictAotInductorResnetHandler (60 ms)
[ RUN      ] ModelPredictTest.TestLoadPredictBaseHandler
[       OK ] ModelPredictTest.TestLoadPredictBaseHandler (13 ms)
[ RUN      ] ModelPredictTest.TestLoadPredictMnistHandler
[       OK ] ModelPredictTest.TestLoadPredictMnistHandler (13 ms)
[ RUN      ] ModelPredictTest.TestBackendInitWrongModelDir
[       OK ] ModelPredictTest.TestBackendInitWrongModelDir (0 ms)
[ RUN      ] ModelPredictTest.TestBackendInitWrongHandler
[       OK ] ModelPredictTest.TestBackendInitWrongHandler (0 ms)
[ RUN      ] ModelPredictTest.TestLoadModelFailure
[       OK ] ModelPredictTest.TestLoadModelFailure (3 ms)
[ RUN      ] ModelPredictTest.TestLoadPredictMnistHandlerFailure
[       OK ] ModelPredictTest.TestLoadPredictMnistHandlerFailure (14 ms)
[----------] 11 tests from ModelPredictTest (4379 ms total)

[----------] 1 test from DLLoaderTest
[ RUN      ] DLLoaderTest.TestGetInstance
[       OK ] DLLoaderTest.TestGetInstance (0 ms)
[----------] 1 test from DLLoaderTest (0 ms total)

[----------] 1 test from JsonTest
[ RUN      ] JsonTest.TestParsingAndGetValue
[       OK ] JsonTest.TestParsingAndGetValue (0 ms)
[----------] 1 test from JsonTest (0 ms total)

[----------] 2 tests from LoggingTest
[ RUN      ] LoggingTest.TestIncorrectLogInitialization
[       OK ] LoggingTest.TestIncorrectLogInitialization (0 ms)
[ RUN      ] LoggingTest.TestFileLogInitialization
[info] 0312 01:23:28.650 /home/ubuntu/serve/cpp/test/utils/logging_test.cc:38] TestBody Test
[       OK ] LoggingTest.TestFileLogInitialization (0 ms)
[----------] 2 tests from LoggingTest (0 ms total)

[----------] 6 tests from TSLogMetricTest
[ RUN      ] TSLogMetricTest.TestCounterMetric
[info] 0312 01:23:28.651 /home/ubuntu/serve/cpp/src/utils/metrics/log_metric.cc:89] Emit [METRICS]test_metric.Milliseconds:1|#level:model,model_name:test_model|#hostname:ip-172-31-55-226,1710206608
[info] 0312 01:23:28.651 /home/ubuntu/serve/cpp/src/utils/metrics/log_metric.cc:92] Emit [METRICS]test_metric.Milliseconds:3.5|#level:model,model_name:test_model|#hostname:ip-172-31-55-226,1710206608,test_request_id
[       OK ] TSLogMetricTest.TestCounterMetric (0 ms)
[ RUN      ] TSLogMetricTest.TestGaugeMetric
[info] 0312 01:23:28.651 /home/ubuntu/serve/cpp/src/utils/metrics/log_metric.cc:89] Emit [METRICS]test_metric.Count:1|#level:model,model_name:test_model|#hostname:ip-172-31-55-226,1710206608
[info] 0312 01:23:28.651 /home/ubuntu/serve/cpp/src/utils/metrics/log_metric.cc:89] Emit [METRICS]test_metric.Count:-2|#level:model,model_name:test_model|#hostname:ip-172-31-55-226,1710206608
[info] 0312 01:23:28.651 /home/ubuntu/serve/cpp/src/utils/metrics/log_metric.cc:92] Emit [METRICS]test_metric.Count:3.5|#level:model,model_name:test_model|#hostname:ip-172-31-55-226,1710206608,test_request_id
[info] 0312 01:23:28.651 /home/ubuntu/serve/cpp/src/utils/metrics/log_metric.cc:92] Emit [METRICS]test_metric.Count:-4|#level:model,model_name:test_model|#hostname:ip-172-31-55-226,1710206608,test_request_id
[       OK ] TSLogMetricTest.TestGaugeMetric (0 ms)
[ RUN      ] TSLogMetricTest.TestHistogramMetric
[info] 0312 01:23:28.652 /home/ubuntu/serve/cpp/src/utils/metrics/log_metric.cc:89] Emit [METRICS]test_metric.Count:1|#level:model,model_name:test_model|#hostname:ip-172-31-55-226,1710206608
[info] 0312 01:23:28.652 /home/ubuntu/serve/cpp/src/utils/metrics/log_metric.cc:89] Emit [METRICS]test_metric.Count:-2|#level:model,model_name:test_model|#hostname:ip-172-31-55-226,1710206608
[info] 0312 01:23:28.652 /home/ubuntu/serve/cpp/src/utils/metrics/log_metric.cc:92] Emit [METRICS]test_metric.Count:3.5|#level:model,model_name:test_model|#hostname:ip-172-31-55-226,1710206608,test_request_id
[info] 0312 01:23:28.652 /home/ubuntu/serve/cpp/src/utils/metrics/log_metric.cc:92] Emit [METRICS]test_metric.Count:-4|#level:model,model_name:test_model|#hostname:ip-172-31-55-226,1710206608,test_request_id
[       OK ] TSLogMetricTest.TestHistogramMetric (0 ms)
[ RUN      ] TSLogMetricTest.TestTSLogMetricEmitWithRequestId
[info] 0312 01:23:28.652 /home/ubuntu/serve/cpp/src/utils/metrics/log_metric.cc:92] Emit [METRICS]test_metric.Milliseconds:1.5|#level:model,model_name:test_model|#hostname:ip-172-31-55-226,1710206608,test_request_id
[       OK ] TSLogMetricTest.TestTSLogMetricEmitWithRequestId (0 ms)
[ RUN      ] TSLogMetricTest.TestTSLogMetricEmitWithoutRequestId
[info] 0312 01:23:28.653 /home/ubuntu/serve/cpp/src/utils/metrics/log_metric.cc:89] Emit [METRICS]test_metric.Milliseconds:1.5|#level:model,model_name:test_model|#hostname:ip-172-31-55-226,1710206608
[       OK ] TSLogMetricTest.TestTSLogMetricEmitWithoutRequestId (0 ms)
[ RUN      ] TSLogMetricTest.TestTSLogMetricEmitWithIncorrectDimensionData
[       OK ] TSLogMetricTest.TestTSLogMetricEmitWithIncorrectDimensionData (0 ms)
[----------] 6 tests from TSLogMetricTest (2 ms total)

[----------] 2 tests from TSLogMetricsCacheTest
[ RUN      ] TSLogMetricsCacheTest.TestInitialize
[       OK ] TSLogMetricsCacheTest.TestInitialize (0 ms)
[ RUN      ] TSLogMetricsCacheTest.TestGetMetric
[info] 0312 01:23:28.654 /home/ubuntu/serve/cpp/src/utils/metrics/log_metric.cc:89] Emit [METRICS]GaugeTsMetricExample.Count:1.5|#model_name:model_name,host_name:host_name|#hostname:ip-172-31-55-226,1710206608
[       OK ] TSLogMetricsCacheTest.TestGetMetric (0 ms)
[----------] 2 tests from TSLogMetricsCacheTest (0 ms total)

[----------] 3 tests from RegistryTest
[ RUN      ] RegistryTest.TestValidConfigFile
[       OK ] RegistryTest.TestValidConfigFile (0 ms)
[ RUN      ] RegistryTest.TestInvalidConfigFile
[       OK ] RegistryTest.TestInvalidConfigFile (0 ms)
[ RUN      ] RegistryTest.TestReInitialize
[       OK ] RegistryTest.TestReInitialize (0 ms)
[----------] 3 tests from RegistryTest (0 ms total)

[----------] 3 tests from UnitsTest
[ RUN      ] UnitsTest.TestGetExistingUnitMapping
[       OK ] UnitsTest.TestGetExistingUnitMapping (0 ms)
[ RUN      ] UnitsTest.TestGetNonExistentUnitMapping
[       OK ] UnitsTest.TestGetNonExistentUnitMapping (0 ms)
[ RUN      ] UnitsTest.TestGetEmptyUnitMapping
[       OK ] UnitsTest.TestGetEmptyUnitMapping (0 ms)
[----------] 3 tests from UnitsTest (0 ms total)

[----------] 10 tests from YAMLConfigTest
[ RUN      ] YAMLConfigTest.TestLoadValidConfigFrontendContext
[       OK ] YAMLConfigTest.TestLoadValidConfigFrontendContext (0 ms)
[ RUN      ] YAMLConfigTest.TestLoadValidConfigBackendContext
[       OK ] YAMLConfigTest.TestLoadValidConfigBackendContext (0 ms)
[ RUN      ] YAMLConfigTest.TestLoadMinimalValidConfig
[       OK ] YAMLConfigTest.TestLoadMinimalValidConfig (0 ms)
[ RUN      ] YAMLConfigTest.TestLoadInvalidConfigWithDuplicateDimension
[       OK ] YAMLConfigTest.TestLoadInvalidConfigWithDuplicateDimension (0 ms)
[ RUN      ] YAMLConfigTest.TestLoadInvalidConfigWithEmptyDimension
[       OK ] YAMLConfigTest.TestLoadInvalidConfigWithEmptyDimension (0 ms)
[ RUN      ] YAMLConfigTest.TestLoadInvalidConfigWithUndefinedDimension
[       OK ] YAMLConfigTest.TestLoadInvalidConfigWithUndefinedDimension (0 ms)
[ RUN      ] YAMLConfigTest.TestLoadInvalidConfigWithDuplicateMetricDimension
[       OK ] YAMLConfigTest.TestLoadInvalidConfigWithDuplicateMetricDimension (0 ms)
[ RUN      ] YAMLConfigTest.TestLoadInvalidConfigWithMissingMetricName
[error] 0312 01:23:28.655 /home/ubuntu/serve/cpp/src/utils/metrics/yaml_config.cc:203] decode Configuration for a metric must consist of "name", "unit" and "dimensions"
[       OK ] YAMLConfigTest.TestLoadInvalidConfigWithMissingMetricName (0 ms)
[ RUN      ] YAMLConfigTest.TestLoadInvalidConfigWithEmptyMetricName
[error] 0312 01:23:28.655 /home/ubuntu/serve/cpp/src/utils/metrics/yaml_config.cc:215] decode Configuration for a metric must consist of a non-empty "name"
[       OK ] YAMLConfigTest.TestLoadInvalidConfigWithEmptyMetricName (0 ms)
[ RUN      ] YAMLConfigTest.TestLoadInvalidConfigWithDuplicateMetricName
[       OK ] YAMLConfigTest.TestLoadInvalidConfigWithDuplicateMetricName (0 ms)
[----------] 10 tests from YAMLConfigTest (0 ms total)

[----------] 1 test from ManifestTest
[ RUN      ] ManifestTest.TestInitialize
[       OK ] ManifestTest.TestInitialize (0 ms)
[----------] 1 test from ManifestTest (0 ms total)

[----------] Global test environment tear-down
[==========] 49 tests from 12 test suites ran. (4503 ms total)
[  PASSED  ] 48 tests.
[  SKIPPED ] 1 test, listed below:
[  SKIPPED ] ModelPredictTest.TestLoadPredictLlamaCppHandler
```

- [X] pytest test/pytest/test_cpp_backend.py
Logs for Test B
```
===================================================================================================================================== test session starts =====================================================================================================================================
platform linux -- Python 3.11.5, pytest-7.3.1, pluggy-1.0.0
rootdir: /home/ubuntu/serve
plugins: mock-3.12.0, cov-4.1.0
collected 1 item

test/pytest/test_cpp_backend.py .                                                                                                                                                                                                                                                       [100%]

====================================================================================================================================== 1 passed in 6.56s ======================================================================================================================================
```

## Checklist:

- [X] Did you have fun?
- [X] Have you added tests that prove your fix is effective or that this feature works?
- [X] Has code been commented, particularly in hard-to-understand areas?
- [X] Have you made corresponding changes to the documentation?