### PR TITLE
Update deprecated TorchVision and PyTorch APIs

### DIFF
--- a/examples/image_segmenter/deeplabv3/model.py
+++ b/examples/image_segmenter/deeplabv3/model.py
@@ -1,9 +1,9 @@
-from torchvision.models.segmentation.deeplabv3 import DeepLabV3
-from torchvision.models import resnet
-from intermediate_layer_getter import IntermediateLayerGetter
 from deeplabv3 import DeepLabHead
 from fcn import FCNHead
+from intermediate_layer_getter import IntermediateLayerGetter
 from torchvision import models
+from torchvision.models import resnet
+from torchvision.models.segmentation.deeplabv3 import DeepLabV3
 
 
 class DeepLabV3ImageSegmenter(DeepLabV3):
@@ -12,9 +12,12 @@ class DeepLabV3ImageSegmenter(DeepLabV3):
     """
 
     def __init__(self, num_classes=21, **kwargs):
-        backbone = resnet.resnet101(weights=models.ResNet101_Weights.IMAGENET1K_V1, replace_stride_with_dilation=[False, True, True])
-        return_layers = {'layer4': 'out'}
-        return_layers['layer3'] = 'aux'
+        backbone = resnet.resnet101(
+            weights=models.ResNet101_Weights.IMAGENET1K_V1,
+            replace_stride_with_dilation=[False, True, True],
+        )
+        return_layers = {"layer4": "out"}
+        return_layers["layer3"] = "aux"
         backbone = IntermediateLayerGetter(backbone, return_layers=return_layers)
 
         inplanes = 1024
@@ -22,4 +25,6 @@ class DeepLabV3ImageSegmenter(DeepLabV3):
         inplanes = 2048
         classifier = DeepLabHead(inplanes, num_classes)
 
-        super(DeepLabV3ImageSegmenter, self).__init__(backbone, classifier, aux_classifier)
+        super(DeepLabV3ImageSegmenter, self).__init__(
+            backbone, classifier, aux_classifier
+        )

--- a/examples/image_segmenter/deeplabv3/model.py
+++ b/examples/image_segmenter/deeplabv3/model.py
@@ -3,6 +3,7 @@ from torchvision.models import resnet
 from intermediate_layer_getter import IntermediateLayerGetter
 from deeplabv3 import DeepLabHead
 from fcn import FCNHead
+from torchvision import models
 
 
 class DeepLabV3ImageSegmenter(DeepLabV3):
@@ -11,8 +12,7 @@ class DeepLabV3ImageSegmenter(DeepLabV3):
     """
 
     def __init__(self, num_classes=21, **kwargs):
-        backbone = resnet.resnet101(pretrained=True,
-                                    replace_stride_with_dilation=[False, True, True])
+        backbone = resnet.resnet101(weights=models.ResNet101_Weights.IMAGENET1K_V1, replace_stride_with_dilation=[False, True, True])
         return_layers = {'layer4': 'out'}
         return_layers['layer3'] = 'aux'
         backbone = IntermediateLayerGetter(backbone, return_layers=return_layers)

--- a/examples/image_segmenter/fcn/model.py
+++ b/examples/image_segmenter/fcn/model.py
@@ -2,6 +2,7 @@ from torchvision.models.segmentation.fcn import FCN
 from torchvision.models import resnet
 from intermediate_layer_getter import IntermediateLayerGetter
 from fcn import FCNHead
+from torchvision import models
 
 
 class FCNImageSegmenter(FCN):
