### PR TITLE
Use weights_only for load

### DIFF
--- a/examples/FasterTransformer_HuggingFace_Bert/Bert_FT_trace.py
+++ b/examples/FasterTransformer_HuggingFace_Bert/Bert_FT_trace.py
@@ -125,7 +125,7 @@ def main():
             from utils.encoder import EncoderWeights, CustomEncoder
             weights = EncoderWeights(
                 model.config.num_hidden_layers, model.config.hidden_size,
-                torch.load(os.path.join(checkpoint, 'pytorch_model.bin'), map_location='cpu'))
+                torch.load(os.path.join(checkpoint, 'pytorch_model.bin'), map_location='cpu', weights_only=True))
             weights.to_cuda()
             if args.data_type == 'fp16':
                 weights.to_half()

--- a/examples/MMF-activity-recognition/handler.py
+++ b/examples/MMF-activity-recognition/handler.py
@@ -79,7 +79,7 @@ class MMFHandler(BaseHandler):
         self.processor = build_processors(
             config.dataset_config["charades"].processors
         )
-        state_dict = torch.load(serialized_file, map_location=self.device)
+        state_dict = torch.load(serialized_file, map_location=self.device, weights_only=True)
         self.model.load_state_dict(state_dict)
         self.model.to(self.device)
         self.model.eval()

--- a/examples/cpp/aot_inductor/llama2/compile.py
+++ b/examples/cpp/aot_inductor/llama2/compile.py
@@ -7,7 +7,7 @@ from model import ModelArgs, Transformer
 
 def load_checkpoint(checkpoint):
     # load the provided model checkpoint
-    checkpoint_dict = torch.load(checkpoint, map_location="cpu")
+    checkpoint_dict = torch.load(checkpoint, map_location="cpu", weights_only=True)
     gptconf = ModelArgs(**checkpoint_dict["model_args"])
     model = Transformer(gptconf)
     state_dict = checkpoint_dict["model"]

--- a/examples/dcgan_fashiongen/dcgan_fashiongen_handler.py
+++ b/examples/dcgan_fashiongen/dcgan_fashiongen_handler.py
@@ -40,7 +40,7 @@ class ModelHandler(BaseHandler):
         # Load Model
         from models.DCGAN import DCGAN
         self.dcgan_model = DCGAN(useGPU=self.use_gpu, storeAVG=self.store_avg)
-        state_dict = torch.load(os.path.join(model_dir, CHECKPOINT), map_location=self.map_location)
+        state_dict = torch.load(os.path.join(model_dir, CHECKPOINT), map_location=self.map_location, weights_only=True)
         self.dcgan_model.load_state_dict(state_dict)
 
         self.initialized = True

--- a/examples/image_classifier/vgg_16/vgg_handler.py
+++ b/examples/image_classifier/vgg_16/vgg_handler.py
@@ -24,7 +24,7 @@ class VGGImageClassifier(ImageClassifier):
                 model_class_definitions))
 
         model_class = model_class_definitions[0]
-        state_dict = torch.load(model_pt_path)
+        state_dict = torch.load(model_pt_path, weights_only=True)
         model = model_class()
         model.load_state_dict(state_dict)
         return model

