### PR TITLE
Install from source for a specific branch with docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,6 +31,8 @@ FROM ${BASE_IMAGE} AS compile-image
 ARG BASE_IMAGE=ubuntu:rolling
 ARG PYTHON_VERSION
 ARG BUILD_NIGHTLY
+ARG BUILD_FROM_SRC
+ARG LOCAL_CHANGES
 ARG BRANCH_NAME
 ENV PYTHONUNBUFFERED TRUE
 
@@ -65,7 +67,14 @@ RUN export USE_CUDA=1
 
 ARG USE_CUDA_VERSION=""
 
-RUN git clone --recursive https://github.com/pytorch/serve.git -b $BRANCH_NAME
+COPY ./ serve
+
+RUN \
+    if echo "$LOCAL_CHANGES" | grep -q "false"; then \
+        rm -rf serve;\
+        git clone --recursive https://github.com/pytorch/serve.git -b $BRANCH_NAME; \
+    fi
+
 
 WORKDIR "serve"
 
@@ -73,10 +82,10 @@ RUN \
     if echo "$BASE_IMAGE" | grep -q "cuda:"; then \
         # Install CUDA version specific binary when CUDA version is specified as a build arg
         if [ "$USE_CUDA_VERSION" ]; then \
-            python ./ts_scripts/install_dependencies.py --cuda $USE_CUDA_VERSION; \
+            python ./ts_scripts/install_dependencies.py --cuda $USE_CUDA_VERSION;\
         # Install the binary with the latest CPU image on a CUDA base image
         else \
-            python ./ts_scripts/install_dependencies.py; \
+            python ./ts_scripts/install_dependencies.py;\
         fi; \
     # Install the CPU binary
     else \
@@ -85,7 +94,7 @@ RUN \
 
 # Make sure latest version of torchserve is uploaded before running this
 RUN \
-    if [ "$BRANCH_NAME" != "master" ]; then \
+    if echo "$BUILD_FROM_SRC" | grep -q "true"; then \
         python -m pip install -r requirements/developer.txt;\
         python ts_scripts/install_from_src.py;\
     elif echo "$BUILD_NIGHTLY" | grep -q "false"; then \
@@ -125,12 +134,12 @@ COPY --chown=model-server --from=compile-image /home/venv /home/venv
 
 ENV PATH="/home/venv/bin:$PATH"
 
-COPY dockerd-entrypoint.sh /usr/local/bin/dockerd-entrypoint.sh
+COPY docker/dockerd-entrypoint.sh /usr/local/bin/dockerd-entrypoint.sh
 
 RUN chmod +x /usr/local/bin/dockerd-entrypoint.sh \
     && chown -R model-server /home/model-server
 
-COPY config.properties /home/model-server/config.properties
+COPY docker/config.properties /home/model-server/config.properties
 RUN mkdir /home/model-server/model-store && chown -R model-server /home/model-server/model-store
 
 EXPOSE 8080 8081 8082 7070 7071
@@ -191,6 +200,8 @@ FROM ${BASE_IMAGE} as dev-image
 # Re-state ARG PYTHON_VERSION to make it active in this build-stage (uses default define at the top)
 ARG PYTHON_VERSION
 ARG BRANCH_NAME
+ARG BUILD_FROM_SRC
+ARG LOCAL_CHANGES
 ARG BUILD_WITH_IPEX
 ARG IPEX_VERSION=1.11.0
 ARG IPEX_URL=https://software.intel.com/ipex-whl-stable
