### PR TITLE
Implement stateful inference session timeout

### DIFF
--- a/examples/stateful/sequence_batching/Readme.md
+++ b/examples/stateful/sequence_batching/Readme.md
@@ -70,7 +70,7 @@ Handler uses sequenceId (ie., `sequence_id = self.context.get_sequence_id(idx)`)
 ### Step 2: Model configuration
 
 Stateful inference has three parameters. TorchServe is able to process (maxWorkers * batchSize) sequences of inference requests of a model in parallel.
-* sequenceMaxIdleMSec: the max idle in milliseconds of a sequence inference request of this stateful model. The default value is 0 (ie. this is not a stateful model.) TorchServe does not process the new inference request if the max idle timeout.
+* sequenceMaxIdleMSec: the max idle in milliseconds of a sequence inference request of this stateful model. The default value is 0 (i.e. this is not a stateful model.) TorchServe does not process the new inference request if the max idle timeout.
 * sequenceTimeoutMSec: the max duration in milliseconds of a sequence inference request of this stateful model. The default value is 0 (i.e. there is effectively no sequence timeout and the sequence does not expire). TorchServe does not process a new inference request if the sequence timeout is exceeded.
 * maxSequenceJobQueueSize: the job queue size of an inference sequence of this stateful model. The default value is 1.
 

--- a/examples/stateful/sequence_batching/Readme.md
+++ b/examples/stateful/sequence_batching/Readme.md
@@ -69,8 +69,9 @@ Handler uses sequenceId (ie., `sequence_id = self.context.get_sequence_id(idx)`)
 
 ### Step 2: Model configuration
 
-Stateful inference has two parameters. TorchServe is able to process (maxWorkers * batchSize) sequences of inference requests of a model in parallel.
+Stateful inference has three parameters. TorchServe is able to process (maxWorkers * batchSize) sequences of inference requests of a model in parallel.
 * sequenceMaxIdleMSec: the max idle in milliseconds of a sequence inference request of this stateful model. The default value is 0 (ie. this is not a stateful model.) TorchServe does not process the new inference request if the max idle timeout.
+* sequenceTimeoutMSec: the max duration in milliseconds of a sequence inference request of this stateful model. The default value is 0 (ie. there is effectively no sequence timeout and the sequence does not expire). TorchServe does not process a new inference request if the sequence timeout is exceeded.
 * maxSequenceJobQueueSize: the job queue size of an inference sequence of this stateful model. The default value is 1.
 
 

--- a/examples/stateful/sequence_batching/Readme.md
+++ b/examples/stateful/sequence_batching/Readme.md
@@ -71,7 +71,7 @@ Handler uses sequenceId (ie., `sequence_id = self.context.get_sequence_id(idx)`)
 
 Stateful inference has three parameters. TorchServe is able to process (maxWorkers * batchSize) sequences of inference requests of a model in parallel.
 * sequenceMaxIdleMSec: the max idle in milliseconds of a sequence inference request of this stateful model. The default value is 0 (ie. this is not a stateful model.) TorchServe does not process the new inference request if the max idle timeout.
-* sequenceTimeoutMSec: the max duration in milliseconds of a sequence inference request of this stateful model. The default value is 0 (ie. there is effectively no sequence timeout and the sequence does not expire). TorchServe does not process a new inference request if the sequence timeout is exceeded.
+* sequenceTimeoutMSec: the max duration in milliseconds of a sequence inference request of this stateful model. The default value is 0 (i.e. there is effectively no sequence timeout and the sequence does not expire). TorchServe does not process a new inference request if the sequence timeout is exceeded.
 * maxSequenceJobQueueSize: the job queue size of an inference sequence of this stateful model. The default value is 1.
 
 

--- a/examples/stateful/sequence_continuous_batching/Readme.md
+++ b/examples/stateful/sequence_continuous_batching/Readme.md
@@ -139,8 +139,9 @@ Handler uses sequenceId (ie., `sequence_id = self.context.get_sequence_id(idx)`)
 
 ### Step 2: Model configuration
 
