### PR TITLE
Feature add openai api for vllm integration

### DIFF
--- a/examples/large_models/utils/test_llm_streaming_response.py
+++ b/examples/large_models/utils/test_llm_streaming_response.py
@@ -81,7 +81,6 @@ class Predictor(threading.Thread):
             prompt_input["max_tokens"] = rt
             if self.args.demo_streaming:
                 prompt_input["stream"] = True
-            breakpoint()
             return prompt_input
         if self.args.prompt_json:
             prompt_input = json.loads(prompt_input)

--- a/examples/large_models/vllm/llama3/Readme.md
+++ b/examples/large_models/vllm/llama3/Readme.md
@@ -49,5 +49,5 @@ torchserve --start --ncs --ts-config ../config.properties --model-store model_st
 ### Step 5: Run inference
 
 ```bash
-python ../../utils/test_llm_streaming_response.py -o 50 -t 2 -n 4 --prompt-text "@prompt.json" --prompt-json
+python ../../utils/test_llm_streaming_response.py -m llama3-8b -o 50 -t 2 -n 4 --prompt-text "@prompt.json" --prompt-json --openai-api
 ```

--- a/examples/large_models/vllm/llama3/Readme.md
+++ b/examples/large_models/vllm/llama3/Readme.md
@@ -1,6 +1,6 @@
 # Example showing inference with vLLM on LoRA model
 