@@ -220,9 +231,15 @@ RUN --mount=type=cache,target=/var/cache/apt \
     numactl \
     && if [ "$BUILD_WITH_IPEX" = "true" ]; then apt-get update && apt-get install -y libjemalloc-dev libgoogle-perftools-dev libomp-dev && ln -s /usr/lib/x86_64-linux-gnu/libjemalloc.so /usr/lib/libjemalloc.so && ln -s /usr/lib/x86_64-linux-gnu/libtcmalloc.so /usr/lib/libtcmalloc.so && ln -s /usr/lib/x86_64-linux-gnu/libiomp5.so /usr/lib/libiomp5.so; fi \
     && rm -rf /var/lib/apt/lists/*
-RUN git clone --recursive https://github.com/pytorch/serve.git \
-    && cd serve \
-    && git checkout ${BRANCH_NAME}
+
+COPY ./ serve
+
+RUN \
+    if echo "$LOCAL_CHANGES" | grep -q "false"; then \
+        rm -rf serve;\
+        git clone --recursive https://github.com/pytorch/serve.git -b $BRANCH_NAME; \
+    fi
+
 COPY --from=compile-image /home/venv /home/venv
 ENV PATH="/home/venv/bin:$PATH"
 WORKDIR "serve"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,6 +31,7 @@ FROM ${BASE_IMAGE} AS compile-image
 ARG BASE_IMAGE=ubuntu:rolling
 ARG PYTHON_VERSION
 ARG BUILD_NIGHTLY
+ARG BRANCH_NAME
 ENV PYTHONUNBUFFERED TRUE
 
 RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt \
@@ -64,7 +65,7 @@ RUN export USE_CUDA=1
 
 ARG USE_CUDA_VERSION=""
 
-RUN git clone --depth 1 --recursive https://github.com/pytorch/serve.git
+RUN git clone --recursive https://github.com/pytorch/serve.git -b $BRANCH_NAME
 
 WORKDIR "serve"
 
@@ -84,7 +85,10 @@ RUN \
 
 # Make sure latest version of torchserve is uploaded before running this
 RUN \
-    if echo "$BUILD_NIGHTLY" | grep -q "false"; then \
+    if [ "$BRANCH_NAME" != "master" ]; then \
+        python -m pip install -r requirements/developer.txt;\
+        python ts_scripts/install_from_src.py;\
+    elif echo "$BUILD_NIGHTLY" | grep -q "false"; then \
         python -m pip install --no-cache-dir torchserve torch-model-archiver torch-workflow-archiver;\
     else \
         python -m pip install --no-cache-dir torchserve-nightly torch-model-archiver-nightly torch-workflow-archiver-nightly;\

--- a/docker/README.md
+++ b/docker/README.md
@@ -44,7 +44,7 @@ Use `build_image.sh` script to build the docker images. The script builds the `p
 |-cpp, --build-cpp specify to build TorchServe CPP|
 |-n, --nightly| Specify to build with TorchServe nightly.|
 |-s, --source| Specify to build with TorchServe from source|
-|-l, --local| Specify to use local changes|
+|-r, --remote| Specify to use github remote repo|
 |-py, --pythonversion| Specify the python version to use. Supported values `3.8`, `3.9`, `3.10`, `3.11`. Default `3.9`|
 
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -43,6 +43,8 @@ Use `build_image.sh` script to build the docker images. The script builds the `p
 |-ipex, --build-with-ipex| Specify to build with intel_extension_for_pytorch. If not specified, script builds without intel_extension_for_pytorch.|
 |-cpp, --build-cpp specify to build TorchServe CPP|
 |-n, --nightly| Specify to build with TorchServe nightly.|
+|-s, --source| Specify to build with TorchServe from source|
+|-l, --local| Specify to use local changes|
 |-py, --pythonversion| Specify the python version to use. Supported values `3.8`, `3.9`, `3.10`, `3.11`. Default `3.9`|
 
 

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -15,7 +15,7 @@ BUILD_WITH_IPEX=false
 BUILD_CPP=false
 BUILD_NIGHTLY=false
 BUILD_FROM_SRC=false
-LOCAL_CHANGES=false
+LOCAL_CHANGES=true
 PYTHON_VERSION=3.9
 
 for arg in "$@"
@@ -105,8 +105,8 @@ do
           BUILD_FROM_SRC=true
           shift
           ;;
-        -l|--local)
-          LOCAL_CHANGES=true
+        -r|--remote)
+          LOCAL_CHANGES=false
           shift
           ;;
         # With default ubuntu version 20.04

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -189,7 +189,7 @@ fi
 
 if [ "${BUILD_TYPE}" == "production" ]
 then
-  DOCKER_BUILDKIT=1 docker build --file Dockerfile --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg USE_CUDA_VERSION="${CUDA_VERSION}"  --build-arg PYTHON_VERSION="${PYTHON_VERSION}" --build-arg BUILD_NIGHTLY="${BUILD_NIGHTLY}" -t "${DOCKER_TAG}" --target production-image  .
+  DOCKER_BUILDKIT=1 docker build --file Dockerfile --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg USE_CUDA_VERSION="${CUDA_VERSION}"  --build-arg PYTHON_VERSION="${PYTHON_VERSION}" --build-arg BUILD_NIGHTLY="${BUILD_NIGHTLY}" --build-arg BRANCH_NAME="${BRANCH_NAME}" -t "${DOCKER_TAG}" --target production-image  .
 elif [ "${BUILD_TYPE}" == "ci" ]
 then
   DOCKER_BUILDKIT=1 docker build --file Dockerfile --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg USE_CUDA_VERSION="${CUDA_VERSION}"  --build-arg PYTHON_VERSION="${PYTHON_VERSION}" --build-arg BUILD_NIGHTLY="${BUILD_NIGHTLY}" --build-arg BRANCH_NAME="${BRANCH_NAME}"  -t "${DOCKER_TAG}" --target ci-image  .

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -14,6 +14,8 @@ USE_LOCAL_SERVE_FOLDER=false
 BUILD_WITH_IPEX=false
 BUILD_CPP=false
 BUILD_NIGHTLY=false
+BUILD_FROM_SRC=false
+LOCAL_CHANGES=false
 PYTHON_VERSION=3.9
 
 for arg in "$@"
@@ -33,6 +35,8 @@ do
           echo "-cpp, --build-cpp specify to build TorchServe CPP"
           echo "-py, --pythonversion specify to python version to use: Possible values: 3.8 3.9 3.10"
           echo "-n, --nightly specify to build with TorchServe nightly"
+          echo "-s, --source specify to build with TorchServe from source"
+          echo "-l, --local specify to use local TorchServe"
           exit 0
           ;;
         -b|--branch_name)
@@ -95,6 +99,14 @@ do
             exit 1
           fi
           shift
+          shift
+          ;;
+        -s|--source)
+          BUILD_FROM_SRC=true
+          shift
+          ;;
+        -l|--local)
+          LOCAL_CHANGES=true
           shift
           ;;
         # With default ubuntu version 20.04
@@ -189,15 +201,15 @@ fi
 
 if [ "${BUILD_TYPE}" == "production" ]
 then
-  DOCKER_BUILDKIT=1 docker build --file Dockerfile --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg USE_CUDA_VERSION="${CUDA_VERSION}"  --build-arg PYTHON_VERSION="${PYTHON_VERSION}" --build-arg BUILD_NIGHTLY="${BUILD_NIGHTLY}" --build-arg BRANCH_NAME="${BRANCH_NAME}" -t "${DOCKER_TAG}" --target production-image  .
+  DOCKER_BUILDKIT=1 docker build --file Dockerfile --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg USE_CUDA_VERSION="${CUDA_VERSION}"  --build-arg PYTHON_VERSION="${PYTHON_VERSION}" --build-arg BUILD_NIGHTLY="${BUILD_NIGHTLY}" --build-arg BRANCH_NAME="${BRANCH_NAME}" --build-arg BUILD_FROM_SRC="${BUILD_FROM_SRC}" --build-arg LOCAL_CHANGES="${LOCAL_CHANGES}" -t "${DOCKER_TAG}" --target production-image  ../
 elif [ "${BUILD_TYPE}" == "ci" ]
 then
-  DOCKER_BUILDKIT=1 docker build --file Dockerfile --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg USE_CUDA_VERSION="${CUDA_VERSION}"  --build-arg PYTHON_VERSION="${PYTHON_VERSION}" --build-arg BUILD_NIGHTLY="${BUILD_NIGHTLY}" --build-arg BRANCH_NAME="${BRANCH_NAME}"  -t "${DOCKER_TAG}" --target ci-image  .
+  DOCKER_BUILDKIT=1 docker build --file Dockerfile --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg USE_CUDA_VERSION="${CUDA_VERSION}"  --build-arg PYTHON_VERSION="${PYTHON_VERSION}" --build-arg BUILD_NIGHTLY="${BUILD_NIGHTLY}" --build-arg BRANCH_NAME="${BRANCH_NAME}" --build-arg BUILD_FROM_SRC="${BUILD_FROM_SRC}" --build-arg LOCAL_CHANGES="${LOCAL_CHANGES}" -t "${DOCKER_TAG}" --target ci-image  ../
 else
   if [ "${BUILD_CPP}" == "true" ]
   then
     DOCKER_BUILDKIT=1 docker build --file Dockerfile.cpp --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg USE_CUDA_VERSION="${CUDA_VERSION}" --build-arg PYTHON_VERSION="${PYTHON_VERSION}" --build-arg BRANCH_NAME="${BRANCH_NAME}" -t "${DOCKER_TAG}" --target cpp-dev-image .
   else
-    DOCKER_BUILDKIT=1 docker build --file Dockerfile --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg USE_CUDA_VERSION="${CUDA_VERSION}"  --build-arg PYTHON_VERSION="${PYTHON_VERSION}" --build-arg BUILD_NIGHTLY="${BUILD_NIGHTLY}" --build-arg BRANCH_NAME="${BRANCH_NAME}" --build-arg BUILD_WITH_IPEX="${BUILD_WITH_IPEX}"  -t "${DOCKER_TAG}" --target dev-image  .
+    DOCKER_BUILDKIT=1 docker build --file Dockerfile --build-arg BASE_IMAGE="${BASE_IMAGE}" --build-arg USE_CUDA_VERSION="${CUDA_VERSION}"  --build-arg PYTHON_VERSION="${PYTHON_VERSION}" --build-arg BUILD_NIGHTLY="${BUILD_NIGHTLY}" --build-arg BRANCH_NAME="${BRANCH_NAME}" --build-arg BUILD_FROM_SRC="${BUILD_FROM_SRC}" --build-arg LOCAL_CHANGES="${LOCAL_CHANGES}" --build-arg BUILD_WITH_IPEX="${BUILD_WITH_IPEX}"  -t "${DOCKER_TAG}" --target dev-image  ../
   fi
 fi


### PR DESCRIPTION
## Description

This PR allows the user to build TorchServe from source from 
- a specific branch and build TS from source
- Build TS from source with Local changes 

Fixes #([issue](https://github.com/pytorch/serve/issues/3054))

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

- [ ] Production image from source and local changes 
```
 ./build_image.sh -s -l -t pytorch/ts:latest
[+] Building 317.5s (28/28) FINISHED                                                                                                                                       docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                 0.0s
 => => transferring dockerfile: 9.62kB                                                                                                                                               0.0s
 => resolve image config for docker.io/docker/dockerfile:experimental                                                                                                                0.5s
 => [auth] docker/dockerfile:pull token for registry-1.docker.io                                                                                                                     0.0s
 => CACHED docker-image://docker.io/docker/dockerfile:experimental@sha256:600e5c62eedff338b3f7a0850beb7c05866e0ef27b2d2e8c02aa468e78496ff5                                           0.0s
 => [internal] load .dockerignore                                                                                                                                                    0.0s
 => => transferring context: 2B                                                                                                                                                      0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                 0.0s
 => [internal] load metadata for docker.io/library/ubuntu:20.04                                                                                                                      0.5s
 => [auth] library/ubuntu:pull token for registry-1.docker.io                                                                                                                        0.0s
 => [internal] load build context                                                                                                                                                   63.1s
 => => transferring context: 7.52GB                                                                                                                                                 62.9s
 => CACHED [production-image 1/9] FROM docker.io/library/ubuntu:20.04@sha256:80ef4a44043dec4490506e6cc4289eeda2d106a70148b74b5ae91ee670e9c35d                                        0.0s
 => [compile-image  2/10] RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt     apt-get update &&     apt-get upgrade -y &&     apt-get install software-properties-common   145.0s
 => [production-image 2/9] RUN --mount=type=cache,target=/var/cache/apt     apt-get update &&     apt-get upgrade -y &&     apt-get install software-properties-common -y &&       145.0s
 => [production-image 3/9] RUN useradd -m model-server     && mkdir -p /home/model-server/tmp                                                                                        0.4s
 => [compile-image  3/10] RUN python3.9 -m venv /home/venv                                                                                                                           2.9s
 => [compile-image  4/10] RUN python -m pip install -U pip setuptools                                                                                                                3.1s 
 => [compile-image  5/10] RUN export USE_CUDA=1                                                                                                                                      0.3s 
 => [compile-image  6/10] COPY ./ serve                                                                                                                                             31.0s 
 => [compile-image  7/10] RUN     if echo "true" | grep -q "false"; then         rm -rf serve;        git clone --recursive https://github.com/pytorch/serve.git -b master;     fi   0.3s 
 => [compile-image  8/10] WORKDIR serve                                                                                                                                              0.0s 
 => [compile-image  9/10] RUN     if echo "ubuntu:20.04" | grep -q "cuda:"; then         if [ "" ]; then             python ./ts_scripts/install_dependencies.py --cuda ;        e  40.2s 
 => [compile-image 10/10] RUN     if echo "true" | grep -q "true"; then         python -m pip install -r requirements/developer.txt;        python ts_scripts/install_from_src.py;  70.5s 
 => [production-image 4/9] COPY --chown=model-server --from=compile-image /home/venv /home/venv                                                                                      7.6s 
 => [production-image 5/9] COPY docker/dockerd-entrypoint.sh /usr/local/bin/dockerd-entrypoint.sh                                                                                    0.0s 
 => [production-image 6/9] RUN chmod +x /usr/local/bin/dockerd-entrypoint.sh     && chown -R model-server /home/model-server                                                         0.3s 
 => [production-image 7/9] COPY docker/config.properties /home/model-server/config.properties                                                                                        0.1s 
 => [production-image 8/9] RUN mkdir /home/model-server/model-store && chown -R model-server /home/model-server/model-store                                                          0.2s 
 => [production-image 9/9] WORKDIR /home/model-server                                                                                                                                0.1s 
 => exporting to image                                                                                                                                                              11.4s
 => => exporting layers                                                                                                                                                             11.4s
 => => writing image sha256:b6f4d83f7917ef2ddfae721fa4d690e2fdb2c7c82b2d91c27d54362aefc04f86                                                                                         0.0s
 => => naming to docker.io/pytorch/ts:latest                                                                                       
```

- [ ] Production Image default
```
./build_image.sh -t pytorch/ts:latest
[+] Building 284.9s (28/28) FINISHED                                                                                                                                       docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                 0.0s
 => => transferring dockerfile: 9.49kB                                                                                                                                               0.0s
 => resolve image config for docker.io/docker/dockerfile:experimental                                                                                                                0.5s
 => [auth] docker/dockerfile:pull token for registry-1.docker.io                                                                                                                     0.0s
 => CACHED docker-image://docker.io/docker/dockerfile:experimental@sha256:600e5c62eedff338b3f7a0850beb7c05866e0ef27b2d2e8c02aa468e78496ff5                                           0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                 0.0s
 => [internal] load .dockerignore                                                                                                                                                    0.0s
 => => transferring context: 2B                                                                                                                                                      0.0s
 => [internal] load metadata for docker.io/library/ubuntu:20.04                                                                                                                      0.5s
 => [auth] library/ubuntu:pull token for registry-1.docker.io                                                                                                                        0.0s
 => [internal] load build context                                                                                                                                                   23.2s
 => => transferring context: 7.52GB                                                                                                                                                 23.0s
 => CACHED [production-image 1/9] FROM docker.io/library/ubuntu:20.04@sha256:80ef4a44043dec4490506e6cc4289eeda2d106a70148b74b5ae91ee670e9c35d                                        0.0s
 => [compile-image  2/10] RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt     apt-get update &&     apt-get upgrade -y &&     apt-get install software-properties-common   113.2s
 => [compile-image  3/10] RUN python3.9 -m venv /home/venv                                                                                                                           2.8s 
 => [compile-image  4/10] RUN python -m pip install -U pip setuptools                                                                                                                3.2s 
 => [compile-image  5/10] RUN export USE_CUDA=1                                                                                                                                      0.3s 
 => [compile-image  6/10] COPY ./ serve                                                                                                                                             30.9s 
 => [compile-image  7/10] RUN     if echo "false" | grep -q "false"; then         rm -rf serve;        git clone --recursive https://github.com/pytorch/serve.git -b master;     f  79.3s 
 => [compile-image  8/10] WORKDIR serve                                                                                                                                              0.0s 
 => [compile-image  9/10] RUN     if echo "ubuntu:20.04" | grep -q "cuda:"; then         if [ "" ]; then             python ./ts_scripts/install_dependencies.py --cuda ;        e  41.2s 
 => [compile-image 10/10] RUN     if echo "false" | grep -q "true"; then         python -m pip install -r requirements/developer.txt;        python ts_scripts/install_from_src.py;  1.9s 
 => CACHED [production-image 2/9] RUN --mount=type=cache,target=/var/cache/apt     apt-get update &&     apt-get upgrade -y &&     apt-get install software-properties-common -y &&  0.0s 
 => CACHED [production-image 3/9] RUN useradd -m model-server     && mkdir -p /home/model-server/tmp                                                                                 0.0s 
 => [production-image 4/9] COPY --chown=model-server --from=compile-image /home/venv /home/venv                                                                                      5.5s 
 => [production-image 5/9] COPY docker/dockerd-entrypoint.sh /usr/local/bin/dockerd-entrypoint.sh                                                                                    0.0s 
 => [production-image 6/9] RUN chmod +x /usr/local/bin/dockerd-entrypoint.sh     && chown -R model-server /home/model-server                                                         0.2s 
 => [production-image 7/9] COPY docker/config.properties /home/model-server/config.properties                                                                                        0.1s 
 => [production-image 8/9] RUN mkdir /home/model-server/model-store && chown -R model-server /home/model-server/model-store                                                          0.2s
 => [production-image 9/9] WORKDIR /home/model-server                                                                                                                                0.1s
 => exporting to image                                                                                                                                                               3.2s
 => => exporting layers                                                                                                                                                              3.2s
 => => writing image sha256:84f4856f5cce4c996283432eabf9f661c9f789193b229e5590a700c3a69e9405                                                                                         0.0s
 => => naming to docker.io/pytorch/ts:latest                                                       
```
- [ ] Dev Image default
```
./build_image.sh -bt dev -t pytorch/ts:latest
[+] Building 398.1s (27/27) FINISHED                                                                                                                                       docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                 0.0s
 => => transferring dockerfile: 9.62kB                                                                                                                                               0.0s
 => resolve image config for docker.io/docker/dockerfile:experimental                                                                                                                0.5s
 => [auth] docker/dockerfile:pull token for registry-1.docker.io                                                                                                                     0.0s
 => CACHED docker-image://docker.io/docker/dockerfile:experimental@sha256:600e5c62eedff338b3f7a0850beb7c05866e0ef27b2d2e8c02aa468e78496ff5                                           0.0s
 => [internal] load .dockerignore                                                                                                                                                    0.0s
 => => transferring context: 2B                                                                                                                                                      0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                 0.0s
 => [internal] load metadata for docker.io/library/ubuntu:20.04                                                                                                                      0.5s
 => [auth] library/ubuntu:pull token for registry-1.docker.io                                                                                                                        0.0s
 => CACHED [compile-image  1/10] FROM docker.io/library/ubuntu:20.04@sha256:80ef4a44043dec4490506e6cc4289eeda2d106a70148b74b5ae91ee670e9c35d                                         0.0s
 => [internal] load build context                                                                                                                                                    0.7s
 => => transferring context: 2.38MB                                                                                                                                                  0.7s
 => [dev-image 2/8] RUN --mount=type=cache,target=/var/cache/apt     apt-get update &&     apt-get upgrade -y &&     apt-get install software-properties-common -y &&     add-apt  102.3s
 => CACHED [compile-image  2/10] RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt     apt-get update &&     apt-get upgrade -y &&     apt-get install software-properties-co  0.0s
 => CACHED [compile-image  3/10] RUN python3.9 -m venv /home/venv                                                                                                                    0.0s
 => CACHED [compile-image  4/10] RUN python -m pip install -U pip setuptools                                                                                                         0.0s
 => CACHED [compile-image  5/10] RUN export USE_CUDA=1                                                                                                                               0.0s
 => CACHED [compile-image  6/10] COPY ./ serve                                                                                                                                       0.0s
 => CACHED [compile-image  7/10] RUN     if echo "false" | grep -q "false"; then         rm -rf serve;        git clone --recursive https://github.com/pytorch/serve.git -b master;  0.0s
 => CACHED [compile-image  8/10] WORKDIR serve                                                                                                                                       0.0s
 => CACHED [compile-image  9/10] RUN     if echo "ubuntu:20.04" | grep -q "cuda:"; then         if [ "" ]; then             python ./ts_scripts/install_dependencies.py --cuda ;     0.0s
 => CACHED [compile-image 10/10] RUN     if echo "false" | grep -q "true"; then         python -m pip install -r requirements/developer.txt;        python ts_scripts/install_from_  0.0s
 => [dev-image 3/8] COPY ./ serve                                                                                                                                                   46.6s 
 => [dev-image 4/8] RUN     if echo "false" | grep -q "false"; then         rm -rf serve;        git clone --recursive https://github.com/pytorch/serve.git -b master;     fi       76.4s 
 => [dev-image 5/8] COPY --from=compile-image /home/venv /home/venv                                                                                                                  8.5s 
 => [dev-image 6/8] WORKDIR serve                                                                                                                                                    0.0s 
 => [dev-image 7/8] RUN python -m pip install -U pip setuptools     && python -m pip install --no-cache-dir -r requirements/developer.txt     && python ts_scripts/install_from_s  147.2s 
 => [dev-image 8/8] WORKDIR /home/model-server                                                                                                                                       0.1s 
 => exporting to image                                                                                                                                                              15.7s 
 => => exporting layers                                                                                                                                                             15.7s 
 => => writing image sha256:a3d095ad7e7c77b117b1e0d9c92ef768ce061ad227ad89c086cf7527d289d434                                                                                         0.0s 
 => => naming to docker.io/pytorch/ts:latest                                               
```
- [ ] Dev image from source
```
 ./build_image.sh -bt dev -l -s -t pytorch/ts:latest                                                                                        
[+] Building 404.0s (27/27) FINISHED                                                                                                                                       docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                 0.0s
 => => transferring dockerfile: 9.62kB                                                                                                                                               0.0s
 => resolve image config for docker.io/docker/dockerfile:experimental                                                                                                                0.5s
 => [auth] docker/dockerfile:pull token for registry-1.docker.io                                                                                                                     0.0s
 => CACHED docker-image://docker.io/docker/dockerfile:experimental@sha256:600e5c62eedff338b3f7a0850beb7c05866e0ef27b2d2e8c02aa468e78496ff5                                           0.0s
 => [internal] load .dockerignore                                                                                                                                                    0.0s
 => => transferring context: 2B                                                                                                                                                      0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                 0.0s
 => [internal] load metadata for docker.io/library/ubuntu:20.04                                                                                                                      0.5s
 => [auth] library/ubuntu:pull token for registry-1.docker.io                                                                                                                        0.0s
 => [internal] load build context                                                                                                                                                    0.7s
 => => transferring context: 2.38MB                                                                                                                                                  0.7s
 => CACHED [compile-image  1/10] FROM docker.io/library/ubuntu:20.04@sha256:80ef4a44043dec4490506e6cc4289eeda2d106a70148b74b5ae91ee670e9c35d                                         0.0s
 => [dev-image 2/8] RUN --mount=type=cache,target=/var/cache/apt     apt-get update &&     apt-get upgrade -y &&     apt-get install software-properties-common -y &&     add-apt  112.4s
 => CACHED [compile-image  2/10] RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt     apt-get update &&     apt-get upgrade -y &&     apt-get install software-properties-co  0.0s
 => CACHED [compile-image  3/10] RUN python3.9 -m venv /home/venv                                                                                                                    0.0s
 => CACHED [compile-image  4/10] RUN python -m pip install -U pip setuptools                                                                                                         0.0s
 => CACHED [compile-image  5/10] RUN export USE_CUDA=1                                                                                                                               0.0s
 => CACHED [compile-image  6/10] COPY ./ serve                                                                                                                                       0.0s
 => CACHED [compile-image  7/10] RUN     if echo "true" | grep -q "false"; then         rm -rf serve;        git clone --recursive https://github.com/pytorch/serve.git -b master;   0.0s
 => CACHED [compile-image  8/10] WORKDIR serve                                                                                                                                       0.0s
 => CACHED [compile-image  9/10] RUN     if echo "ubuntu:20.04" | grep -q "cuda:"; then         if [ "" ]; then             python ./ts_scripts/install_dependencies.py --cuda ;     0.0s
 => CACHED [compile-image 10/10] RUN     if echo "true" | grep -q "true"; then         python -m pip install -r requirements/developer.txt;        python ts_scripts/install_from_s  0.0s
 => [dev-image 3/8] COPY ./ serve                                                                                                                                                   55.4s 
 => [dev-image 4/8] RUN     if echo "true" | grep -q "false"; then         rm -rf serve;        git clone --recursive https://github.com/pytorch/serve.git -b master;     fi         0.2s 
 => [dev-image 5/8] COPY --from=compile-image /home/venv /home/venv                                                                                                                 32.9s 
 => [dev-image 6/8] WORKDIR serve                                                                                                                                                    0.0s 
 => [dev-image 7/8] RUN python -m pip install -U pip setuptools     && python -m pip install --no-cache-dir -r requirements/developer.txt     && python ts_scripts/install_from_s  185.5s 
 => [dev-image 8/8] WORKDIR /home/model-server                                                                                                                                       0.0s 
 => exporting to image                                                                                                                                                              16.3s 
 => => exporting layers                                                                                                                                                             16.3s 
 => => writing image sha256:03c1048e6d30c8466064e0d2a792e1b14df0dfd45faaf5013666cb8b46b76de7                                                                                         0.0s 
 => => naming to docker.io/pytorch/ts:latest                                 
```

## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?