@@ -10,8 +11,7 @@ class FCNImageSegmenter(FCN):
     """
 
     def __init__(self, num_classes=21, **kwargs):
-        backbone = resnet.resnet101(pretrained=True,
-                                    replace_stride_with_dilation=[False, True, True])
+        backbone = resnet.resnet101(weights=models.ResNet101_Weights.IMAGENET1K_V1, replace_stride_with_dilation=[False, True, True])
         return_layers = {'layer4': 'out'}
         return_layers['layer3'] = 'aux'
         backbone = IntermediateLayerGetter(backbone, return_layers=return_layers)

--- a/examples/image_segmenter/fcn/model.py
+++ b/examples/image_segmenter/fcn/model.py
@@ -1,8 +1,8 @@
-from torchvision.models.segmentation.fcn import FCN
-from torchvision.models import resnet
-from intermediate_layer_getter import IntermediateLayerGetter
 from fcn import FCNHead
+from intermediate_layer_getter import IntermediateLayerGetter
 from torchvision import models
+from torchvision.models import resnet
+from torchvision.models.segmentation.fcn import FCN
 
 
 class FCNImageSegmenter(FCN):
@@ -11,9 +11,12 @@ class FCNImageSegmenter(FCN):
     """
 
     def __init__(self, num_classes=21, **kwargs):
-        backbone = resnet.resnet101(weights=models.ResNet101_Weights.IMAGENET1K_V1, replace_stride_with_dilation=[False, True, True])
-        return_layers = {'layer4': 'out'}
-        return_layers['layer3'] = 'aux'
+        backbone = resnet.resnet101(
+            weights=models.ResNet101_Weights.IMAGENET1K_V1,
+            replace_stride_with_dilation=[False, True, True],
+        )
+        return_layers = {"layer4": "out"}
+        return_layers["layer3"] = "aux"
         backbone = IntermediateLayerGetter(backbone, return_layers=return_layers)
 
         inplanes = 1024

--- a/examples/text_to_speech_synthesizer/waveglow_model.py
+++ b/examples/text_to_speech_synthesizer/waveglow_model.py
@@ -52,7 +52,7 @@ class Invertible1x1Conv(torch.nn.Module):
                                     bias=False)
 
         # Sample a random orthonormal matrix to initialize weights
-        W = torch.qr(torch.FloatTensor(c, c).normal_())[0]
+        W = torch.linalg.qr(torch.FloatTensor(c, c).normal_())[0]
 
         # Ensure determinant is 1.0 not -1.0
         if torch.det(W) < 0:

--- a/examples/text_to_speech_synthesizer/waveglow_model.py
+++ b/examples/text_to_speech_synthesizer/waveglow_model.py
@@ -25,8 +25,8 @@
 #
 # *****************************************************************************
 import torch
-from torch.autograd import Variable
 import torch.nn.functional as F
+from torch.autograd import Variable
 
 
 @torch.jit.script
@@ -48,8 +48,9 @@ class Invertible1x1Conv(torch.nn.Module):
 
     def __init__(self, c):
         super(Invertible1x1Conv, self).__init__()
-        self.conv = torch.nn.Conv1d(c, c, kernel_size=1, stride=1, padding=0,
-                                    bias=False)
+        self.conv = torch.nn.Conv1d(
+            c, c, kernel_size=1, stride=1, padding=0, bias=False
+        )
 
         # Sample a random orthonormal matrix to initialize weights
         W = torch.linalg.qr(torch.FloatTensor(c, c).normal_())[0]
@@ -67,18 +68,25 @@ class Invertible1x1Conv(torch.nn.Module):
         W = self.conv.weight.squeeze()
 
         if reverse:
-            if not hasattr(self, 'W_inverse'):
+            if not hasattr(self, "W_inverse"):
                 # Reverse computation
                 W_inverse = W.float().inverse()
                 W_inverse = Variable(W_inverse[..., None])
-                if z.type() == 'torch.cuda.HalfTensor' or z.type() == 'torch.HalfTensor':
+                if (
+                    z.type() == "torch.cuda.HalfTensor"
+                    or z.type() == "torch.HalfTensor"
+                ):
                     W_inverse = W_inverse.half()
                 self.W_inverse = W_inverse
             z = F.conv1d(z, self.W_inverse, bias=None, stride=1, padding=0)
             return z
         else:
             # Forward computation
-            log_det_W = batch_size * n_of_groups * torch.logdet(W.unsqueeze(0).float()).squeeze()
+            log_det_W = (
+                batch_size
+                * n_of_groups
+                * torch.logdet(W.unsqueeze(0).float()).squeeze()
+            )
             z = self.conv(z)
             return z, log_det_W
 
