### PR TITLE
typo fixes in HF Transformers example

### DIFF
--- a/examples/Huggingface_Transformers/Transformer_handler_generalized.py
+++ b/examples/Huggingface_Transformers/Transformer_handler_generalized.py
@@ -154,7 +154,7 @@ class TransformersSeqClassifierHandler(BaseHandler):
         self.initialized = True
 
     def preprocess(self, requests):
-        """Basic text preprocessing, based on the user's chocie of application mode.
+        """Basic text preprocessing, based on the user's choice of application mode.
         Args:
             requests (str): The Input data in the form of text is passed on to the preprocess
             function.
@@ -193,14 +193,14 @@ class TransformersSeqClassifierHandler(BaseHandler):
 
             # preprocessing text for question_answering.
             elif self.setup_config["mode"] == "question_answering":
-                # TODO Reading the context from a pickeled file or other fromats that
+                # TODO Reading the context from a pickled file or other formats that
                 # fits the requirements of the task in hand. If this is done then need to
                 # modify the following preprocessing accordingly.
 
                 # the sample text for question_answering in the current version
-                # should be formated as dictionary with question and text as keys
+                # should be formatted as dictionary with question and text as keys
                 # and related text as values.
-                # we use this format here seperate question and text for encoding.
+                # we use this format here separate question and text for encoding.
 
                 question_context = ast.literal_eval(input_text)
                 question = question_context["question"]
@@ -215,7 +215,7 @@ class TransformersSeqClassifierHandler(BaseHandler):
                 )
             input_ids = inputs["input_ids"].to(self.device)
             attention_mask = inputs["attention_mask"].to(self.device)
-            # making a batch out of the recieved requests
+            # making a batch out of the received requests
             # attention masks are passed for cases where input tokens are padded.
             if input_ids.shape is not None:
                 if input_ids_batch is None:
@@ -486,7 +486,7 @@ def captum_sequence_forward(inputs, attention_mask=None, position=0, model=None)
 
 
 def summarize_attributions(attributions):
-    """Summarises the attribution across multiple runs
+    """Summarizes the attribution across multiple runs
     Args:
         attributions ([list): attributions from the Layer Integrated Gradients
     Returns:


### PR DESCRIPTION
## Description

Typo fixes in docstrings and comments.

I noticed these while reading the code so thought I would open a quick PR.

Note once change from Summarises -> Summarizes. While the first isn't wrong per se (British English vs. American English), it doesn't match the spelling in the actual function name.

Fixes #(issue)

## Type of change

Just typo fixes


## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

No testing as just typo fixes.

## Checklist:

- [X] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?