### PR TITLE
Fix GRPC address assignment to localhost by default

### DIFF
--- a/docker/config.properties
+++ b/docker/config.properties
@@ -1,6 +1,8 @@
 inference_address=http://0.0.0.0:8080
 management_address=http://0.0.0.0:8081
 metrics_address=http://0.0.0.0:8082
+grpc_inference_address=0.0.0.0
+grpc_management_address=0.0.0.0
 number_of_netty_threads=32
 job_queue_size=1000
 model_store=/home/model-server/model-store

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,8 +93,13 @@ inference_address=https://127.0.0.1:8443
 inference_address=https://172.16.1.10:8080
 ```
 
-### Configure TorchServe gRPC listening ports
-The inference gRPC API is listening on port 7070, and the management gRPC API is listening on port 7071 by default.
+### Configure TorchServe gRPC listening addresses and ports
+The inference gRPC API is listening on port 7070, and the management gRPC API is listening on port 7071 on localhost by default.
+
+To configure different addresses use following properties
+
+* `grpc_inference_address`: Inference gRPC API IP address. Default: 127.0.0.1
+* `grpc_management_address`: Management gRPC API IP address. Default: 127.0.0.1
 
 To configure different ports use following properties
 

--- a/docs/grpc_api.md
+++ b/docs/grpc_api.md
@@ -19,8 +19,8 @@ TorchServe provides following gRPCs apis
   - **DescribeModel** : Get detail runtime status of default version of a model
   - **SetDefault** : Set any registered version of a model as default version
 
-By default, TorchServe listens on port 7070 for the gRPC Inference API and 7071 for the gRPC Management API.
-To configure gRPC APIs on different ports refer [configuration documentation](configuration.md)
+By default, TorchServe listens on port 7070 for the gRPC Inference API and 7071 for the gRPC Management API on localhost.
+To configure gRPC APIs on different address and ports refer [configuration documentation](configuration.md)
 
 ## Python client example for gRPC APIs
 

--- a/docs/grpc_api.md
+++ b/docs/grpc_api.md
@@ -20,7 +20,7 @@ TorchServe provides following gRPCs apis
   - **SetDefault** : Set any registered version of a model as default version
 
 By default, TorchServe listens on port 7070 for the gRPC Inference API and 7071 for the gRPC Management API on localhost.
-To configure gRPC APIs on different address and ports refer [configuration documentation](configuration.md)
+To configure gRPC APIs on different addresses and ports refer [configuration documentation](configuration.md)
 
 ## Python client example for gRPC APIs
 

--- a/frontend/server/src/main/java/org/pytorch/serve/ModelServer.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/ModelServer.java
@@ -17,6 +17,7 @@ import io.netty.util.internal.logging.Slf4JLoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
+import java.net.InetSocketAddress;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -447,7 +448,10 @@ public class ModelServer {
     private Server startGRPCServer(ConnectorType connectorType) throws IOException {
 
         ServerBuilder<?> s =
-                NettyServerBuilder.forPort(configManager.getGRPCPort(connectorType))
+                NettyServerBuilder.forAddress(
+                                new InetSocketAddress(
+                                        configManager.getGRPCAddress(connectorType),
+                                        configManager.getGRPCPort(connectorType)))
                         .maxInboundMessageSize(configManager.getMaxRequestSize())
                         .addService(
                                 ServerInterceptors.intercept(

--- a/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
@@ -359,20 +359,27 @@ public final class ConfigManager {
         return Connector.parse(binding, connectorType);
     }
 
-    public InetAddress getGRPCAddress(ConnectorType connectorType) throws UnknownHostException {
+    public InetAddress getGRPCAddress(ConnectorType connectorType)
+            throws UnknownHostException, IllegalArgumentException {
         if (connectorType == ConnectorType.MANAGEMENT_CONNECTOR) {
             return InetAddress.getByName(prop.getProperty(TS_GRPC_MANAGEMENT_ADDRESS, "127.0.0.1"));
-        } else {
+        } else if (connectorType == ConnectorType.INFERENCE_CONNECTOR) {
             return InetAddress.getByName(prop.getProperty(TS_GRPC_INFERENCE_ADDRESS, "127.0.0.1"));
+        } else {
+            throw new IllegalArgumentException(
+                    "Connector type not supporte dy gRPC: " + connectorType);
         }
     }
 
-    public int getGRPCPort(ConnectorType connectorType) {
+    public int getGRPCPort(ConnectorType connectorType) throws IllegalArgumentException {
         String port;
         if (connectorType == ConnectorType.MANAGEMENT_CONNECTOR) {
             port = prop.getProperty(TS_GRPC_MANAGEMENT_PORT, "7071");
-        } else {
+        } else if (connectorType == ConnectorType.INFERENCE_CONNECTOR) {
             port = prop.getProperty(TS_GRPC_INFERENCE_PORT, "7070");
+        } else {
+            throw new IllegalArgumentException(
+                    "Connector type not supporte dy gRPC: " + connectorType);
         }
         return Integer.parseInt(port);
     }

--- a/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
@@ -367,7 +367,7 @@ public final class ConfigManager {
             return InetAddress.getByName(prop.getProperty(TS_GRPC_INFERENCE_ADDRESS, "127.0.0.1"));
         } else {
             throw new IllegalArgumentException(
-                    "Connector type not supporte dy gRPC: " + connectorType);
+                    "Connector type not supported by gRPC: " + connectorType);
         }
     }
 
@@ -379,7 +379,7 @@ public final class ConfigManager {
             port = prop.getProperty(TS_GRPC_INFERENCE_PORT, "7070");
         } else {
             throw new IllegalArgumentException(
-                    "Connector type not supporte dy gRPC: " + connectorType);
+                    "Connector type not supported by gRPC: " + connectorType);
         }
         return Integer.parseInt(port);
     }

--- a/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
@@ -101,6 +101,8 @@ public final class ConfigManager {
     private static final String TS_ALLOWED_URLS = "allowed_urls";
     private static final String TS_INSTALL_PY_DEP_PER_MODEL = "install_py_dep_per_model";
     private static final String TS_ENABLE_METRICS_API = "enable_metrics_api";
+    private static final String TS_GRPC_INFERENCE_ADDRESS = "grpc_inference_address";
+    private static final String TS_GRPC_MANAGEMENT_ADDRESS = "grpc_management_address";
     private static final String TS_GRPC_INFERENCE_PORT = "grpc_inference_port";
     private static final String TS_GRPC_MANAGEMENT_PORT = "grpc_management_port";
     private static final String TS_ENABLE_GRPC_SSL = "enable_grpc_ssl";
@@ -355,6 +357,14 @@ public final class ConfigManager {
                 binding = prop.getProperty(TS_INFERENCE_ADDRESS, "http://127.0.0.1:8080");
         }
         return Connector.parse(binding, connectorType);
+    }
+
+    public InetAddress getGRPCAddress(ConnectorType connectorType) throws UnknownHostException {
+        if (connectorType == ConnectorType.MANAGEMENT_CONNECTOR) {
+            return InetAddress.getByName(prop.getProperty(TS_GRPC_MANAGEMENT_ADDRESS, "127.0.0.1"));
+        } else {
+            return InetAddress.getByName(prop.getProperty(TS_GRPC_INFERENCE_ADDRESS, "127.0.0.1"));
+        }
     }
 
     public int getGRPCPort(ConnectorType connectorType) {


### PR DESCRIPTION
## Description
In the current implementation, the configured GRPC port is by default associated with the wildcard address

https://github.com/pytorch/serve/blob/cdba0fd449c2fd23dcf37c54c0784035541d5114/frontend/server/src/main/java/org/pytorch/serve/ModelServer.java#L450

```
$ torchserve --ncs --start --model-store ./model-store

