### PR TITLE
Updating night CIs to account for model control 

### DIFF
--- a/.github/workflows/kubernetes_tests.yml
+++ b/.github/workflows/kubernetes_tests.yml
@@ -3,11 +3,8 @@ name: Kubernetes Nightly Tests
 on:
   workflow_dispatch:
   # runs everyday  at 6:15am
-  # schedule:
-  #   - cron:  '15 6 * * *'
-  push:
-    branches:
-      - model_update
+  schedule:
+    - cron:  '15 6 * * *'
 
 jobs:
   kubernetes-tests:

--- a/.github/workflows/kubernetes_tests.yml
+++ b/.github/workflows/kubernetes_tests.yml
@@ -3,8 +3,11 @@ name: Kubernetes Nightly Tests
 on:
   workflow_dispatch:
   # runs everyday  at 6:15am
-  schedule:
-    - cron:  '15 6 * * *'
+  # schedule:
+  #   - cron:  '15 6 * * *'
+  push:
+    branches:
+      - model_update
 
 jobs:
   kubernetes-tests:

--- a/benchmarks/utils/system_under_test.py
+++ b/benchmarks/utils/system_under_test.py
@@ -116,7 +116,7 @@ class LocalTorchServeUnderTest(TorchServeUnderTest):
         click.secho("*Starting local Torchserve instance...", fg="green")
 
         ts_cmd = (
-            f"torchserve --start --model-store {self.execution_params['tmp_dir']}/model_store "
+            f"torchserve --start --model-store {self.execution_params['tmp_dir']}/model_store --model-api-enabled"
             f"--workflow-store {self.execution_params['tmp_dir']}/wf_store "
             f"--ts-config {self.execution_params['tmp_dir']}/benchmark/conf/{self.execution_params['config_properties_name']} "
             f" > {self.execution_params['tmp_dir']}/benchmark/logs/model_metrics.log"
@@ -195,7 +195,7 @@ class DockerTorchServeUnderTest(TorchServeUnderTest):
             f"docker run {self.execution_params['docker_runtime']} {backend_profiling} --name ts --user root -p "
             f"127.0.0.1:{inference_port}:{inference_port} -p 127.0.0.1:{management_port}:{management_port} "
             f"-v {self.execution_params['tmp_dir']}:/tmp {enable_gpu} -itd {docker_image} "
-            f'"torchserve --start --model-store /home/model-server/model-store '
+            f'"torchserve --start --model-store /home/model-server/model-store --model-api-enabled'
             f"\--workflow-store /home/model-server/wf-store "
             f"--ts-config /tmp/benchmark/conf/{self.execution_params['config_properties_name']} > "
             f'/tmp/benchmark/logs/model_metrics.log"'

--- a/benchmarks/utils/system_under_test.py
+++ b/benchmarks/utils/system_under_test.py
@@ -116,7 +116,7 @@ class LocalTorchServeUnderTest(TorchServeUnderTest):
         click.secho("*Starting local Torchserve instance...", fg="green")
 
         ts_cmd = (
-            f"torchserve --start --model-store {self.execution_params['tmp_dir']}/model_store --model-api-enabled"
+            f"torchserve --start --model-store {self.execution_params['tmp_dir']}/model_store --model-api-enabled --disable-token"
             f"--workflow-store {self.execution_params['tmp_dir']}/wf_store "
             f"--ts-config {self.execution_params['tmp_dir']}/benchmark/conf/{self.execution_params['config_properties_name']} "
             f" > {self.execution_params['tmp_dir']}/benchmark/logs/model_metrics.log"
@@ -195,7 +195,7 @@ class DockerTorchServeUnderTest(TorchServeUnderTest):
             f"docker run {self.execution_params['docker_runtime']} {backend_profiling} --name ts --user root -p "
             f"127.0.0.1:{inference_port}:{inference_port} -p 127.0.0.1:{management_port}:{management_port} "
             f"-v {self.execution_params['tmp_dir']}:/tmp {enable_gpu} -itd {docker_image} "
-            f'"torchserve --start --model-store /home/model-server/model-store --model-api-enabled'
+            f'"torchserve --start --model-store /home/model-server/model-store --model-api-enabled --disable-token'
             f"\--workflow-store /home/model-server/wf-store "
             f"--ts-config /tmp/benchmark/conf/{self.execution_params['config_properties_name']} > "
             f'/tmp/benchmark/logs/model_metrics.log"'

--- a/kubernetes/tests/scripts/test_mnist.sh
+++ b/kubernetes/tests/scripts/test_mnist.sh
@@ -22,7 +22,7 @@ function start_minikube_cluster() {
 
 function build_docker_image() {
     eval $(minikube docker-env)
-    echo "model_api_enabled=true" >> $ROOT_DIR/$EXAMPLE_DIR/../docker/Dockerfile
+    echo "model_api_enabled=true" >> $ROOT_DIR/$EXAMPLE_DIR/../docker/config.properties
     docker system prune -f
     docker build -t $DOCKER_IMAGE --file $ROOT_DIR/$EXAMPLE_DIR/../docker/Dockerfile --build-arg EXAMPLE_DIR="${EXAMPLE_DIR}" .
     eval $(minikube docker-env -u)

--- a/kubernetes/tests/scripts/test_mnist.sh
+++ b/kubernetes/tests/scripts/test_mnist.sh
@@ -23,6 +23,7 @@ function start_minikube_cluster() {
 function build_docker_image() {
     eval $(minikube docker-env)
     echo "model_api_enabled=true" >> $ROOT_DIR/$EXAMPLE_DIR/../docker/config.properties
+    echo "disable_token_authorization=true" >> $ROOT_DIR/$EXAMPLE_DIR/../docker/config.properties
     docker system prune -f
     docker build -t $DOCKER_IMAGE --file $ROOT_DIR/$EXAMPLE_DIR/../docker/Dockerfile --build-arg EXAMPLE_DIR="${EXAMPLE_DIR}" .
     eval $(minikube docker-env -u)

--- a/kubernetes/tests/scripts/test_mnist.sh
+++ b/kubernetes/tests/scripts/test_mnist.sh
@@ -22,6 +22,7 @@ function start_minikube_cluster() {
 
 function build_docker_image() {
     eval $(minikube docker-env)
+    echo "model_api_enabled=true" >> $ROOT_DIR/$EXAMPLE_DIR/../docker/Dockerfile
     docker system prune -f
     docker build -t $DOCKER_IMAGE --file $ROOT_DIR/$EXAMPLE_DIR/../docker/Dockerfile --build-arg EXAMPLE_DIR="${EXAMPLE_DIR}" .
     eval $(minikube docker-env -u)


### PR DESCRIPTION
## Description
Adding `--model-api-enabled` flag to nightly benchmark tests to ensure they run

Adding `model_api_enabled=true` to kubernetes nightly test 
Test: [Kubernetes nightly test](https://github.com/pytorch/serve/actions/runs/9488203897)