### PR TITLE
Example to demonstrate building a custom endpoint plugin

### DIFF
--- a/examples/custom_endpoint_plugin/ModelReady.java
+++ b/examples/custom_endpoint_plugin/ModelReady.java
@@ -1,0 +1,54 @@
+package org.pytorch.serve.plugins.endpoint;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.pytorch.serve.servingsdk.Context;
+import org.pytorch.serve.servingsdk.Model;
+import org.pytorch.serve.servingsdk.ModelServerEndpoint;
+import org.pytorch.serve.servingsdk.Worker;
+import org.pytorch.serve.servingsdk.annotations.Endpoint;
+import org.pytorch.serve.servingsdk.annotations.helpers.EndpointTypes;
+import org.pytorch.serve.servingsdk.http.Request;
+import org.pytorch.serve.servingsdk.http.Response;
+
+@Endpoint(
+        urlPattern = "model-ready",
+        endpointType = EndpointTypes.INFERENCE,
+        description = "Endpoint indicating registered model/s ready to serve inference requests")
+public class ModelReady extends ModelServerEndpoint {
+    private boolean modelsLoaded(Context ctx) {
+        Map<String, Model> modelMap = ctx.getModels();
+
+        for (Map.Entry<String, Model> entry : modelMap.entrySet()) {
+            boolean workerReady = false;
+            for (Worker w : entry.getValue().getModelWorkers()) {
+                if (w.isRunning()) {
+                    workerReady = true;
+                    break;
+                }
+            }
+            if (!workerReady) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public void doGet(Request req, Response rsp, Context ctx) throws IOException {
+        if (modelsLoaded(ctx)) {
+            rsp.setStatus(200, "Model/s ready");
+            rsp.getOutputStream()
+                    .write(
+                            "{\n\t\"Status\": \"Model/s ready\"\n}\n"
+                                    .getBytes(StandardCharsets.UTF_8));
+        } else {
+            rsp.setStatus(503, "Model/s not ready");
+            rsp.getOutputStream()
+                    .write(
+                            "{\n\t\"Status\": \"Model/s not ready\"\n}\n"
+                                    .getBytes(StandardCharsets.UTF_8));
+        }
+    }
+}

--- a/examples/custom_endpoint_plugin/ModelReady.java
+++ b/examples/custom_endpoint_plugin/ModelReady.java
@@ -20,6 +20,10 @@ public class ModelReady extends ModelServerEndpoint {
     private boolean modelsLoaded(Context ctx) {
         Map<String, Model> modelMap = ctx.getModels();
 
+        if (modelMap.isEmpty()) {
+            return false;
+        }
+
         for (Map.Entry<String, Model> entry : modelMap.entrySet()) {
             boolean workerReady = false;
             for (Worker w : entry.getValue().getModelWorkers()) {

--- a/examples/custom_endpoint_plugin/README.md
+++ b/examples/custom_endpoint_plugin/README.md
@@ -1,0 +1,112 @@
+# Torchserve custom endpoint plugin
+
+In this example, we demonstrate how to create a custom HTTP API endpoint plugin for TorchServe. Endpoint plugins enable us to dynamically add custom functionality to TorchServe at start time, without having to rebuild the entire TorchServe codebase. For more details on endpoint plugins and TorchServe SDK, refer to the following links:
+- [Plugins Readme](https://github.com/pytorch/serve/tree/master/plugins)
+- [TorchServe SDK source](https://github.com/pytorch/serve/tree/master/serving-sdk)
+
+In this example, we will build an endpoint plugin that implements the functionality of a HTTP API endpoint that reports the readiness of models registered on TorchServe to serve inference requests.
+
+Run the commands given in the following steps from the root directory of the repository. For example, if you cloned the repository into `/home/my_path/serve`, run the steps from `/home/my_path/serve`
+
+## Steps
+
+- Step 1: Install the necessary dependencies for TorchServe development environment
+
+  ```bash
+  $ python ts_scripts/install_dependencies.py --environment=dev
+  ```
+
+- Step 2: Copy [ModelReady.java](ModelReady.java) to the endpoint plugins directory
+
+  ```bash
+  $ cp examples/custom_endpoint_plugin/ModelReady.java plugins/endpoints/src/main/java/org/pytorch/serve/plugins/endpoint
+  ```
+  Review the utilization of the [TorchServe SDK API](https://github.com/pytorch/serve/tree/master/serving-sdk) in [ModelReady.java](ModelReady.java) to implement the necessary functionality for the HTTP API endpoint.
+
+- Step 3: Copy [org.pytorch.serve.servingsdk.ModelServerEndpoint](org.pytorch.serve.servingsdk.ModelServerEndpoint) to the plugins service provider configuration directory
+
+  ```bash
+  $ cp examples/custom_endpoint_plugin/org.pytorch.serve.servingsdk.ModelServerEndpoint plugins/endpoints/src/main/resources/META-INF/services
+  ```
+
+- Step 4: Update the [endpoint plugins build script](../../plugins/endpoints/build.gradle) to only include the required plugins in the JAR
+
+  ```bash
+  .....
+  .....
+  /**
+   * By default, include all endpoint plugins in the JAR.
+   * In order to build a custom JAR with specific endpoint plugins, specify the required paths.
+   * For example:
+   * include "org/pytorch/serve/plugins/endpoint/Ping*"
+   * include "org/pytorch/serve/plugins/endpoint/ExecutionParameters*"
+   */
+  include "org/pytorch/serve/plugins/endpoint/ModelReady*"
+  .....
+  .....
+  ```
+
+- Step 5: Build the custom endpoint plugin
+
+  ```bash
+  $ cd plugins
+  $ ./gradlew clean build
+  $ cd ..
+  ``` 
+
+- Step 6: Create an example model archive to test the plugin with
+
+  ```bash
+  $ torch-model-archiver --model-name mnist --version 1.0 --model-file examples/image_classifier/mnist/mnist.py --serialized-file examples/image_classifier/mnist/mnist_cnn.pt --handler  examples/image_classifier/mnist/mnist_handler.py
+  $ mkdir -p model_store
+  $ cp mnist.mar ./model_store 
+  ```
+
+- Step 7: Start Torchserve with the appropriate plugins path containing the JAR we just built
+
+  ```bash
+  $ torchserve --ncs --start --model-store ./model_store --disable-token-auth --enable-model-api --plugins-path ./plugins/endpoints/build/libs
+  ```
+
+- Step 8: Register the model and test the custom endpoint
+
+  ```bash
+  $ curl -X POST  "http://localhost:8081/models?url=mnist.mar"
+  {
+    "status": "Model \"mnist\" Version: 1.0 registered with 0 initial workers. Use scale workers API to add workers for the model."
+  }
+  ```
+
+  ```bash
+  $ curl -X GET http://localhost:8080/model-ready
+  {
+    "Status": "Model/s not ready"
+  }
+  ```
+
+  The `model-ready` endpoint reports that the model is not ready since there are no workers that have loaded the model and ready to serve inference requests.
+
+- Step 9: Scale up workers and test the custom endpoint again
+  
+  ```bash
+  $ curl -X PUT "http://localhost:8081/models/mnist?min_worker=1&synchronous=true"
+  {
+    "status": "Workers scaled to 1 for model: mnist"
+  }
+  ```
+
+  ```bash
+  $ curl -X GET http://localhost:8080/model-ready
+  {
+    "Status": "Model/s ready"
+  }
+  ```
+
+  The `model-ready` endpoint reports that the model is now ready since there is atleast one worker that has loaded the model and is ready to serve inference requests.
+
+- Step 10: Stop TorchServe
+
+  ```bash
+  $ torchserve --stop
+  ```
+

--- a/examples/custom_endpoint_plugin/README.md
+++ b/examples/custom_endpoint_plugin/README.md
@@ -1,6 +1,6 @@
 # Torchserve custom endpoint plugin
 
-In this example, we demonstrate how to create a custom HTTP API endpoint plugin for TorchServe. Endpoint plugins enable us to dynamically add custom functionality to TorchServe at start time, without having to rebuild the entire TorchServe codebase. For more details on endpoint plugins and TorchServe SDK, refer to the following links:
+In this example, we demonstrate how to create a custom HTTP API endpoint plugin for TorchServe. Endpoint plugins enable us to dynamically add custom functionality to TorchServe at start time, without having to rebuild TorchServe. For more details on endpoint plugins and TorchServe SDK, refer to the following links:
 - [Plugins Readme](https://github.com/pytorch/serve/tree/master/plugins)
 - [TorchServe SDK source](https://github.com/pytorch/serve/tree/master/serving-sdk)
 

--- a/examples/custom_endpoint_plugin/README.md
+++ b/examples/custom_endpoint_plugin/README.md
@@ -21,7 +21,7 @@ Run the commands given in the following steps from the root directory of the rep
   ```bash
   $ cp examples/custom_endpoint_plugin/ModelReady.java plugins/endpoints/src/main/java/org/pytorch/serve/plugins/endpoint
   ```
-  Review the utilization of the [TorchServe SDK API](https://github.com/pytorch/serve/tree/master/serving-sdk) in [ModelReady.java](ModelReady.java) to implement the necessary functionality for the HTTP API endpoint.
+  For reference on implemeting your own custom plugin, review the utilization of the [TorchServe SDK API](https://github.com/pytorch/serve/tree/master/serving-sdk/src/main/java/org/pytorch/serve/servingsdk) and its corresponding [implementation](https://github.com/pytorch/serve/tree/master/frontend/server/src/main/java/org/pytorch/serve/servingsdk/impl) in [ModelReady.java](ModelReady.java).
 
 - Step 3: Copy [org.pytorch.serve.servingsdk.ModelServerEndpoint](org.pytorch.serve.servingsdk.ModelServerEndpoint) to the plugins service provider configuration directory
 

--- a/examples/custom_endpoint_plugin/org.pytorch.serve.servingsdk.ModelServerEndpoint
+++ b/examples/custom_endpoint_plugin/org.pytorch.serve.servingsdk.ModelServerEndpoint
@@ -1,0 +1,1 @@
+org.pytorch.serve.plugins.endpoint.ModelReady

--- a/plugins/endpoints/build.gradle
+++ b/plugins/endpoints/build.gradle
@@ -22,8 +22,15 @@ jar {
     exclude "META-INF/MANIFEST*"
     exclude "META-INF//LICENSE*"
     exclude "META-INF//NOTICE*"
-    exclude "org/pytorch/serve/plugins/endpoint/ExecutionParameters*" // Comment out if ExecutionParameter endpoint is needed
-    exclude "org/pytorch/serve/plugins/endpoint/Ping*" // Comment out if Ping endpoint is needed
+    include "META-INF/services/*"
+    /**
+     * By default, include all endpoint plugins in the JAR.
+     * In order to build a custom JAR with specific endpoint plugins, specify the required paths.
+     * For example:
+     * include "org/pytorch/serve/plugins/endpoint/Ping*"
+     * include "org/pytorch/serve/plugins/endpoint/ExecutionParameters*"
+     */
+    include "org/pytorch/serve/plugins/endpoint/*"
 }
 
 java {

--- a/plugins/endpoints/src/main/resources/META-INF/services/org.pytorch.serve.servingsdk.ModelServerEndpoint
+++ b/plugins/endpoints/src/main/resources/META-INF/services/org.pytorch.serve.servingsdk.ModelServerEndpoint
@@ -1,0 +1,2 @@
+org.pytorch.serve.plugins.endpoint.ExecutionParameters
+org.pytorch.serve.plugins.endpoint.Ping


### PR DESCRIPTION
## Description
Add an example to demonstrate building a custom endpoint plugin which reports model ready status to serve inference requests.

## Type of change
- [x] This change requires a documentation update

## Feature/Issue validation/testing
- [ ] Readme includes the steps and the outputs seen as a result