### PR TITLE
Copy remote branch entrypoint to compile and production image stages

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -78,6 +78,8 @@ RUN \
 
 WORKDIR "serve"
 
+RUN cp docker/dockerd-entrypoint.sh /usr/local/bin/dockerd-entrypoint.sh
+
 RUN \
     if echo "$BASE_IMAGE" | grep -q "cuda:"; then \
         # Install CUDA version specific binary when CUDA version is specified as a build arg
@@ -131,10 +133,8 @@ RUN useradd -m model-server \
     && mkdir -p /home/model-server/tmp
 
 COPY --chown=model-server --from=compile-image /home/venv /home/venv
-
+COPY --from=compile-image /usr/local/bin/dockerd-entrypoint.sh /usr/local/bin/dockerd-entrypoint.sh
 ENV PATH="/home/venv/bin:$PATH"
-
-COPY docker/dockerd-entrypoint.sh /usr/local/bin/dockerd-entrypoint.sh
 
 RUN chmod +x /usr/local/bin/dockerd-entrypoint.sh \
     && chown -R model-server /home/model-server

--- a/docker/build_image.sh
+++ b/docker/build_image.sh
@@ -43,6 +43,7 @@ do
           if test $
           then
             BRANCH_NAME="$2"
+            LOCAL_CHANGES=false
             shift
           else
             echo "Error! branch_name not provided"


### PR DESCRIPTION
## Description

Torchserve docker build with remote branch needs to copy the remote version of entrypoint (`dockerd-entrypoint.sh`) to the image to keep it consistent with the `--branch_name` specified for the build.

Fixes #(issue)
We encountered this issue where the torchserve image is expected from --branch_name v0.11.0 in order to work with pinned torchserve pypi package version, but the current entrypoint is out-of-sync and uses additional flag `--disable-token` from master.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Re-run `bash ./build_image.sh --branch_name v0.11.0 --pythonversion 3.10 --tag test-image` to verify that the newly built image now has `/usr/local/bin/dockerd-entrypoint.sh` from branch v0.11.0 without `--disable-token` set. 
```
% docker run --rm -it --entrypoint bash test-image
model-server@465e40c1ead4:~$ cat /usr/local/bin/dockerd-entrypoint.sh
#!/bin/bash
set -e

if [[ "$1" = "serve" ]]; then
    shift 1
    torchserve --start --ts-config /home/model-server/config.properties
else
    eval "$@"
fi

# prevent docker exit
tail -f /dev/null
```
Also ran without branch name to verify the entrypoint has the new flag.