-This is an example showing how to integrate [vLLM](https://github.com/vllm-project/vllm) with TorchServe and run inference on model `meta-llama/Meta-Llama-3-8B-Instruct` with continuous batching.
+This is an example showing how to integrate [vLLM](https://github.com/vllm-project/vllm) with TorchServe and run inference on model `meta-llama/Meta-Llama-3.1-8B-Instruct` with continuous batching.
 This examples supports distributed inference by following [this instruction](../Readme.md#distributed-inference)
 
 ### Step 0: Install vLLM
@@ -21,7 +21,7 @@ huggingface-cli login --token $HUGGINGFACE_TOKEN
 ```
 
 ```bash
-python ../../utils/Download_model.py --model_path model --model_name meta-llama/Meta-Llama-3-8B-Instruct --use_auth_token True
+python ../../utils/Download_model.py --model_path model --model_name meta-llama/Meta-Llama-3.1-8B-Instruct --use_auth_token True
 ```
 
 ### Step 2: Generate model artifacts
@@ -47,7 +47,12 @@ torchserve --start --ncs --ts-config ../config.properties --model-store model_st
 ```
 
 ### Step 5: Run inference
-
+Run a text completion:
 ```bash
 python ../../utils/test_llm_streaming_response.py -m llama3-8b -o 50 -t 2 -n 4 --prompt-text "@prompt.json" --prompt-json --openai-api
+```
+
+Or use the chat interface:
+```bash
+python ../../utils/test_llm_streaming_response.py -m llama3-8b -o 50 -t 2 -n 4 --prompt-text "@chat.json" --prompt-json --openai-api --demo-streaming --api-endpoint "v1/chat/completions"
 ```

--- a/examples/large_models/vllm/llama3/chat.json
+++ b/examples/large_models/vllm/llama3/chat.json
@@ -1,0 +1,11 @@
+{
+    "model": "llama3-8b",
+    "messages":[
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Who won the world series in 2020?"},
+        {"role": "assistant", "content": "The Los Angeles Dodgers won the World Series in 2020."},
+        {"role": "user", "content": "Where was it played?"}
+    ],
+    "temperature":0.0,
+    "max_tokens": 50
+}

--- a/examples/large_models/vllm/llama3/model-config.yaml
+++ b/examples/large_models/vllm/llama3/model-config.yaml
@@ -11,3 +11,6 @@ handler:
     vllm_engine_config:
         max_num_seqs: 16
         max_model_len: 250
+        served_model_name:
+            - "meta-llama/Meta-Llama-3-8B"
+            - "llama3-8b"

--- a/examples/large_models/vllm/llama3/model-config.yaml
+++ b/examples/large_models/vllm/llama3/model-config.yaml
@@ -7,10 +7,10 @@ deviceType: "gpu"
 asyncCommunication: true
 
 handler:
-    model_path: "model/models--meta-llama--Meta-Llama-3-8B-Instruct/snapshots/e1945c40cd546c78e41f1151f4db032b271faeaa/"
+    model_path: "model/models--meta-llama--Meta-Llama-3.1-8B-Instruct/snapshots/8c22764a7e3675c50d4c7c9a4edb474456022b16"
     vllm_engine_config:
         max_num_seqs: 16
         max_model_len: 250
         served_model_name:
-            - "meta-llama/Meta-Llama-3-8B"
+            - "meta-llama/Meta-Llama-3.1-8B"
             - "llama3-8b"

--- a/examples/large_models/vllm/llama3/prompt.json
+++ b/examples/large_models/vllm/llama3/prompt.json
@@ -1,9 +1,7 @@
 {
   "prompt": "A robot may not injure a human being",
-  "max_new_tokens": 50,
   "temperature": 0.8,
   "logprobs": 1,
-  "prompt_logprobs": 1,
   "max_tokens": 128,
   "adapter": "adapter_1"
 }

--- a/examples/large_models/vllm/llama3/prompt.json
+++ b/examples/large_models/vllm/llama3/prompt.json
@@ -3,5 +3,5 @@
   "temperature": 0.8,
   "logprobs": 1,
   "max_tokens": 128,
-  "adapter": "adapter_1"
+  "model": "llama3-8b"
 }

--- a/examples/large_models/vllm/lora/model-config.yaml
+++ b/examples/large_models/vllm/lora/model-config.yaml
@@ -7,13 +7,17 @@ deviceType: "gpu"
 asyncCommunication: true
 
 handler:
-    model_path: "model/models--meta-llama--Llama-2-7b-chat-hf/snapshots/f5db02db724555f92da89c216ac04704f23d4590/"
+    model_path: "model/models--meta-llama--Meta-Llama-3.1-8B/snapshots/48d6d0fc4e02fb1269b36940650a1b7233035cbb"
     vllm_engine_config:
         enable_lora: true
         max_loras: 4
         max_cpu_loras: 4
+        max_lora_rank: 32
         max_num_seqs: 16
         max_model_len: 250
+        served_model_name:
+            - "meta-llama/Meta-Llama-3.1-8B"
+            - "llama-8b-lora"
 
     adapters:
-        adapter_1: "adapters/model/models--yard1--llama-2-7b-sql-lora-test/snapshots/0dfa347e8877a4d4ed19ee56c140fa518470028c/"
+        adapter_1: "adapters/model/models--llama-duo--llama3.1-8b-summarize-gpt4o-128k/snapshots/4ba83353f24fa38946625c8cc49bf21c80a22825"

--- a/examples/large_models/vllm/lora/prompt.json
+++ b/examples/large_models/vllm/lora/prompt.json
@@ -1,9 +1,7 @@
 {
+  "model": "adapter_1",
   "prompt": "A robot may not injure a human being",
-  "max_new_tokens": 50,
-  "temperature": 0.8,
+  "temperature": 0.0,
   "logprobs": 1,
-  "prompt_logprobs": 1,
-  "max_tokens": 128,
-  "adapter": "adapter_1"
+  "max_tokens": 128
 }

--- a/examples/large_models/vllm/mistral/Readme.md
+++ b/examples/large_models/vllm/mistral/Readme.md
@@ -49,5 +49,5 @@ torchserve --start --ncs --ts-config ../config.properties --model-store model_st
 ### Step 5: Run inference
 
 ```bash
-python ../../utils/test_llm_streaming_response.py -m mistral -o 50 -t 2 -n 4 --prompt-text "@prompt.json" --prompt-json
+python ../../utils/test_llm_streaming_response.py -m mistral -o 50 -t 2 -n 4 --prompt-text "@prompt.json" --prompt-json --openai-api
 ```

--- a/examples/large_models/vllm/mistral/model-config.yaml
+++ b/examples/large_models/vllm/mistral/model-config.yaml
@@ -12,3 +12,5 @@ handler:
         max_model_len: 250
         max_num_seqs: 16
         tensor_parallel_size: 4
+        served_model_name:
+            - "mistral"

--- a/examples/large_models/vllm/mistral/prompt.json
+++ b/examples/large_models/vllm/mistral/prompt.json
@@ -1,8 +1,7 @@
 {
+  "model": "mistral",
   "prompt": "A robot may not injure a human being",
-  "max_new_tokens": 50,
   "temperature": 0.8,
   "logprobs": 1,
-  "prompt_logprobs": 1,
   "max_tokens": 128
 }

--- a/frontend/server/src/main/java/org/pytorch/serve/http/api/rest/InferenceRequestHandler.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/http/api/rest/InferenceRequestHandler.java
@@ -166,6 +166,11 @@ public class InferenceRequestHandler extends HttpRequestHandlerChain {
             modelVersion = segments[3];
         }
         req.headers().add("url_path", "");
+        /**
+         * If url provides more segments as model_name/version we provide these as url_path in the
+         * request header This way users can leverage them in the custom handler to e.g. influence
+         * handler behavior
+         */
         if (segments.length > 4) {
             String joinedSegments =
                     String.join("/", Arrays.copyOfRange(segments, 4, segments.length));

--- a/frontend/server/src/main/java/org/pytorch/serve/http/api/rest/InferenceRequestHandler.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/http/api/rest/InferenceRequestHandler.java
@@ -162,9 +162,16 @@ public class InferenceRequestHandler extends HttpRequestHandlerChain {
 
         String modelVersion = null;
 
-        if (segments.length == 4) {
+        if (segments.length >= 4) {
             modelVersion = segments[3];
         }
+        req.headers().add("url_path", "");
+        if (segments.length > 4) {
+            String joinedSegments =
+                    String.join("/", Arrays.copyOfRange(segments, 4, segments.length));
+            req.headers().add("url_path", joinedSegments);
+        }
+
         req.headers().add("explain", "False");
         if (explain) {
             req.headers().add("explain", "True");

--- a/test/pytest/test_example_vllm.py
+++ b/test/pytest/test_example_vllm.py
@@ -19,6 +19,10 @@ LLAMA_MODEL_PATH = "model/models--meta-llama--Meta-Llama-3.1-8B/snapshots/48d6d0
 
 ADAPTER_PATH = "adapters/model/models--llama-duo--llama3.1-8b-summarize-gpt4o-128k/snapshots/4ba83353f24fa38946625c8cc49bf21c80a22825"
 
+TOKENIZER_CONFIG = LORA_SRC_PATH / LLAMA_MODEL_PATH / "tokenizer_config.json"
+
+CHAT_TEMPLATE = '{{- bos_token }}\n{%- if custom_tools is defined %}\n    {%- set tools = custom_tools %}\n{%- endif %}\n{%- if not tools_in_user_message is defined %}\n    {%- set tools_in_user_message = true %}\n{%- endif %}\n{%- if not date_string is defined %}\n    {%- set date_string = "26 Jul 2024" %}\n{%- endif %}\n{%- if not tools is defined %}\n    {%- set tools = none %}\n{%- endif %}\n\n{#- This block extracts the system message, so we can slot it into the right place. #}\n{%- if messages[0][\'role\'] == \'system\' %}\n    {%- set system_message = messages[0][\'content\']|trim %}\n    {%- set messages = messages[1:] %}\n{%- else %}\n    {%- set system_message = "" %}\n{%- endif %}\n\n{#- System message + builtin tools #}\n{{- "<|start_header_id|>system<|end_header_id|>\\n\\n" }}\n{%- if builtin_tools is defined or tools is not none %}\n    {{- "Environment: ipython\\n" }}\n{%- endif %}\n{%- if builtin_tools is defined %}\n    {{- "Tools: " + builtin_tools | reject(\'equalto\', \'code_interpreter\') | join(", ") + "\\n\\n"}}\n{%- endif %}\n{{- "Cutting Knowledge Date: December 2023\\n" }}\n{{- "Today Date: " + date_string + "\\n\\n" }}\n{%- if tools is not none and not tools_in_user_message %}\n    {{- "You have access to the following functions. To call a function, please respond with JSON for a function call." }}\n    {{- \'Respond in the format {"name": function name, "parameters": dictionary of argument name and its value}.\' }}\n    {{- "Do not use variables.\\n\\n" }}\n    {%- for t in tools %}\n        {{- t | tojson(indent=4) }}\n        {{- "\\n\\n" }}\n    {%- endfor %}\n{%- endif %}\n{{- system_message }}\n{{- "<|eot_id|>" }}\n\n{#- Custom tools are passed in a user message with some extra guidance #}\n{%- if tools_in_user_message and not tools is none %}\n    {#- Extract the first user message so we can plug it in here #}\n    {%- if messages | length != 0 %}\n        {%- set first_user_message = messages[0][\'content\']|trim %}\n        {%- set messages = messages[1:] %}\n    {%- else %}\n        {{- raise_exception("Cannot put tools in the first user message when there\'s no first user message!") }}\n{%- endif %}\n    {{- \'<|start_header_id|>user<|end_header_id|>\\n\\n\' -}}\n    {{- "Given the following functions, please respond with a JSON for a function call " }}\n    {{- "with its proper arguments that best answers the given prompt.\\n\\n" }}\n    {{- \'Respond in the format {"name": function name, "parameters": dictionary of argument name and its value}.\' }}\n    {{- "Do not use variables.\\n\\n" }}\n    {%- for t in tools %}\n        {{- t | tojson(indent=4) }}\n        {{- "\\n\\n" }}\n    {%- endfor %}\n    {{- first_user_message + "<|eot_id|>"}}\n{%- endif %}\n\n{%- for message in messages %}\n    {%- if not (message.role == \'ipython\' or message.role == \'tool\' or \'tool_calls\' in message) %}\n        {{- \'<|start_header_id|>\' + message[\'role\'] + \'<|end_header_id|>\\n\\n\'+ message[\'content\'] | trim + \'<|eot_id|>\' }}\n    {%- elif \'tool_calls\' in message %}\n        {%- if not message.tool_calls|length == 1 %}\n            {{- raise_exception("This model only supports single tool-calls at once!") }}\n        {%- endif %}\n        {%- set tool_call = message.tool_calls[0].function %}\n        {%- if builtin_tools is defined and tool_call.name in builtin_tools %}\n            {{- \'<|start_header_id|>assistant<|end_header_id|>\\n\\n\' -}}\n            {{- "<|python_tag|>" + tool_call.name + ".call(" }}\n            {%- for arg_name, arg_val in tool_call.arguments | items %}\n                {{- arg_name + \'="\' + arg_val + \'"\' }}\n                {%- if not loop.last %}\n                    {{- ", " }}\n                {%- endif %}\n                {%- endfor %}\n            {{- ")" }}\n        {%- else  %}\n            {{- \'<|start_header_id|>assistant<|end_header_id|>\\n\\n\' -}}\n            {{- \'{"name": "\' + tool_call.name + \'", \' }}\n            {{- \'"parameters": \' }}\n            {{- tool_call.arguments | tojson }}\n            {{- "}" }}\n        {%- endif %}\n        {%- if builtin_tools is defined %}\n            {#- This means we\'re in ipython mode #}\n            {{- "<|eom_id|>" }}\n        {%- else %}\n            {{- "<|eot_id|>" }}\n        {%- endif %}\n    {%- elif message.role == "tool" or message.role == "ipython" %}\n        {{- "<|start_header_id|>ipython<|end_header_id|>\\n\\n" }}\n        {%- if message.content is mapping or message.content is iterable %}\n            {{- message.content | tojson }}\n        {%- else %}\n            {{- message.content }}\n        {%- endif %}\n        {{- "<|eot_id|>" }}\n    {%- endif %}\n{%- endfor %}\n{%- if add_generation_prompt %}\n    {{- \'<|start_header_id|>assistant<|end_header_id|>\\n\\n\' }}\n{%- endif %}\n)'
+
 YAML_CONFIG = f"""
 # TorchServe frontend parameters
 minWorkers: 1
@@ -43,6 +47,8 @@ handler:
         tensor_parallel_size: {torch.cuda.device_count()}
         served_model_name:
             - "Meta-Llama-31-8B"
+
+    chat_template: "chat_template.txt"
 
     adapters:
         adapter_1: "{(LORA_SRC_PATH / ADAPTER_PATH).as_posix()}"
@@ -145,6 +151,9 @@ def create_mar_file(work_dir, model_archiver, model_name, request):
     model_config_yaml = Path(work_dir) / "model-config.yaml"
     model_config_yaml.write_text(YAML_CONFIG)
 
+    chat_template_txt = Path(work_dir) / "chat_template.txt"
+    chat_template_txt.write_text(CHAT_TEMPLATE)
+
     config = ModelArchiverConfig(
         model_name=model_name,
         version="1.0",
@@ -155,6 +164,7 @@ def create_mar_file(work_dir, model_archiver, model_name, request):
         runtime="python",
         force=False,
         config_file=model_config_yaml.as_posix(),
+        extra_files=chat_template_txt.as_posix(),
         archive_format="no-archive",
     )
 
@@ -206,13 +216,26 @@ def extract_text(chunk):
     return json.loads(chunk)["choices"][0]["text"]
 
 
+def extract_chat(chunk):
+    if not isinstance(chunk, str):
+        chunk = chunk.decode("utf-8")
+    if chunk.startswith("data:"):
+        chunk = chunk[len("data:") :].split("\n")[0].strip()
+        if chunk.startswith("[DONE]"):
+            return ""
+    try:
+        return json.loads(chunk)["choices"][0].get("message", {})["content"]
+    except KeyError:
+        return json.loads(chunk)["choices"][0].get("delta", {}).get("content", "")
+
+
 @pytest.mark.skipif(**necessary_files_unavailable())
 def test_vllm_lora(model_name):
     """
     Register the model in torchserve
     """
 
-    base_url = f"http://localhost:8080/predictions/{model_name}/1.0/v1"
+    base_url = f"http://localhost:8080/predictions/{model_name}/1.0/v1/completions"
 
     responses = []
 
@@ -242,8 +265,8 @@ def test_vllm_lora(model_name):
 
 @pytest.mark.skipif(**necessary_files_unavailable())
 @pytest.mark.parametrize("stream", [True, False])
-def test_openai_api_streaming(model_name, stream):
-    base_url = f"http://localhost:8080/predictions/{model_name}/1.0/v1"
+def test_openai_api_completions(model_name, stream):
+    base_url = f"http://localhost:8080/predictions/{model_name}/1.0/v1/completions"
 
     data = {
         "model": model_name,
@@ -274,3 +297,40 @@ def test_openai_api_streaming(model_name, stream):
             extract_text(response.text)
             == "! I’m a new blogger and I’m excited to share my thoughts and experiences"
         )
+
+
+@pytest.mark.skipif(**necessary_files_unavailable())
+@pytest.mark.parametrize("stream", [True, False])
+def test_openai_api_chat_complations(model_name, stream):
+    base_url = f"http://localhost:8080/predictions/{model_name}/1.0/v1/chat/completions"
+
+    data = {
+        "model": model_name,
+        "messages": [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Who won the world series in 2020?"},
+            {
+                "role": "assistant",
+                "content": "The Los Angeles Dodgers won the World Series in 2020.",
+            },
+            {"role": "user", "content": "Where was it played?"},
+        ],
+        "temperature": 0.0,
+        "max_tokens": 50,
+        "stream": stream,
+    }
+
+    response = requests.post(base_url, json=data, stream=stream)
+
+    EXPECTED = " The World Series was played in Arlington, Texas. The Dodgers defeated the Tampa Bay Rays in six games."
+    if stream:
+        assert response.headers["Transfer-Encoding"] == "chunked"
+
+        text = ""
+        for chunk in response.iter_content(chunk_size=None):
+            if chunk:
+                text += extract_chat(chunk)
+        assert text.startswith(EXPECTED)
+
+    else:
+        assert extract_chat(response.text).startswith(EXPECTED)

--- a/test/pytest/test_example_vllm.py
+++ b/test/pytest/test_example_vllm.py
@@ -40,6 +40,8 @@ handler:
         max_num_seqs: 16
         max_model_len: 250
         tensor_parallel_size: {torch.cuda.device_count()}
+        served_model_name:
+            - "Llama-2-7b-chat-hf"
 
     adapters:
         adapter_1: "{(LORA_SRC_PATH / ADAPTER_PATH).as_posix()}"
@@ -48,24 +50,24 @@ handler:
 PROMPTS = [
     {
         "prompt": "A robot may not injure a human being",
-        "max_new_tokens": 50,
         "temperature": 0.8,
         "logprobs": 1,
-        "prompt_logprobs": 1,
+        # "prompt_logprobs": 1,
         "max_tokens": 128,
-        "adapter": "adapter_1",
+        "model": "Llama-2-7b-chat-hf",
+        # "model": "adapter_1",
         "stream": True,
     },
     {
         "prompt": "Paris is, ",
-        "max_new_tokens": 50,
         "logprobs": 1,
-        "prompt_logprobs": 1,
+        # "prompt_logprobs": 1,
         "max_tokens": 128,
         "temperature": 0.0,
         "top_k": 1,
         "top_p": 0,
-        "adapter": "adapter_1",
+        "model": "Llama-2-7b-chat-hf",
+        "model": "adapter_1",
         "seed": 42,
         "stream": True,
     },
@@ -126,7 +128,7 @@ def add_paths():
 
 @pytest.fixture(scope="module")
 def model_name():
-    yield "test_lora"
+    yield "Llama-2-7b-chat-hf"
 
 
 @pytest.fixture(scope="module")

--- a/test/pytest/test_example_vllm.py
+++ b/test/pytest/test_example_vllm.py
@@ -119,7 +119,7 @@ def create_mar_file(work_dir, model_archiver, model_name, request):
     config = ModelArchiverConfig(
         model_name=model_name,
         version="1.0",
-        handler=(VLLM_PATH / "base_vllm_handler.py").as_posix(),
+        handler="vllm_handler",
         serialized_file=None,
         export_path=work_dir,
         requirements_file=None,

--- a/test/pytest/test_example_vllm.py
+++ b/test/pytest/test_example_vllm.py
@@ -334,3 +334,18 @@ def test_openai_api_chat_complations(model_name, stream):
 
     else:
         assert extract_chat(response.text).startswith(EXPECTED)
+
+
+@pytest.mark.skipif(**necessary_files_unavailable())
+def test_openai_api_models(model_name):
+    base_url = f"http://localhost:8080/predictions/{model_name}/1.0/v1/models"
+
+    response = requests.post(base_url)
+
+    data = json.loads(response.text)
+
+    models = [m["id"] for m in data["data"]]
+
+    assert model_name in models
+
+    assert "adapter_1" in models

--- a/test/pytest/test_url_path.py
+++ b/test/pytest/test_url_path.py
@@ -1,0 +1,151 @@
+import shutil
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import requests
+import test_utils
+from model_archiver import ModelArchiverConfig
+
+CURR_FILE_PATH = Path(__file__).parent
+REPO_ROOT_DIR = CURR_FILE_PATH.parents[1]
+
+HANDLER_PY = """
+import logging
+import torch
+from ts.torch_handler.base_handler import BaseHandler
+
+logger = logging.getLogger(__file__)
+
+class customHandler(BaseHandler):
+
+    def initialize(self, context):
+        self.context = context
+        pass
+
+    def preprocess(self, data):
+        reqs = []
+        for i in range(len(data)):
+            reqs.append(self.context.get_request_header(i, "url_path"))
+        return reqs
+
+    def inference(self, data):
+        return data
+
+    def postprocess(self, data):
+        return data
+"""
+
+MODEL_CONFIG_YAML = """
+    #frontend settings
+    # TorchServe frontend parameters
+    minWorkers: 1
+    batchSize: 2
+    maxBatchDelay: 2000
+    maxWorkers: 1
+    """
+
+
+@pytest.fixture(scope="module")
+def model_name():
+    yield "some_model"
+
+
+@pytest.fixture(scope="module")
+def work_dir(tmp_path_factory, model_name):
+    return Path(tmp_path_factory.mktemp(model_name))
+
+
+@pytest.fixture(scope="module", name="mar_file_path")
+def create_mar_file(work_dir, model_archiver, model_name):
+    mar_file_path = work_dir.joinpath(model_name + ".mar")
+
+    model_config_yaml_file = work_dir / "model_config.yaml"
+    model_config_yaml_file.write_text(MODEL_CONFIG_YAML)
+
+    handler_py_file = work_dir / "handler.py"
+    handler_py_file.write_text(HANDLER_PY)
+
+    config = ModelArchiverConfig(
+        model_name=model_name,
+        version="1.0",
+        serialized_file=None,
+        model_file=None,
+        handler=handler_py_file.as_posix(),
+        extra_files=None,
+        export_path=work_dir,
+        requirements_file=None,
+        runtime="python",
+        force=False,
+        archive_format="default",
+        config_file=model_config_yaml_file.as_posix(),
+    )
+
+    with patch("archiver.ArgParser.export_model_args_parser", return_value=config):
+        model_archiver.generate_model_archive()
+
+        assert mar_file_path.exists()
+
+        yield mar_file_path.as_posix()
+
+        # Clean up files
+
+    mar_file_path.unlink(missing_ok=True)
+
+    # Clean up files
+
+
+@pytest.fixture(scope="module", name="model_name")
+def register_model(mar_file_path, model_store, torchserve):
+    """
+    Register the model in torchserve
+    """
+    shutil.copy(mar_file_path, model_store)
+
+    file_name = Path(mar_file_path).name
+
+    model_name = Path(file_name).stem
+
+    params = (
+        ("model_name", model_name),
+        ("url", file_name),
+        ("initial_workers", "1"),
+        ("synchronous", "true"),
+        ("batch_size", "2"),
+        ("max_batch_delay", "2000"),
+    )
+
+    test_utils.reg_resp = test_utils.register_model_with_params(params)
+
+    yield model_name
+
+    test_utils.unregister_model(model_name)
+
+
+def test_mnist_template(model_name):
+    response = requests.get(f"http://localhost:8081/models/{model_name}")
+    assert response.status_code == 200, "Describe Failed"
+
+    response = requests.get(
+        f"http://localhost:8080/predictions/{model_name}/1.0/v1/chat/completion",
+        json={"prompt": "Hello world"},
+    )
+
+    url_paths = ["v1/chat/completion", "v1/completion"]
+
+    with ThreadPoolExecutor(max_workers=2) as e:
+        futures = []
+        for p in url_paths:
+
+            def send_file(url):
+                return requests.post(
+                    f"http://localhost:8080/predictions/{model_name}/1.0/" + url,
+                    json={"prompt": "Hello world"},
+                )
+
+            futures += [e.submit(send_file, p)]
+
+    for i, f in enumerate(futures):
+        prediction = f.result()
+        assert prediction.content.decode("utf-8") == url_paths[i], "Wrong prediction"

--- a/test/pytest/test_url_path.py
+++ b/test/pytest/test_url_path.py
@@ -46,13 +46,6 @@ MODEL_CONFIG_YAML = """
     maxWorkers: 1
     """
 
-try:
-    from openai import OpenAI  # noqa
-
-    openai_missing = False
-except ImportError:
-    openai_missing = True
-
 
 @pytest.fixture(scope="module")
 def model_name():
@@ -156,24 +149,3 @@ def test_url_paths(model_name):
     for i, f in enumerate(futures):
         prediction = f.result()
         assert prediction.content.decode("utf-8") == url_paths[i], "Wrong prediction"
-
-
-@pytest.mark.skipif(openai_missing, reason="Could not find OpenAI client")
-def test_openai_api(model_name):
-    from openai import OpenAI
-
-    openai_api_key = "EMPTY"
-    openai_api_base = f"http://localhost:8080/predictions/{model_name}/1.0/v1"
-
-    client = OpenAI(
-        api_key=openai_api_key,
-        base_url=openai_api_base,
-    )
-
-    response = client.completions.create(model=model_name, prompt="Hello world")
-
-    assert response == "v1/completions"
-
-    response = client.chat.completions.create(model=model_name, messages=[])
-
-    assert response == "v1/chat/completions"

--- a/ts/torch_handler/vllm_handler.py
+++ b/ts/torch_handler/vllm_handler.py
@@ -1,20 +1,12 @@
-import json
 import logging
 import pathlib
 import time
+from unittest.mock import MagicMock
 
-from vllm import AsyncEngineArgs, AsyncLLMEngine, SamplingParams
-from vllm.entrypoints.openai.protocol import (
-    CompletionRequest,
-    CompletionResponse,
-    CompletionResponseChoice,
-    CompletionResponseStreamChoice,
-    CompletionStreamResponse,
-    UsageInfo,
-)
+from vllm import AsyncEngineArgs, AsyncLLMEngine
+from vllm.entrypoints.openai.protocol import CompletionRequest, ErrorResponse
 from vllm.entrypoints.openai.serving_completion import OpenAIServingCompletion
 from vllm.entrypoints.openai.serving_engine import LoRAModulePath
-from vllm.lora.request import LoRARequest
 
 from ts.handler_utils.utils import send_intermediate_predict_response
 from ts.torch_handler.base_handler import BaseHandler
@@ -44,9 +36,9 @@ class VLLMHandler(BaseHandler):
         self.adapters = ctx.model_yaml_config.get("handler", {}).get("adapters", {})
         lora_modules = [LoRAModulePath(n, p) for n, p in self.adapters.items()]
 
-        try:
+        if vllm_engine_config.served_model_name:
             served_model_name = vllm_engine_config.served_model_name
-        except (KeyError, TypeError):
+        else:
             served_model_name = [vllm_engine_config.model]
 
         self.completion_service = OpenAIServingCompletion(
@@ -85,16 +77,7 @@ class VLLMHandler(BaseHandler):
         return [self.prepare_completion_request(data)]
 
     async def inference(self, input_batch, context):
-        logger.debug(f"Inputs: {input_batch[0]}")
-        request, params, lora = input_batch[0]
-        prompt = request.prompt
-        stream = request.stream
-        request_id = context.request_ids[0]
-        generator = self.vllm_engine.generate(prompt, params, request_id, lora)
-        request_header = context.get_all_request_header(0)
-        use_openai = request_header.get("url_path", "").startswith("v1/completions")
-
-        from unittest.mock import MagicMock
+        request = input_batch[0]
 
         raw_request = MagicMock()
         raw_request.headers = {}
@@ -108,94 +91,24 @@ class VLLMHandler(BaseHandler):
             raw_request,
         )
 
-        try:
-            async for obj in g:
-                print(f"{obj=}")
-        except:
-            print(f"{g.model_dump()=}")
-
-        text_len = 0
-        async for output in generator:
-            if stream:
-                if not use_openai:
-                    result = {
-                        "text": output.outputs[0].text[text_len:],
-                        "tokens": output.outputs[0].token_ids[-1],
-                    }
-                    result = json.dumps(result)
-                else:
-                    choices = [
-                        CompletionResponseStreamChoice(
-                            index=0,
-                            text=output.outputs[0].text[text_len:],
-                            logprobs=None,
-                            finish_reason=output.outputs[0].finish_reason,
-                            stop_reason=output.outputs[0].stop_reason,
-                        )
-                    ]
-
-                    usage = UsageInfo(
-                        prompt_tokens=0,
-                        completion_tokens=0,
-                        total_tokens=0,
-                    )
-
-                    result = CompletionStreamResponse(
-                        id=request_id,
-                        created=int(time.time()),
-                        model="model_name",
-                        choices=choices,
-                        usage=usage,
-                    )
-                    result = f"data: {result.model_dump_json()}\n\n"
-
-                if not output.finished:
+        if isinstance(g, ErrorResponse):
+            return [g.model_dump()]
+        if request.stream:
+            async for response in g:
+                if response != "data: [DONE]\n\n":
                     send_intermediate_predict_response(
-                        [result], context.request_ids, "Result", 200, context
+                        [response], context.request_ids, "Result", 200, context
                     )
-                text_len = len(output.outputs[0].text)
-
-        if not stream:
-            if not use_openai:
-                result = {
-                    "text": output.outputs[0].text,
-                    "tokens": output.outputs[0].token_ids,
-                }
-                result = json.dumps(result)
-            else:
-                choices = [
-                    CompletionResponseChoice(
-                        index=0,
-                        text=output.outputs[0].text,
-                        logprobs=None,
-                    )
-                ]
-
-                usage = UsageInfo(
-                    prompt_tokens=0,
-                    completion_tokens=0,
-                    total_tokens=0,
-                )
-
-                result = CompletionResponse(
-                    id=request_id,
-                    created=int(time.time()),
-                    model="model_name",
-                    choices=choices,
-                    usage=usage,
-                )
-                result = result.model_dump_json()
-
-        return [result]
+            return [response]
+        else:
+            return [g.model_dump()]
 
     async def postprocess(self, inference_outputs):
         return inference_outputs
 
     def prepare_completion_request(self, request_data):
-        lora_request = self._get_lora_request(request_data)
-        sampling_params = self._get_sampling_params(request_data)
         request = CompletionRequest.model_validate(request_data)
-        return request, sampling_params, lora_request
+        return request  # , sampling_params, lora_request
 
     def _get_vllm_engine_config(self, handler_config: dict):
         vllm_engine_params = handler_config.get("vllm_engine_config", {})
@@ -218,28 +131,8 @@ class VLLMHandler(BaseHandler):
         self._set_attr_value(vllm_engine_config, vllm_engine_params)
         return vllm_engine_config
 
-    def _get_sampling_params(self, req_data: dict):
-        sampling_params = SamplingParams()
-        self._set_attr_value(sampling_params, req_data)
-
-        return sampling_params
-
-    def _get_lora_request(self, req_data: dict):
-        adapter_name = req_data.get("lora_adapter", "")
-
-        if len(adapter_name) > 0:
-            adapter_path = self.adapters.get(adapter_name, "")
-            assert len(adapter_path) > 0, f"{adapter_name} misses adapter path"
-            lora_id = self.lora_ids.setdefault(adapter_name, len(self.lora_ids) + 1)
-            adapter_path = str(pathlib.Path(self.model_dir).joinpath(adapter_path))
-            return LoRARequest(adapter_name, lora_id, adapter_path)
-
-        return None
-
     def _set_attr_value(self, obj, config: dict):
         items = vars(obj)
-        keys = list(config.keys())
-        for k in keys:
+        for k, v in config.items():
             if k in items:
-                setattr(obj, k, config[k])
-                del config[k]
+                setattr(obj, k, v)

--- a/ts_scripts/spellcheck_conf/wordlist.txt
+++ b/ts_scripts/spellcheck_conf/wordlist.txt
@@ -1297,3 +1297,5 @@ photorealistic
 miniconda
 torchaudio
 ln
+OpenAI
+openai


### PR DESCRIPTION
## Description
This PR enables OpenAI compatible api for vllm integration.
It removes the previous undefined interface for llms served through vllm engine.

New interface can be used like OpenAI endpoint:
Curl:
```bash
curl --header "Content-Type: application/json"   --request POST   --data @prompt.json http://localhost:8080/predictions/llama-8b-lora/1.0/v1/completions
```

Python + Request:
```bash
 python ../../utils/test_llm_streaming_response.py -m llama-8b-lora -o 50 -t 2 -n 4 --prompt-text "@prompt.json" --prompt-json --openai-api --demo-streaming
 ```

OpenAI client:
```python
from openai import OpenAI
model_name = "llama-8b-lora"
stream=True
openai_api_key = "EMPTY"
openai_api_base = f"http://localhost:8080/predictions/{model_name}/1.0/v1"

client = OpenAI(
    api_key=openai_api_key,
    base_url=openai_api_base,
)

response = client.completions.create(
    model=model_name, prompt="Hello world", temperature=0.0, stream=stream
)
for chunk in reponse:
    print(f"{chunk=}")
```

Supported and planned APIs:
- [X] "/v1/completions"
- [x] "/v1/chat/completions"
- [x] "/v1/models"

## Type of change

Please delete options that are not relevant.

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [X] ```pytest test/pytest/test_example_vllm.py```
Logs for Test A:
```
========================================================================================================================================================================== test session starts ===========================================================================================================================================================================
platform linux -- Python 3.11.9, pytest-7.3.1, pluggy-1.0.0
rootdir: /home/ubuntu/serve
plugins: cov-4.1.0, anyio-4.4.0, mock-3.14.0
collected 6 items

test/pytest/test_example_vllm.py 2024-08-17T04:04:33,713 [INFO ] W-29500-Meta-Llama-31-8B_1.0-stdout MODEL_LOG - INFO 08-17 04:04:33 chat_utils.py:90]
2024-08-17T04:04:33,713 [INFO ] W-29500-Meta-Llama-31-8B_1.0-stdout MODEL_LOG - INFO 08-17 04:04:33 chat_utils.py:90] {%- for message in messages %}
2024-08-17T04:04:33,713 [INFO ] W-29500-Meta-Llama-31-8B_1.0-stdout MODEL_LOG - INFO 08-17 04:04:33 chat_utils.py:90]     {%- if not (message.role == 'ipython' or message.role == 'tool' or 'tool_calls' in message) %}
2024-08-17T04:04:33,713 [INFO ] W-29500-Meta-Llama-31-8B_1.0-stdout MODEL_LOG - INFO 08-17 04:04:33 chat_utils.py:90]         {{- '<|start_header_id|>' + message['role'] + '<|end_header_id|>\n\n'+ message['content'] | trim + '<|eot_id|>' }}
2024-08-17T04:04:33,713 [INFO ] W-29500-Meta-Llama-31-8B_1.0-stdout MODEL_LOG - INFO 08-17 04:04:33 chat_utils.py:90]     {%- elif 'tool_calls' in message %}
2024-08-17T04:04:33,713 [INFO ] W-29500-Meta-Llama-31-8B_1.0-stdout MODEL_LOG - INFO 08-17 04:04:33 chat_utils.py:90]         {%- if not message.tool_calls|length == 1 %}
.2024-08-17T04:04:39,102 [INFO ] epollEventLoopGroup-5-1 TS_METRICS - ts_queue_latency_microseconds.Microseconds:0.0|#model_name:Meta-Llama-31-8B,model_version:1.0|#hostname:ip-172-31-3-46,timestamp:1723867479
2024-08-17T04:04:39,102 [DEBUG] epollEventLoopGroup-5-1 org.pytorch.serve.job.RestJob - Waiting time ns: 0, Backend time ns: 989658222
2024-08-17T04:04:39,102 [INFO ] epollEventLoopGroup-5-1 TS_METRICS - QueueTime.Milliseconds:0.0|#Level:Host|#hostname:ip-172-31-3-46,timestamp:1723867479
.2024-08-17T04:04:40,098 [INFO ] epollEventLoopGroup-5-1 TS_METRICS - QueueTime.Milliseconds:0.0|#Level:Host|#hostname:ip-172-31-3-46,timestamp:1723867480
.2024-08-17T04:04:43,200 [DEBUG] epollEventLoopGroup-5-1 org.pytorch.serve.job.RestJob - Waiting time ns: 0, Backend time ns: 3093682692
2024-08-17T04:04:43,200 [INFO ] epollEventLoopGroup-5-1 TS_METRICS - QueueTime.Milliseconds:0.0|#Level:Host|#hostname:ip-172-31-3-46,timestamp:1723867483
...                                                                                                                                                                                                                                                                                                                            [100%]

============================================================================================================================================================================ warnings summary ============================================================================================================================================================================
../miniconda3/envs/serve/lib/python3.11/site-packages/pyairports/airports.py:1
  /home/ubuntu/miniconda3/envs/serve/lib/python3.11/site-packages/pyairports/airports.py:1: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    from pkg_resources import resource_string

../miniconda3/envs/serve/lib/python3.11/site-packages/pkg_resources/__init__.py:2832
  /home/ubuntu/miniconda3/envs/serve/lib/python3.11/site-packages/pkg_resources/__init__.py:2832: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('ruamel')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================================================================================================================== 6 passed, 2 warnings in 28.55s =====================================================================================================================================================================
```

## Checklist:

- [X] Did you have fun?
- [X] Have you added tests that prove your fix is effective or that this feature works?
- [X] Has code been commented, particularly in hard-to-understand areas?
- [X] Have you made corresponding changes to the documentation?