### PR TITLE
Kserve fix ray & setuptools dependency issue

### DIFF
--- a/.github/workflows/kserve_cpu_tests.yml
+++ b/.github/workflows/kserve_cpu_tests.yml
@@ -1,13 +1,10 @@
 name: KServe CPU Nightly Tests
 
 on:
-  # workflow_dispatch:
-  # # runs everyday  at 5:15am
-  # schedule:
-  #   - cron:  '15 5 * * *'
-  push:
-    branches:
-      - kserve_fix
+  workflow_dispatch:
+  # runs everyday  at 5:15am
+  schedule:
+    - cron:  '15 5 * * *'
 
 jobs:
   kserve-cpu-tests:

--- a/.github/workflows/kserve_cpu_tests.yml
+++ b/.github/workflows/kserve_cpu_tests.yml
@@ -1,10 +1,13 @@
 name: KServe CPU Nightly Tests
 
 on:
-  workflow_dispatch:
-  # runs everyday  at 5:15am
-  schedule:
-    - cron:  '15 5 * * *'
+  # workflow_dispatch:
+  # # runs everyday  at 5:15am
+  # schedule:
+  #   - cron:  '15 5 * * *'
+  push:
+    branches:
+      - kserve_fix
 
 jobs:
   kserve-cpu-tests:

--- a/kubernetes/kserve/requirements.txt
+++ b/kubernetes/kserve/requirements.txt
@@ -1,5 +1,6 @@
 kserve[storage]>=0.12.0
 ray[serve]<=2.9.3,>=2.9.2
+setuptools==69.5.1
 transformers
 captum
 grpcio

--- a/kubernetes/kserve/requirements.txt
+++ b/kubernetes/kserve/requirements.txt
@@ -1,6 +1,5 @@
 kserve[storage]>=0.12.0
-ray[serve]<=2.9.3,>=2.9.2
-setuptools==69.5.1
+ray[serve]>=2.9.2
 transformers
 captum
 grpcio


### PR DESCRIPTION
## Description
Current pinned version of ray is causing dependency issues with newer version of setuptools. Solution is to unpin ray and test to see if the newer release of ray will work. 
