### PR TITLE
Changing mar file for Bert torch compile

### DIFF
--- a/benchmarks/models_config/bert_torch_compile_gpu.yaml
+++ b/benchmarks/models_config/bert_torch_compile_gpu.yaml
@@ -21,7 +21,7 @@ bert:
             - "gpus": "all"
     torch_compile_default_mode:
         benchmark_engine: "ab"
-        url: https://torchserve.pytorch.org/mar_files/bert-default.mar
+        url: https://torchserve.pytorch.org/mar_files/bert-compile.mar
         workers:
             - 4
         batch_delay: 100


### PR DESCRIPTION
## Description

Changing mar file for Bert torch compile so that it includes `torch.inference_mode()` 