### PR TITLE
Fixing docker CI 

### DIFF
--- a/.github/workflows/docker-ci.yaml
+++ b/.github/workflows/docker-ci.yaml
@@ -29,7 +29,7 @@ jobs:
         working-directory: docker
         run: |
           IMAGE_TAG=test-image-${{ matrix.python-version }}
-          ./build_image.sh -py "${{ matrix.python-version }}" -t "${IMAGE_TAG}"
+          ./build_image.sh -py "${{ matrix.python-version }}" -t "${IMAGE_TAG}" -s -r
           echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_OUTPUT
 
       - name: Container Healthcheck
@@ -40,7 +40,7 @@ jobs:
         working-directory: docker
         run: ./test_container_python_version.sh ${{ steps.image_build.outputs.IMAGE_TAG }} ${{ matrix.python-version }}
 
-      - name: Test model running in container with sample image data 
+      - name: Test model running in container with sample image data
         working-directory: docker
         run: |
           ./test_container_model_prediction.sh ${{ steps.image_build.outputs.IMAGE_TAG }}

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -36,7 +36,7 @@ do
           echo "-py, --pythonversion specify to python version to use: Possible values: 3.8 3.9 3.10"
           echo "-n, --nightly specify to build with TorchServe nightly"
           echo "-s, --source specify to build with TorchServe from source"
-          echo "-l, --local specify to use local TorchServe"
+          echo "-r, --remote specify to use local TorchServe"
           exit 0
           ;;
         -b|--branch_name)

--- a/docker/dockerd-entrypoint.sh
+++ b/docker/dockerd-entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 if [[ "$1" = "serve" ]]; then
     shift 1
-    torchserve --start --ts-config /home/model-server/config.properties
+    torchserve --start --ts-config /home/model-server/config.properties --disable-token
 else
     eval "$@"
 fi

--- a/docker/test_container_model_prediction.sh
+++ b/docker/test_container_model_prediction.sh
@@ -19,7 +19,7 @@ torch-model-archiver \
     --handler=/home/model-server/mnist_handler.py \
     --export-path=/home/model-server/model-store
 
-torchserve --start --ts-config=/home/model-server/config.properties --models mnist=mnist.mar
+torchserve --start --ts-config=/home/model-server/config.properties --models mnist=mnist.mar --disable-token
 EOF
 
 echo "Starting container ${CONTAINER}"


### PR DESCRIPTION
## Description
Current Docker CI is using latest TorchServe release rather then the branch that is being merged in. 
Fix by using the `-s ` and `-r` flag that will build TorchServe from the source and use the local branch. 

Also adding '--disable-token` flag for the docker tests to run properly. 

