### PR TITLE
Remove compile note for hpu

### DIFF
--- a/examples/pt2/torch_compile_hpu/README.md
+++ b/examples/pt2/torch_compile_hpu/README.md
@@ -41,9 +41,6 @@ cd examples/pt2/torch_compile_hpu
 
 ### 1. Configure torch.compile
 
-`torch.compile` allows various configurations that can influence performance outcomes. Explore different options in the [official PyTorch documentation](https://pytorch.org/docs/stable/generated/torch.compile.html)
-
-
 In this example, we use the following config that is provided in `model-config.yaml` file:
 
 ```bash


### PR DESCRIPTION
## Description

We'd like to remove the note as some options are unsupported, what can be misleading.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] Did you have fun?