-Stateful inference has two parameters. TorchServe is able to process (maxWorkers * batchSize) sequences of inference requests of a model in parallel.
+Stateful inference has three parameters. TorchServe is able to process (maxWorkers * batchSize) sequences of inference requests of a model in parallel.
 * sequenceMaxIdleMSec: the max idle in milliseconds of a sequence inference request of this stateful model. The default value is 0 (ie. this is not a stateful model.) TorchServe does not process the new inference request if the max idle timeout.
+* sequenceTimeoutMSec: the max duration in milliseconds of a sequence inference request of this stateful model. The default value is 0 (ie. there is effectively no sequence timeout and the sequence does not expire). TorchServe does not process a new inference request if the sequence timeout is exceeded.
 * maxSequenceJobQueueSize: the job queue size of an inference sequence of this stateful model. The default value is 1.
 
 

--- a/examples/stateful/sequence_continuous_batching/Readme.md
+++ b/examples/stateful/sequence_continuous_batching/Readme.md
@@ -141,7 +141,7 @@ Handler uses sequenceId (ie., `sequence_id = self.context.get_sequence_id(idx)`)
 
 Stateful inference has three parameters. TorchServe is able to process (maxWorkers * batchSize) sequences of inference requests of a model in parallel.
 * sequenceMaxIdleMSec: the max idle in milliseconds of a sequence inference request of this stateful model. The default value is 0 (ie. this is not a stateful model.) TorchServe does not process the new inference request if the max idle timeout.
-* sequenceTimeoutMSec: the max duration in milliseconds of a sequence inference request of this stateful model. The default value is 0 (ie. there is effectively no sequence timeout and the sequence does not expire). TorchServe does not process a new inference request if the sequence timeout is exceeded.
+* sequenceTimeoutMSec: the max duration in milliseconds of a sequence inference request of this stateful model. The default value is 0 (i.e. there is effectively no sequence timeout and the sequence does not expire). TorchServe does not process a new inference request if the sequence timeout is exceeded.
 * maxSequenceJobQueueSize: the job queue size of an inference sequence of this stateful model. The default value is 1.
 
 

