### PR TITLE
disable torch export test in docker

### DIFF
--- a/.github/workflows/regression_tests_docker.yml
+++ b/.github/workflows/regression_tests_docker.yml
@@ -1,6 +1,9 @@
 name: Run Regression Tests on Docker
 
 on:
+  push:
+    tags:
+      - docker
   workflow_dispatch:
   # run every day at 5:15am
   schedule:

--- a/test/pytest/test_torch_export.py
+++ b/test/pytest/test_torch_export.py
@@ -49,6 +49,10 @@ def custom_working_directory(tmp_path):
     os.chdir(tmp_path)
 
 
+@pytest.mark.skipif(
+    os.environ.get("TS_RUN_IN_DOCKER", False),
+    reason="Test to be run outside docker",
+)
 @pytest.mark.skipif(PT_230_AVAILABLE == False, reason="torch version is < 2.3.0")
 def test_torch_export_aot_compile(custom_working_directory):
     # Get the path to the custom working directory
@@ -90,6 +94,10 @@ def test_torch_export_aot_compile(custom_working_directory):
     assert labels == EXPECTED_RESULTS
 
 
+@pytest.mark.skipif(
+    os.environ.get("TS_RUN_IN_DOCKER", False),
+    reason="Test to be run outside docker",
+)
 @pytest.mark.skipif(PT_230_AVAILABLE == False, reason="torch version is < 2.3.0")
 def test_torch_export_aot_compile_dynamic_batching(custom_working_directory):
     # Get the path to the custom working directory


### PR DESCRIPTION
## Description

Currently `torch._export.aot_load` inference doesn't work in docker. 
It looks like it needs the other other cubin files created at the time of generation of the .so file

This PR also enables docker regressions to be run based on label `docker`

Passing Run: https://github.com/pytorch/serve/actions/runs/8853483743/job/24314425401

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B


## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?