### PR TITLE
Revert "Bump twine from 4.0.2 to 5.1.0"

### DIFF
--- a/requirements/developer.txt
+++ b/requirements/developer.txt
@@ -12,7 +12,7 @@ transformers>=4.34.0
 pyspelling==2.8.2
 pygit2==1.13.3
 pre-commit==3.3.2
-twine==5.1.0
+twine==4.0.2
 mypy==1.3.0
 torchpippy==0.1.1
 intel_extension_for_pytorch==2.3.0; sys_platform != 'win32' and sys_platform != 'darwin' and platform_machine != 'aarch64'


### PR DESCRIPTION
Reverts pytorch/serve#3171

twine upload fails https://github.com/pytorch/serve/actions/runs/9678681051