--- a/examples/large_models/tp_llama/llama2.py
+++ b/examples/large_models/tp_llama/llama2.py
@@ -480,7 +480,7 @@ def _convert_fairscale_checkpoints(
     state_dict_pth = get_consolidated_ckpt_path(
         ckpt_dir=original_ckpt_dir, mp_rank=mp_rank, mp_size=model_parallel_size
     )
-    state_dict = torch.load(state_dict_pth)
+    state_dict = torch.load(state_dict_pth, weights_only=True)
     dist_state_dict = build_distributed_state_dict_from_consolidated(
         meta_model,
         state_dict,
@@ -504,7 +504,7 @@ def _load_checkpoint(
     state_dict_pth = get_consolidated_ckpt_path(
         ckpt_dir=ckpt_dir, mp_rank=mp_rank, mp_size=model_parallel_size
     )
-    state_dict = torch.load(state_dict_pth)
+    state_dict = torch.load(state_dict_pth, weights_only=True)
     dist_state_dict = build_distributed_state_dict_from_consolidated(
         meta_model,
         state_dict,

--- a/examples/text_classification_with_scriptable_tokenizer/script_tokenizer_and_model.py
+++ b/examples/text_classification_with_scriptable_tokenizer/script_tokenizer_and_model.py
@@ -76,7 +76,7 @@ def main(args):
     model = XLMR_BASE_ENCODER.get_model(head=classifier_head)
 
     # Load trained parameters and load them into the model
-    model.load_state_dict(torch.load(args.input_file, map_location=torch.device("cpu")))
+    model.load_state_dict(torch.load(args.input_file, map_location=torch.device("cpu"), weights_only=True))
 
     # Chain the tokenizer, the adapter and the model
     combi_model = T.Sequential(

--- a/examples/text_to_speech_synthesizer/waveglow_handler.py
+++ b/examples/text_to_speech_synthesizer/waveglow_handler.py
@@ -41,8 +41,8 @@ class WaveGlowSpeechSynthesizer(BaseHandler):
         from PyTorch.SpeechSynthesis.Tacotron2.tacotron2.text import text_to_sequence
 
         tacotron2_checkpoint = torch.load(
-            os.path.join(model_dir, "nvidia_tacotron2pyt_fp32_20190427.pth")
-        )
+            os.path.join(model_dir, "nvidia_tacotron2pyt_fp32_20190427.pth"), 
+        weights_only=True)
         tacotron2_state_dict = self._unwrap_distributed(
             tacotron2_checkpoint["state_dict"]
         )
@@ -65,8 +65,8 @@ class WaveGlowSpeechSynthesizer(BaseHandler):
             zip_ref.extractall(model_dir)
 
         waveglow_checkpoint = torch.load(
-            os.path.join(model_dir, "nvidia_waveglowpyt_fp32_20190427.pth")
-        )
+            os.path.join(model_dir, "nvidia_waveglowpyt_fp32_20190427.pth"), 
+        weights_only=True)
         waveglow_state_dict = self._unwrap_distributed(
             waveglow_checkpoint["state_dict"]
         )

--- a/frontend/server/src/test/resources/densenet_workflow_handler.py
+++ b/frontend/server/src/test/resources/densenet_workflow_handler.py
@@ -43,7 +43,7 @@ def post_processing(data, context):
         if isinstance(data, list):
             data = data[0]
         data = data.get("data") or data.get("body")
-        data = torch.load(io.BytesIO(data))
+        data = torch.load(io.BytesIO(data), weights_only=True)
 
         properties = context.system_properties
         model_dir = properties.get("model_dir")

--- a/test/pytest/test_cpp_backend.py
+++ b/test/pytest/test_cpp_backend.py
@@ -137,4 +137,4 @@ def test_cpp_mnist(model_name_and_stdout):
 
         assert response.status_code == 200
 
-        assert torch.load(io.BytesIO(response.content)).argmax().item() == n
+        assert torch.load(io.BytesIO(response.content), weights_only=True).argmax().item() == n

--- a/ts/torch_handler/base_handler.py
+++ b/ts/torch_handler/base_handler.py
@@ -313,7 +313,7 @@ class BaseHandler(abc.ABC):
             map_location = (
                 None if (XLA_AVAILABLE and self.map_location is None) else self.device
             )
-            state_dict = torch.load(model_pt_path, map_location=map_location)
+            state_dict = torch.load(model_pt_path, map_location=map_location, weights_only=True)
             model.load_state_dict(state_dict)
         return model
 

--- a/ts/torch_handler/densenet_handler.py
+++ b/ts/torch_handler/densenet_handler.py
@@ -80,7 +80,7 @@ class DenseNetHandler:
             )
 
         model_class = model_class_definitions[0]
-        state_dict = torch.load(model_pt_path, map_location=self.map_location)
+        state_dict = torch.load(model_pt_path, map_location=self.map_location, weights_only=True)
         model = model_class()
         model.load_state_dict(state_dict)
         return model
@@ -111,7 +111,7 @@ class DenseNetHandler:
         values = []
         for row in data:
             image = row.get("data") or row.get("body")
-            tensor = torch.load(io.BytesIO(image))
+            tensor = torch.load(io.BytesIO(image), weights_only=True)
             values.append(tensor)
         data = self.inference(torch.stack(values))
 

--- a/ts/torch_handler/text_handler.py
+++ b/ts/torch_handler/text_handler.py
@@ -54,9 +54,9 @@ class TextHandler(BaseHandler, ABC):
         )
         if source_vocab:
             # Backward compatibility
-            self.source_vocab = torch.load(source_vocab)
+            self.source_vocab = torch.load(source_vocab, weights_only=True)
         else:
-            self.source_vocab = torch.load(self.get_source_vocab_path(context))
+            self.source_vocab = torch.load(self.get_source_vocab_path(context), weights_only=True)
         # Captum initialization
         self.lig = LayerIntegratedGradients(self.model, self.model.embedding)
         self.initialized = True


### PR DESCRIPTION
## Description

`torch.load` without `weights_only` parameter is unsafe. Explicitly set `weights_only` to False only if you trust the data you load and full pickle functionality is needed, otherwise set `weights_only=True`.

If `weights_only=True` doesn't work for some cases, then explicit `weights_only=False` should be used.

Found with https://github.com/pytorch-labs/torchfix/

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Feature/Issue validation/testing

This should be a no-op.