### PR TITLE
Workaround for kserve nightly failure

### DIFF
--- a/.github/workflows/kserve_cpu_tests.yml
+++ b/.github/workflows/kserve_cpu_tests.yml
@@ -39,7 +39,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: kserve/kserve
-          ref: v0.11.0
           path: kserve
       - name: Validate torchserve-kfs and Open Inference Protocol
         run: ./kubernetes/kserve/tests/scripts/test_mnist.sh

--- a/.github/workflows/kserve_cpu_tests.yml
+++ b/.github/workflows/kserve_cpu_tests.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: kserve/kserve
-          ref: v0.11.1
+          ref: v0.11.0
           path: kserve
       - name: Validate torchserve-kfs and Open Inference Protocol
         run: ./kubernetes/kserve/tests/scripts/test_mnist.sh

--- a/.github/workflows/kserve_cpu_tests.yml
+++ b/.github/workflows/kserve_cpu_tests.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: kserve/kserve
+          ref: v0.12.0
           path: kserve
       - name: Validate torchserve-kfs and Open Inference Protocol
         run: ./kubernetes/kserve/tests/scripts/test_mnist.sh

--- a/kubernetes/kserve/requirements.txt
+++ b/kubernetes/kserve/requirements.txt
@@ -1,4 +1,5 @@
-kserve[storage]>=0.11.0
+kserve[storage]>=0.12.0
+ray[serve]<=2.9.3,>=2.9.2
 transformers
 captum
 grpcio


### PR DESCRIPTION
## Description

KServe nightlies are failing because of KServe's dependency on Ray Serve.

This PR downgrades the version of rayserve as suggested by KServe team , which fixes the problem

Fixes #([issue](https://github.com/pytorch/serve/issues/3044))

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Default
```
model-server@41267f0551c9:~$ pip list | grep -i serve
kserve                          0.12.0
torchserve-nightly              2024.4.8
model-server@41267f0551c9:~$ pip list | grep -i ray  
ray                             2.10.0
model-server@41267f0551c9:~$ exit
exit
Traceback (most recent call last):
  File "/home/model-server/kserve_wrapper/__main__.py", line 6, in <module>
    import kserve
  File "/home/venv/lib/python3.9/site-packages/kserve/__init__.py", line 18, in <module>
    from .model_server import ModelServer
  File "/home/venv/lib/python3.9/site-packages/kserve/model_server.py", line 27, in <module>
    from ray.serve.handle import RayServeHandle
ImportError: cannot import name 'RayServeHandle' from 'ray.serve.handle' (/home/venv/lib/python3.9/site-packages/ray/serve/handle.py)
```

- [ ] After fix
```
model-server@a5b9bcb5c9bc:~$ pip list | grep -i ray
ray                             2.9.3
model-server@a5b9bcb5c9bc:~$ pip list | grep -i kserve
kserve                          0.12.0

model-server@c7199beae5a5:~$ python
Python 3.9.19 (main, Apr  6 2024, 17:57:55) 
[GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import kserve
>>> 
```


## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?