### PR TITLE
Fixing torch compile benchmark 

### DIFF
--- a/ts_scripts/install_dependencies.py
+++ b/ts_scripts/install_dependencies.py
@@ -141,7 +141,7 @@ class Common:
                 f"pip3 install numpy --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/{pt_nightly}"
             )
             os.system(
-                f"pip3 install --pre torchtext --index-url https://download.pytorch.org/whl/nightly/cpu"
+                f"pip3 install --pre torchtext --index-url https://download.pytorch.org/whl/nightly/cpu --no-deps"
             )
         else:
             self.install_torch_packages(cuda_version)


### PR DESCRIPTION
## Description
Torch compile nightly tests are running for 22+ hours and are terminating due to extended use. Root cause is that torchtext installation is causing torch cpu to be installed rather then cu121 which causes the tests to run on the CPU rather then GPU. 

This can be verified through ec2 stats showing 99% CPU usage during the failed tests and `nvidia-smi` showing no running processes during the tests. 

Solution to add `no-deps` flag to the installation of torchtext to prevent it from installing a different version of torch.

## Logs 
https://github.com/pytorch/serve/actions/runs/9395103010/job/25873916833 
Can verify torch version and can also see 
```
GPU models and configuration: 
GPU 0: NVIDIA A10G
GPU 1: NVIDIA A10G
GPU 2: NVIDIA A10G
GPU 3: NVIDIA A10G
```