### PR TITLE
Remove vllm dependency to not bloat docker image size

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -6,4 +6,3 @@ pynvml==11.5.0
 pyyaml==6.0.1
 ninja==1.11.1.1
 setuptools
-vllm==0.5.0; sys_platform == 'linux'


### PR DESCRIPTION
## Description

Removes dependency on vllm to avoid docker size bloat.
This will be addressed after the 0.11.1 release

Fixes #([issue](https://github.com/pytorch/serve/issues/3244))

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B


## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?