$ netstat -an | grep 7070
Proto Recv-Q Send-Q  Local Address          Foreign Address        (state)
tcp46      0      0  *.7070                 *.*                    LISTEN

$ netstat -an | grep 7071
Proto Recv-Q Send-Q  Local Address          Foreign Address        (state)
tcp46      0      0  *.7071                 *.*                    LISTEN
```

Note that the grpc ports `7070` and `7071` are associated with the wildcard address `*`.

With the fix in this PR, the grpc ports are associated with localhost(`127.0.0.1`) by default.

```
$ torchserve --ncs --start --model-store ./model-store

$ netstat -an | grep 7070
Proto Recv-Q Send-Q  Local Address          Foreign Address        (state)
tcp46      0      0  127.0.0.1.7070                 *.*                    LISTEN

$ netstat -an | grep 7071
Proto Recv-Q Send-Q  Local Address          Foreign Address        (state)
tcp46      0      0  127.0.0.1.7071                 *.*                    LISTEN
```

In case of docker, the grpc address will need to be configured to `0.0.0.0` similar to the http management and inference addresses because otherwise, the grpc endpoint will not be accessible from outside the container:
https://github.com/pytorch/serve/blob/cdba0fd449c2fd23dcf37c54c0784035541d5114/docker/config.properties#L1-L2

Documentation already includes best practice to bind `localhost` ports to the ports exposed by docker to ensure access only to the host on which the container is running.
https://github.com/pytorch/serve/tree/master/docker#security-guideline

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Feature/Issue validation/testing
- [ ] CI

- [ ] Manual Test
```
$ torchserve --ncs --start --model-store ./model-store

$ python ts_scripts/torchserve_grpc_client.py register densenet161
## Check densenet161.mar in mar_set : set()
## Register marfile: https://torchserve.s3.amazonaws.com/mar_files/densenet161.mar

Model densenet161 registered successfully

$ python ts_scripts/torchserve_grpc_client.py infer densenet161 examples/image_classifier/kitten.jpg
{
  "tabby": 0.46661901473999023,
  "tiger_cat": 0.46449053287506104,
  "Egyptian_cat": 0.06614045053720474,
  "lynx": 0.0012924427865073085,
  "plastic_bag": 0.00022909742256160825
}

$ python ts_scripts/torchserve_grpc_client.py unregister densenet161
Model densenet161 unregistered successfully
```