### PR TITLE
Make torchserve-kfs docker image multiplatform

### DIFF
--- a/kubernetes/kserve/build_image.sh
+++ b/kubernetes/kserve/build_image.sh
@@ -57,4 +57,5 @@ fi
 cp ../../frontend/server/src/main/resources/proto/*.proto .
 cp -r ../../third_party .
 
-DOCKER_BUILDKIT=1 docker build --file "$DOCKER_FILE" --build-arg BASE_IMAGE=$BASE_IMAGE -t "$DOCKER_TAG" .
+docker buildx create --name mybuilder --use --bootstrap
+docker buildx build --file "$DOCKER_FILE" --build-arg BASE_IMAGE=$BASE_IMAGE --platform linux/amd64,linux/arm64 --push -t "$DOCKER_TAG" .

--- a/kubernetes/kserve/build_upload_release.py
+++ b/kubernetes/kserve/build_upload_release.py
@@ -39,12 +39,6 @@ if __name__ == "__main__":
         dry_run,
     )
 
-    for image in [
-        f"{organization}/torchserve-kfs:{check_ts_version()}",
-        f"{organization}/torchserve-kfs:{check_ts_version()}-gpu",
-    ]:
-        try_and_handle(f"docker push {image}", dry_run)
-
     # Cleanup built images
     if args.cleanup:
         try_and_handle(f"docker system prune --all --volumes -f", dry_run)

--- a/kubernetes/kserve/docker_nightly.py
+++ b/kubernetes/kserve/docker_nightly.py
@@ -36,18 +36,16 @@ if __name__ == "__main__":
     cpu_version = f"{project}:cpu-{get_nightly_version()}"
     gpu_version = f"{project}:gpu-{get_nightly_version()}"
 
-    # Build Nightly images and append the date in the name
-    try_and_handle(f"./build_image.sh -n -t {organization}/{cpu_version}", dry_run)
+    # Build and push Nightly images and append the date in the name
+    try_and_handle(
+        f"./build_image.sh -n -t {organization}/{cpu_version}",
+        dry_run)
     try_and_handle(
         f"./build_image.sh -g -n -t {organization}/{gpu_version}",
         dry_run,
     )
 
-    # Push Nightly images to official PyTorch Dockerhub account
-    try_and_handle(f"docker push {organization}/{cpu_version}", dry_run)
-    try_and_handle(f"docker push {organization}/{gpu_version}", dry_run)
-
-    # Tag nightly images with latest
+    # Build and push Nightly images with latest
     try_and_handle(
         f"docker tag {organization}/{cpu_version} {organization}/{project}:latest-cpu",
         dry_run,
@@ -56,10 +54,6 @@ if __name__ == "__main__":
         f"docker tag {organization}/{gpu_version} {organization}/{project}:latest-gpu",
         dry_run,
     )
-
-    # Push images with latest tag
-    try_and_handle(f"docker push {organization}/{project}:latest-cpu", dry_run)
-    try_and_handle(f"docker push {organization}/{project}:latest-gpu", dry_run)
 
     # Cleanup built images
     if args.cleanup:


### PR DESCRIPTION
## Description
This PR does the following:
* Update build_image.sh to build image using buildx and use both arm and amd platforms, this command also pushes the image, it can not be loaded into the local registry due to limitations in buildx
* Update build_upload_release.py and docker_nightly.py so docker images do not need to be pushed separately

Please read our [CONTRIBUTING.md](https://github.com/pytorch/serve/blob/master/CONTRIBUTING.md) prior to creating your first pull request.

Please include a summary of the feature or issue being fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #3161

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## Feature/Issue validation/testing
Built image locally, pushed [here](https://hub.docker.com/layers/dtemesgen/torchserve-kfs/ma/images/sha256-35ddd0cefce547b23459d5f1d015b269046c303512779c31dbf785e5d0284ea8?context=explore).

## Checklist:
- [X] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [X] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?