@@ -90,11 +98,12 @@ class WN(torch.nn.Module):
     also no dilation size reset.  The dilation only doubles on each layer
     """
 
-    def __init__(self, n_in_channels, n_mel_channels, n_layers, n_channels,
-                 kernel_size):
+    def __init__(
+        self, n_in_channels, n_mel_channels, n_layers, n_channels, kernel_size
+    ):
         super(WN, self).__init__()
-        assert(kernel_size % 2 == 1)
-        assert(n_channels % 2 == 0)
+        assert kernel_size % 2 == 1
+        assert n_channels % 2 == 0
         self.n_layers = n_layers
         self.n_channels = n_channels
         self.in_layers = torch.nn.ModuleList()
@@ -102,7 +111,7 @@ class WN(torch.nn.Module):
         self.cond_layers = torch.nn.ModuleList()
 
         start = torch.nn.Conv1d(n_in_channels, n_channels, 1)
-        start = torch.nn.utils.weight_norm(start, name='weight')
+        start = torch.nn.utils.weight_norm(start, name="weight")
         self.start = start
 
         # Initializing last layer to 0 makes the affine coupling layers
@@ -113,15 +122,20 @@ class WN(torch.nn.Module):
         self.end = end
 
         for i in range(n_layers):
-            dilation = 2 ** i
+            dilation = 2**i
             padding = int((kernel_size * dilation - dilation) / 2)
-            in_layer = torch.nn.Conv1d(n_channels, 2 * n_channels, kernel_size,
-                                       dilation=dilation, padding=padding)
-            in_layer = torch.nn.utils.weight_norm(in_layer, name='weight')
+            in_layer = torch.nn.Conv1d(
+                n_channels,
+                2 * n_channels,
+                kernel_size,
+                dilation=dilation,
+                padding=padding,
+            )
+            in_layer = torch.nn.utils.weight_norm(in_layer, name="weight")
             self.in_layers.append(in_layer)
 
             cond_layer = torch.nn.Conv1d(n_mel_channels, 2 * n_channels, 1)
-            cond_layer = torch.nn.utils.weight_norm(cond_layer, name='weight')
+            cond_layer = torch.nn.utils.weight_norm(cond_layer, name="weight")
             self.cond_layers.append(cond_layer)
 
             # last one is not necessary
@@ -130,8 +144,7 @@ class WN(torch.nn.Module):
             else:
                 res_skip_channels = n_channels
             res_skip_layer = torch.nn.Conv1d(n_channels, res_skip_channels, 1)
-            res_skip_layer = torch.nn.utils.weight_norm(
-                res_skip_layer, name='weight')
+            res_skip_layer = torch.nn.utils.weight_norm(res_skip_layer, name="weight")
             self.res_skip_layers.append(res_skip_layer)
 
     def forward(self, forward_input):
@@ -142,12 +155,13 @@ class WN(torch.nn.Module):
             acts = fused_add_tanh_sigmoid_multiply(
                 self.in_layers[i](audio),
                 self.cond_layers[i](spect),
-                torch.IntTensor([self.n_channels]))
+                torch.IntTensor([self.n_channels]),
+            )
 
             res_skip_acts = self.res_skip_layers[i](acts)
             if i < self.n_layers - 1:
-                audio = res_skip_acts[:, :self.n_channels, :] + audio
-                skip_acts = res_skip_acts[:, self.n_channels:, :]
+                audio = res_skip_acts[:, : self.n_channels, :] + audio
+                skip_acts = res_skip_acts[:, self.n_channels :, :]
             else:
                 skip_acts = res_skip_acts
 
@@ -159,14 +173,15 @@ class WN(torch.nn.Module):
 
 
 class WaveGlow(torch.nn.Module):
-    def __init__(self, n_mel_channels, n_flows, n_group, n_early_every,
-                 n_early_size, WN_config):
+    def __init__(
+        self, n_mel_channels, n_flows, n_group, n_early_every, n_early_size, WN_config
+    ):
         super(WaveGlow, self).__init__()
 
-        self.upsample = torch.nn.ConvTranspose1d(n_mel_channels,
-                                                 n_mel_channels,
-                                                 1024, stride=256)
-        assert(n_group % 2 == 0)
+        self.upsample = torch.nn.ConvTranspose1d(
+            n_mel_channels, n_mel_channels, 1024, stride=256
+        )
+        assert n_group % 2 == 0
         self.n_flows = n_flows
         self.n_group = n_group
         self.n_early_every = n_early_every
@@ -196,9 +211,9 @@ class WaveGlow(torch.nn.Module):
 
         #  Upsample spectrogram to size of audio
         spect = self.upsample(spect)
-        assert(spect.size(2) >= audio.size(1))
+        assert spect.size(2) >= audio.size(1)
         if spect.size(2) > audio.size(1):
-            spect = spect[:, :, :audio.size(1)]
+            spect = spect[:, :, : audio.size(1)]
 
         spect = spect.unfold(2, self.n_group, self.n_group).permute(0, 2, 1, 3)
         spect = spect.contiguous().view(spect.size(0), spect.size(1), -1)
@@ -211,8 +226,8 @@ class WaveGlow(torch.nn.Module):
 
         for k in range(self.n_flows):
             if k % self.n_early_every == 0 and k > 0:
-                output_audio.append(audio[:, :self.n_early_size, :])
-                audio = audio[:, self.n_early_size:, :]
+                output_audio.append(audio[:, : self.n_early_size, :])
+                audio = audio[:, self.n_early_size :, :]
 
             audio, log_det_W = self.convinv[k](audio)
             log_det_W_list.append(log_det_W)
@@ -233,7 +248,6 @@ class WaveGlow(torch.nn.Module):
         return torch.cat(output_audio, 1), log_s_list, log_det_W_list
 
     def infer(self, spect, sigma=1.0):
-
         spect = self.upsample(spect)
         # trim conv artifacts. maybe pad spec to kernel multiple
         time_cutoff = self.upsample.kernel_size[0] - self.upsample.stride[0]
@@ -243,9 +257,9 @@ class WaveGlow(torch.nn.Module):
         spect = spect.contiguous().view(spect.size(0), spect.size(1), -1)
         spect = spect.permute(0, 2, 1)
 
-        audio = torch.randn(spect.size(0),
-                            self.n_remaining_channels,
-                            spect.size(2), device=spect.device).to(spect.dtype)
+        audio = torch.randn(
+            spect.size(0), self.n_remaining_channels, spect.size(2), device=spect.device
+        ).to(spect.dtype)
 
         audio = torch.autograd.Variable(sigma * audio)
 
@@ -263,15 +277,13 @@ class WaveGlow(torch.nn.Module):
             audio = self.convinv[k](audio, reverse=True)
 
             if k % self.n_early_every == 0 and k > 0:
-                z = torch.randn(spect.size(0), self.n_early_size, spect.size(
-                    2), device=spect.device).to(spect.dtype)
+                z = torch.randn(
+                    spect.size(0), self.n_early_size, spect.size(2), device=spect.device
+                ).to(spect.dtype)
                 audio = torch.cat((sigma * z, audio), 1)
 
-        audio = audio.permute(
-            0, 2, 1).contiguous().view(
-            audio.size(0), -1).data
+        audio = audio.permute(0, 2, 1).contiguous().view(audio.size(0), -1).data
         return audio
-
 
     @staticmethod
     def remove_weightnorm(model):


### PR DESCRIPTION
## Description

1. For TorchVision models, pretrained parameters have been deprecated in favor of "Multi-weight support API" - see https://pytorch.org/vision/0.15/models.html
2. `torch.qr` updated to `torch.linalg.qr`

Found with https://github.com/pytorch-labs/torchfix/

Also applied pre-commit to pass linter.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Feature/Issue validation/testing

This should be a no-op.