--- a/frontend/archive/src/main/java/org/pytorch/serve/archive/model/ModelConfig.java
+++ b/frontend/archive/src/main/java/org/pytorch/serve/archive/model/ModelConfig.java
@@ -60,6 +60,10 @@ public class ModelConfig {
      */
     private long sequenceMaxIdleMSec;
     /**
+     * the timeout of a sequence inference request of this stateful model. The default value is 0.
+     */
+    private long sequenceTimeoutMSec;
+    /**
      * the job queue size of one inference sequence of this stateful model. The default value is 1.
      */
     private int maxSequenceJobQueueSize = 1;
@@ -194,6 +198,15 @@ public class ModelConfig {
                             } else {
                                 logger.warn(
                                         "Invalid sequenceMaxIdleMSec: {}, should be positive int",
+                                        v);
+                            }
+                            break;
+                        case "sequenceTimeoutMSec":
+                            if (v instanceof Integer) {
+                                modelConfig.setSequenceTimeoutMSec(((Integer) v).longValue());
+                            } else {
+                                logger.warn(
+                                        "Invalid sequenceTimeoutMSec: {}, should be positive int",
                                         v);
                             }
                             break;
@@ -393,6 +406,14 @@ public class ModelConfig {
 
     public void setSequenceMaxIdleMSec(long sequenceMaxIdleMSec) {
         this.sequenceMaxIdleMSec = Math.max(0, sequenceMaxIdleMSec);
+    }
+
+    public long getSequenceTimeoutMSec() {
+        return sequenceTimeoutMSec;
+    }
+
+    public void setSequenceTimeoutMSec(long sequenceTimeoutMSec) {
+        this.sequenceTimeoutMSec = Math.max(0, sequenceTimeoutMSec);
     }
 
     public int getMaxSequenceJobQueueSize() {

--- a/frontend/server/src/main/java/org/pytorch/serve/http/messages/DescribeModelResponse.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/http/messages/DescribeModelResponse.java
@@ -33,6 +33,7 @@ public class DescribeModelResponse {
     private boolean useVenv;
     private boolean stateful;
     private long sequenceMaxIdleMSec;
+    private long sequenceTimeoutMSec;
     private int maxNumSequence;
     private int maxSequenceJobQueueSize;
     private String status;
@@ -221,6 +222,14 @@ public class DescribeModelResponse {
 
     public void setSequenceMaxIdleMSec(long sequenceMaxIdleMSec) {
         this.sequenceMaxIdleMSec = sequenceMaxIdleMSec;
+    }
+
+    public long getSequenceTimeoutMSec() {
+        return sequenceTimeoutMSec;
+    }
+
+    public void setSequenceTimeoutMSec(long sequenceTimeoutMSec) {
+        this.sequenceTimeoutMSec = sequenceTimeoutMSec;
     }
 
     public int getMaxNumSequence() {

--- a/frontend/server/src/main/java/org/pytorch/serve/job/JobGroup.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/job/JobGroup.java
@@ -1,5 +1,6 @@
 package org.pytorch.serve.job;
 
+import java.time.Instant;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -13,13 +14,18 @@ public class JobGroup {
     int maxJobQueueSize;
     AtomicBoolean finished;
     AtomicBoolean polling;
+    Instant expiryTimestamp;
 
-    public JobGroup(String groupId, int maxJobQueueSize) {
+    public JobGroup(String groupId, int maxJobQueueSize, long sequenceTimeoutMSec) {
         this.groupId = groupId;
         this.maxJobQueueSize = maxJobQueueSize;
         this.jobs = new LinkedBlockingDeque<>(maxJobQueueSize);
         this.finished = new AtomicBoolean(false);
         this.polling = new AtomicBoolean(false);
+        this.expiryTimestamp =
+                sequenceTimeoutMSec > 0
+                        ? Instant.now().plusMillis(sequenceTimeoutMSec)
+                        : Instant.MAX;
     }
 
     public boolean appendJob(Job job) {
@@ -52,5 +58,9 @@ public class JobGroup {
 
     public AtomicBoolean getPolling() {
         return this.polling;
+    }
+
+    public Instant getExpiryTimestamp() {
+        return this.expiryTimestamp;
     }
 }

--- a/frontend/server/src/main/java/org/pytorch/serve/util/ApiUtils.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/ApiUtils.java
@@ -414,6 +414,7 @@ public final class ApiUtils {
         resp.setUseVenv(model.isUseVenv());
         resp.setStateful(model.isSequenceBatching());
         resp.setSequenceMaxIdleMSec(model.getSequenceMaxIdleMSec());
+        resp.setSequenceTimeoutMSec(model.getSequenceTimeoutMSec());
         resp.setMaxNumSequence(model.getMaxNumSequence());
         resp.setMaxSequenceJobQueueSize(model.getMaxSequenceJobQueueSize());
 

--- a/frontend/server/src/main/java/org/pytorch/serve/wlm/Model.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/wlm/Model.java
@@ -58,6 +58,7 @@ public class Model {
     private ReentrantLock jobGroupLock;
     private int responseTimeout;
     private long sequenceMaxIdleMSec;
+    private long sequenceTimeoutMSec;
     private int maxNumSequence;
     private int maxSequenceJobQueueSize;
     private boolean stateful;
@@ -129,6 +130,7 @@ public class Model {
             useJobTicket = modelArchive.getModelConfig().isUseJobTicket();
             if (modelArchive.getModelConfig().getSequenceMaxIdleMSec() > 0) {
                 sequenceMaxIdleMSec = modelArchive.getModelConfig().getSequenceMaxIdleMSec();
+                sequenceTimeoutMSec = modelArchive.getModelConfig().getSequenceTimeoutMSec();
                 maxSequenceJobQueueSize =
                         modelArchive.getModelConfig().getMaxSequenceJobQueueSize();
                 maxNumSequence =
@@ -305,7 +307,9 @@ public class Model {
             JobGroup jobGroup = jobGroups.get(job.getGroupId());
             if (jobGroup == null) {
                 if (jobGroups.size() < maxNumSequence) {
-                    jobGroup = new JobGroup(job.getGroupId(), maxSequenceJobQueueSize);
+                    jobGroup =
+                            new JobGroup(
+                                    job.getGroupId(), maxSequenceJobQueueSize, sequenceTimeoutMSec);
                     jobGroups.put(job.getGroupId(), jobGroup);
                     pendingJobGroups.offer(job.getGroupId());
                     logger.info("added jobGroup for sequenceId:{}", job.getGroupId());
@@ -612,6 +616,14 @@ public class Model {
 
     public void setSequenceMaxIdleMSec(long sequenceMaxIdleMSec) {
         this.sequenceMaxIdleMSec = sequenceMaxIdleMSec;
+    }
+
+    public long getSequenceTimeoutMSec() {
+        return sequenceTimeoutMSec;
+    }
+
+    public void setSequenceTimeoutMSec(long sequenceTimeoutMSec) {
+        this.sequenceTimeoutMSec = sequenceTimeoutMSec;
     }
 
     public int getMaxSequenceJobQueueSize() {

--- a/frontend/server/src/main/java/org/pytorch/serve/wlm/SequenceBatching.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/wlm/SequenceBatching.java
@@ -247,7 +247,9 @@ public class SequenceBatching extends BatchAggregator {
             Instant currentTimestamp = Instant.now();
             Instant expiryTimestamp = jobGroup.getExpiryTimestamp();
 
-            if (currentTimestamp.isBefore(expiryTimestamp)) {
+            if (expiryTimestamp == Instant.MAX) {
+                pollTimeout = model.getSequenceMaxIdleMSec();
+            } else if (currentTimestamp.isBefore(expiryTimestamp)) {
                 long remainingPollDuration =
                         Duration.between(currentTimestamp, expiryTimestamp).toMillis();
                 pollTimeout = Math.min(model.getSequenceMaxIdleMSec(), remainingPollDuration);

--- a/frontend/server/src/main/java/org/pytorch/serve/wlm/SequenceBatching.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/wlm/SequenceBatching.java
@@ -1,5 +1,7 @@
 package org.pytorch.serve.wlm;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.concurrent.CompletableFuture;
@@ -224,7 +226,7 @@ public class SequenceBatching extends BatchAggregator {
             AtomicBoolean isPolling = jobGroup.getPolling();
             if (!jobGroup.isFinished()) {
                 if (!isPolling.getAndSet(true)) {
-                    job = jobGroup.pollJob(model.getSequenceMaxIdleMSec());
+                    job = jobGroup.pollJob(getPollJobGroupTimeoutMSec(jobGroup));
                     isPolling.set(false);
                 } else {
                     return;
@@ -238,6 +240,20 @@ public class SequenceBatching extends BatchAggregator {
             } else {
                 jobsQueue.add(job);
             }
+        }
+
+        private long getPollJobGroupTimeoutMSec(JobGroup jobGroup) {
+            long pollTimeout = 0;
+            Instant currentTimestamp = Instant.now();
+            Instant expiryTimestamp = jobGroup.getExpiryTimestamp();
+
+            if (currentTimestamp.isBefore(expiryTimestamp)) {
+                long remainingPollDuration =
+                        Duration.between(currentTimestamp, expiryTimestamp).toMillis();
+                pollTimeout = Math.min(model.getSequenceMaxIdleMSec(), remainingPollDuration);
+            }
+
+            return pollTimeout;
         }
     }
 }

--- a/model-archiver/README.md
+++ b/model-archiver/README.md
@@ -170,7 +170,7 @@ A model config yaml file. For example:
 
 ```
 # TS frontend parameters
-# See all supported parameters: https://github.com/pytorch/serve/blob/688f09ebb8527c184d63bd66ee6265a4609ac194/frontend/archive/src/main/java/org/pytorch/serve/archive/model/ModelConfig.java#L14
+# See all supported parameters: https://github.com/pytorch/serve/blob/master/frontend/archive/src/main/java/org/pytorch/serve/archive/model/ModelConfig.java#L14
 minWorkers: 1 # default: #CPU or #GPU
 maxWorkers: 1 # default: #CPU or #GPU
 batchSize: 1 # default: 1

--- a/test/pytest/test_example_stateful_sequence_continuous_batching_http.py
+++ b/test/pytest/test_example_stateful_sequence_continuous_batching_http.py
@@ -22,7 +22,8 @@ minWorkers: 2
 maxWorkers: 2
 batchSize: 1
 maxNumSequence: 2
-sequenceMaxIdleMSec: 60000
+sequenceMaxIdleMSec: 30000
+sequenceTimeoutMSec: 60000
 maxSequenceJobQueueSize: 10
 sequenceBatching: true
 continuousBatching: true
@@ -263,6 +264,97 @@ def test_infer_stateful_cancel(mar_file_path, model_store):
                 data=str(0).encode(),
             ) as response:
                 assert response.status_code == 200
+
+    finally:
+        test_utils.unregister_model(model_name)
+
+        # Clean up files
+        shutil.rmtree(Path(model_store) / model_name)
+        test_utils.stop_torchserve()
+
+
+def test_infer_stateful_idle_timeout(mar_file_path, model_store):
+    file_name = Path(mar_file_path).name
+    model_name = Path(file_name).stem
+    shutil.copytree(mar_file_path, Path(model_store) / model_name)
+    params = (
+        ("model_name", model_name),
+        ("url", Path(model_store) / model_name),
+        ("initial_workers", "2"),
+        ("synchronous", "true"),
+    )
+
+    test_utils.start_torchserve(
+        model_store=model_store, snapshot_file=CONFIG_PROPERTIES_PATH, gen_mar=False
+    )
+
+    try:
+        test_utils.reg_resp = test_utils.register_model_with_params(params)
+
+        response = requests.post(
+                url=f"http://localhost:8080/predictions/{model_name}",
+                data=str(2).encode()) 
+        response.raise_for_status()
+
+        # Idle for a duration greater than the max session idle time
+        time.sleep(31)
+
+        # Ensure that the session has been automatically cleand up
+        with pytest.raises(requests.exceptions.HTTPError):
+            response = requests.post(
+                url=f"http://localhost:8080/predictions/{model_name}",
+                headers = {"ts_request_sequence_id": response.headers.get("ts_request_sequence_id")},
+                data=str(2).encode())
+            response.raise_for_status()
+
+    finally:
+        test_utils.unregister_model(model_name)
+
+        # Clean up files
+        shutil.rmtree(Path(model_store) / model_name)
+        test_utils.stop_torchserve()
+
+
+def test_infer_stateful_session_timeout(mar_file_path, model_store):
+    file_name = Path(mar_file_path).name
+    model_name = Path(file_name).stem
+    shutil.copytree(mar_file_path, Path(model_store) / model_name)
+    params = (
+        ("model_name", model_name),
+        ("url", Path(model_store) / model_name),
+        ("initial_workers", "2"),
+        ("synchronous", "true"),
+    )
+
+    test_utils.start_torchserve(
+        model_store=model_store, snapshot_file=CONFIG_PROPERTIES_PATH, gen_mar=False
+    )
+
+    try:
+        test_utils.reg_resp = test_utils.register_model_with_params(params)
+
+        response = requests.post(
+                url=f"http://localhost:8080/predictions/{model_name}",
+                data=str(2).encode()) 
+        response.raise_for_status()
+
+        # Idle for a duration greater than the max session timeout
+        start = time.time()
+        while (time.time() - start) < 60:
+            response = requests.post(
+                url=f"http://localhost:8080/predictions/{model_name}",
+                headers = {"ts_request_sequence_id": response.headers.get("ts_request_sequence_id")},
+                data=str(2).encode())
+            response.raise_for_status()
+            time.sleep(2)
+
+        # Ensure that the session has been automatically cleand up
+        with pytest.raises(requests.exceptions.HTTPError):
+            response = requests.post(
+                url=f"http://localhost:8080/predictions/{model_name}",
+                headers = {"ts_request_sequence_id": response.headers.get("ts_request_sequence_id")},
+                data=str(2).encode())
+            response.raise_for_status()
 
     finally:
         test_utils.unregister_model(model_name)

--- a/test/pytest/test_example_stateful_sequence_continuous_batching_http.py
+++ b/test/pytest/test_example_stateful_sequence_continuous_batching_http.py
@@ -292,8 +292,8 @@ def test_infer_stateful_idle_timeout(mar_file_path, model_store):
         test_utils.reg_resp = test_utils.register_model_with_params(params)
 
         response = requests.post(
-                url=f"http://localhost:8080/predictions/{model_name}",
-                data=str(2).encode()) 
+            url=f"http://localhost:8080/predictions/{model_name}", data=str(2).encode()
+        )
         response.raise_for_status()
 
         # Idle for a duration greater than the max session idle time
@@ -303,8 +303,13 @@ def test_infer_stateful_idle_timeout(mar_file_path, model_store):
         with pytest.raises(requests.exceptions.HTTPError):
             response = requests.post(
                 url=f"http://localhost:8080/predictions/{model_name}",
-                headers = {"ts_request_sequence_id": response.headers.get("ts_request_sequence_id")},
-                data=str(2).encode())
+                headers={
+                    "ts_request_sequence_id": response.headers.get(
+                        "ts_request_sequence_id"
+                    )
+                },
+                data=str(2).encode(),
+            )
             response.raise_for_status()
 
     finally:
@@ -334,8 +339,8 @@ def test_infer_stateful_session_timeout(mar_file_path, model_store):
         test_utils.reg_resp = test_utils.register_model_with_params(params)
 
         response = requests.post(
-                url=f"http://localhost:8080/predictions/{model_name}",
-                data=str(2).encode()) 
+            url=f"http://localhost:8080/predictions/{model_name}", data=str(2).encode()
+        )
         response.raise_for_status()
 
         # Idle for a duration greater than the max session timeout
@@ -343,8 +348,13 @@ def test_infer_stateful_session_timeout(mar_file_path, model_store):
         while (time.time() - start) < 60:
             response = requests.post(
                 url=f"http://localhost:8080/predictions/{model_name}",
-                headers = {"ts_request_sequence_id": response.headers.get("ts_request_sequence_id")},
-                data=str(2).encode())
+                headers={
+                    "ts_request_sequence_id": response.headers.get(
+                        "ts_request_sequence_id"
+                    )
+                },
+                data=str(2).encode(),
+            )
             response.raise_for_status()
             time.sleep(2)
 
@@ -352,8 +362,13 @@ def test_infer_stateful_session_timeout(mar_file_path, model_store):
         with pytest.raises(requests.exceptions.HTTPError):
             response = requests.post(
                 url=f"http://localhost:8080/predictions/{model_name}",
-                headers = {"ts_request_sequence_id": response.headers.get("ts_request_sequence_id")},
-                data=str(2).encode())
+                headers={
+                    "ts_request_sequence_id": response.headers.get(
+                        "ts_request_sequence_id"
+                    )
+                },
+                data=str(2).encode(),
+            )
             response.raise_for_status()
 
     finally:

--- a/ts_scripts/spellcheck_conf/wordlist.txt
+++ b/ts_scripts/spellcheck_conf/wordlist.txt
@@ -1128,6 +1128,7 @@ interdependencies
 maxSequenceJobQueueSize
 sequenceId
 sequenceMaxIdleMSec
+sequenceTimeoutMSec
 stateful
 tgz
 bitsandbytes


### PR DESCRIPTION
## Description
Add support for session timeout for stateful inference.

`sequenceTimeoutMSec`: the max duration in milliseconds of a sequence inference request of this stateful model. The default value is 0 (ie. there is effectively no sequence timeout and the sequence does not expire). TorchServe does not process a new inference request if the sequence timeout is exceeded.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Feature/Issue validation/testing
- [ ] `test/pytest/test_example_stateful_sequence_continuous_batching_http.py::test_infer_stateful_idle_timeout`
- [ ] `test/pytest/test_example_stateful_sequence_continuous_batching_http.py::test_infer_stateful_session_timeout`