### PR TITLE
Leave response and sendError when request is canceled

### DIFF
--- a/frontend/server/src/main/java/org/pytorch/serve/job/GRPCJob.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/job/GRPCJob.java
@@ -127,6 +127,8 @@ public class GRPCJob extends Job {
                 ServerCallStreamObserver<PredictionResponse> responseObserver =
                         (ServerCallStreamObserver<PredictionResponse>) predictionResponseObserver;
                 if (cancelHandler(responseObserver)) {
+                    // issue #3087: Leave response early as the request has been canceled.
+                    // Note: trying to continue wil trigger an exception when calling `onNext`.
                     return;
                 }
                 PredictionResponse reply =
@@ -213,6 +215,8 @@ public class GRPCJob extends Job {
                 ServerCallStreamObserver<PredictionResponse> responseObserver =
                         (ServerCallStreamObserver<PredictionResponse>) predictionResponseObserver;
                 if (cancelHandler(responseObserver)) {
+                    // issue #3087: Leave response early as the request has been canceled.
+                    // Note: trying to continue wil trigger an exception when calling `onNext`.
                     return;
                 }
                 if (cmd == WorkerCommands.PREDICT || cmd == WorkerCommands.STREAMPREDICT) {

--- a/frontend/server/src/main/java/org/pytorch/serve/job/GRPCJob.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/job/GRPCJob.java
@@ -139,6 +139,9 @@ public class GRPCJob extends Job {
                                 && responseHeaders
                                         .get(RequestInput.TS_STREAM_NEXT)
                                         .equals("false"))) {
+                    if (cancelHandler(responseObserver)) {
+                        return;
+                    }
                     responseObserver.onCompleted();
                     logQueueTime();
                 } else if (cmd == WorkerCommands.STREAMPREDICT2


### PR DESCRIPTION
## Description

Leave `response` and `sendError` method when `responseObserver` is canceled to avoid continuing on canceled requests.

This was the previous behavior introduced by #2420 and lost during a later refactoring. A similar early return on cancel exists for case `OIPPREDICT` in `response` method.

Fixes #3087 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Feature/Issue validation/testing

To my knowledge, there is no dedicated tests for this issue (it was fixed before and then reintroduced).

Currently trying to figure out how to properly test it.

## Checklist:

- [x] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?