### PR TITLE
torchao quantization integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,23 @@ Refer to [torchserve docker](docker/README.md) for details.
 ### 🤖 Quick Start LLM Deployment
 
 ```bash
+# Make sure to install torchserve with pip or conda as described above and login with `huggingface-cli login`
+python -m ts.llm_launcher --model_id meta-llama/Meta-Llama-3-8B-Instruct --disable_token_auth
+
+# Try it out
+curl -X POST -d '{"model":"meta-llama/Meta-Llama-3-8B-Instruct", "prompt":"Hello, my name is", "max_tokens": 200}' --header "Content-Type: application/json" "http://localhost:8080/predictions/model/1.0/v1/completions"
+```
+
+### 🚢 Quick Start LLM Deployment with Docker
+
+```bash
 #export token=<HUGGINGFACE_HUB_TOKEN>
 docker build --pull . -f docker/Dockerfile.llm -t ts/llm
 
 docker run --rm -ti --shm-size 10g --gpus all -e HUGGING_FACE_HUB_TOKEN=$token -p 8080:8080 -v data:/data ts/llm --model_id meta-llama/Meta-Llama-3-8B-Instruct --disable_token_auth
 
-curl -X POST -d '{"prompt":"Hello, my name is", "max_new_tokens": 50}' --header "Content-Type: application/json" "http://localhost:8080/predictions/model"
+# Try it out
+curl -X POST -d '{"model":"meta-llama/Meta-Llama-3-8B-Instruct", "prompt":"Hello, my name is", "max_tokens": 200}' --header "Content-Type: application/json" "http://localhost:8080/predictions/model/1.0/v1/completions"
 ```
 
 Refer to [LLM deployment](docs/llm_deployment.md) for details and other methods.

--- a/examples/pt2/torchao/quantization/README.md
+++ b/examples/pt2/torchao/quantization/README.md
@@ -81,7 +81,7 @@ produces the output
 
 ## torchao Affine Quantization
 
-Affine Quantization refers to the type of quantization that maps from high precision floating point numbers to quantized numbers (low precision integer or floating point dtype) with an affine transformation. You can find addtional details [here](https://github.com/pytorch/ao/blob/main/torchao/quantization/README.md#affine-quantization) In the example below, we use `int8_weight_only` quantization
+Affine Quantization refers to the type of quantization that maps from high precision floating point numbers to quantized numbers (low precision integer or floating point dtype) with an Affine transformation. You can find additional details [here](https://github.com/pytorch/ao/blob/main/torchao/quantization/README.md#affine-quantization) In the example below, we use `int8_weight_only` quantization
 
 In this example , we use the following config
 

--- a/examples/pt2/torchao/quantization/README.md
+++ b/examples/pt2/torchao/quantization/README.md
@@ -1,0 +1,106 @@
+
+# TorchServe inference with torchao optimizations
+
+This example shows how to take eager model of `ResNet50`, configure TorchServe to use `torch.compile`, using PyTorch native quantization using [`torchao`](https://github.com/pytorch/ao) and run inference
+
+
+## Pre-requisites
+
+- `PyTorch >= 2.4`
+- `CUDA` enabled device
+- `torchao` [installed](https://github.com/pytorch/ao?tab=readme-ov-file#installation)
+
+Change directory to the examples directory
+Ex:  `cd  examples/pt2/torchao/quantization`
+
+
+## torchao autoquant API
+
+`torchao.autoquant` first identifies the shapes of the activations that the different linear layers see, it then benchmarks these shapes across different types of quantized and non-quantized layers in order to pick the fastest one, attempting to take into account fusions where possible. Finally once the best class is found for each layer, it swaps the linear. You can find addtional details [here](https://github.com/pytorch/ao/blob/main/torchao/quantization/README.md#autoquantization)
+
+In this example , we use the following config
+
+```
+minWorkers: 1
+maxWorkers: 1
+responseTimeout: 600
+handler:
+  profile: True
+pt2:
+  compile:
+    enable: True
+    backend: inductor
+    mode: max-autotune
+  ao:
+    enable: True
+    autoquant:
+      enable: True > model-config.yaml
+```
+
+By default torch.autoquant uses `int8` quantization. You can specify `int4` quantization using the following config
+
+```
+pt2:
+  ao:
+    enable: True
+    autoquant:
+      enable: True
+      qtensor_class_list: DEFAULT_INT4_AUTOQUANT_CLASS_LIST
+```
+
+### Create model archive
+
+```
+wget https://download.pytorch.org/models/resnet50-11ad3fa6.pth
+mkdir model_store
+torch-model-archiver --model-name resnet-50 --version 1.0 --model-file model.py   --serialized-file resnet50-11ad3fa6.pth --export-path model_store   --extra-files ../../image_classifier/index_to_name.json --handler image_classifier   --config-file model-config.yaml -f
+```
+
+#### Start TorchServe
+```
+torchserve --start --ncs --model-store model_store --models resnet-50.mar --disable-token-auth --enable-model-api
+```
+
+#### Run Inference
+
+```
+curl http://127.0.0.1:8080/predictions/resnet-50 -T ../../../image_classifier/kitten.jpg
+```
+
+produces the output
+
+```
+{
+  "tabby": 0.4664836823940277,
+  "tiger_cat": 0.4645617604255676,
+  "Egyptian_cat": 0.06619937717914581,
+  "lynx": 0.0012969186063855886,
+  "plastic_bag": 0.00022856894065625966
+}
+```
+
+## torchao affine quantization
+
+Affine quantization refers to the type of quantization that maps from high precision floating point numbers to quantized numbers (low precision integer or floating point dtypes) with an affine transformation. You can find addtional details [here](https://github.com/pytorch/ao/blob/main/torchao/quantization/README.md#affine-quantization) In the example below, we use `int8_weight_only` quantization
+
+In this example , we use the following config
+
+```
+minWorkers: 1
+maxWorkers: 1
+responseTimeout: 600
+handler:
+  profile: True
+pt2:
+  compile:
+    enable: True
+    backend: inductor
+    mode: max-autotune
+  ao:
+    enable: True
+    quantize:
+      enable: True
+      quant_api: int8_weight_only > model-config.yaml
+```
+
+The rest of the steps to create a model archive and run inference are the same as shown above.

--- a/examples/pt2/torchao/quantization/README.md
+++ b/examples/pt2/torchao/quantization/README.md
@@ -53,7 +53,7 @@ pt2:
 ```
 wget https://download.pytorch.org/models/resnet50-11ad3fa6.pth
 mkdir model_store
-torch-model-archiver --model-name resnet-50 --version 1.0 --model-file model.py   --serialized-file resnet50-11ad3fa6.pth --export-path model_store   --extra-files ../../image_classifier/index_to_name.json --handler image_classifier   --config-file model-config.yaml -f
+torch-model-archiver --model-name resnet-50 --version 1.0 --model-file model.py   --serialized-file resnet50-11ad3fa6.pth --export-path model_store   --extra-files ../../../image_classifier/index_to_name.json --handler image_classifier   --config-file model-config.yaml -f
 ```
 
 #### Start TorchServe

--- a/examples/pt2/torchao/quantization/README.md
+++ b/examples/pt2/torchao/quantization/README.md
@@ -16,7 +16,7 @@ Ex:  `cd  examples/pt2/torchao/quantization`
 
 ## torchao autoquant API
 
-`torchao.autoquant` first identifies the shapes of the activations that the different linear layers see, it then benchmarks these shapes across different types of quantized and non-quantized layers in order to pick the fastest one, attempting to take into account fusions where possible. Finally once the best class is found for each layer, it swaps the linear. You can find addtional details [here](https://github.com/pytorch/ao/blob/main/torchao/quantization/README.md#autoquantization)
+`torchao.autoquant` first identifies the shapes of the activations that the different linear layers see, it then benchmarks these shapes across different types of quantized and non-quantized layers in order to pick the fastest one, attempting to take into account fusions where possible. Finally once the best class is found for each layer, it swaps the linear. You can find additional details [here](https://github.com/pytorch/ao/blob/main/torchao/quantization/README.md#autoquantization)
 
 In this example , we use the following config
 
@@ -71,17 +71,17 @@ produces the output
 
 ```
 {
-  "tabby": 0.4664836823940277,
-  "tiger_cat": 0.4645617604255676,
-  "Egyptian_cat": 0.06619937717914581,
-  "lynx": 0.0012969186063855886,
-  "plastic_bag": 0.00022856894065625966
+  "tabby": 0.2691785991191864,
+  "tiger_cat": 0.13622364401817322,
+  "Egyptian_cat": 0.04588942974805832,
+  "lynx": 0.0032150563783943653,
+  "lens_cap": 0.0023105053696781397
 }
 ```
 
-## torchao affine quantization
+## torchao Affine Quantization
 
-Affine quantization refers to the type of quantization that maps from high precision floating point numbers to quantized numbers (low precision integer or floating point dtypes) with an affine transformation. You can find addtional details [here](https://github.com/pytorch/ao/blob/main/torchao/quantization/README.md#affine-quantization) In the example below, we use `int8_weight_only` quantization
+Affine Quantization refers to the type of quantization that maps from high precision floating point numbers to quantized numbers (low precision integer or floating point dtype) with an affine transformation. You can find addtional details [here](https://github.com/pytorch/ao/blob/main/torchao/quantization/README.md#affine-quantization) In the example below, we use `int8_weight_only` quantization
 
 In this example , we use the following config
 

--- a/examples/pt2/torchao/quantization/model-config.yaml
+++ b/examples/pt2/torchao/quantization/model-config.yaml
@@ -1,0 +1,14 @@
+minWorkers: 1
+maxWorkers: 1
+responseTimeout: 600
+handler:
+  profile: True
+pt2:
+  compile:
+    enable: True
+    backend: inductor
+    mode: max-autotune
+  ao:
+    enable: True
+    autoquant:
+      enable: True

--- a/examples/pt2/torchao/quantization/model.py
+++ b/examples/pt2/torchao/quantization/model.py
@@ -1,0 +1,6 @@
+from torchvision.models.resnet import Bottleneck, ResNet
+
+
+class ImageClassifier(ResNet):
+    def __init__(self):
+        super(ImageClassifier, self).__init__(Bottleneck, [3, 4, 6, 3])

--- a/test/pytest/test_example_torchao.py
+++ b/test/pytest/test_example_torchao.py
@@ -1,0 +1,91 @@
+import os
+import sys
+from pathlib import Path
+
+import packaging.version
+import pytest
+import torch
+
+from ts.torch_handler.image_classifier import ImageClassifier
+from ts.torch_handler.unit_tests.test_utils.mock_context import MockContext
+from ts.utils.util import load_label_mapping
+from ts_scripts.utils import try_and_handle
+
+CURR_FILE_PATH = Path(__file__).parent.absolute()
+REPO_ROOT_DIR = CURR_FILE_PATH.parents[1]
+EXAMPLE_ROOT_DIR = REPO_ROOT_DIR.joinpath("examples", "pt2", "torchao", "quantization")
+TEST_DATA = REPO_ROOT_DIR.joinpath("examples", "image_classifier", "kitten.jpg")
+MAPPING_DATA = REPO_ROOT_DIR.joinpath(
+    "examples", "image_classifier", "index_to_name.json"
+)
+MODEL_PTH_FILE = "resnet50-11ad3fa6.pth"
+MODEL_FILE = "model.py"
+MODEL_YAML_CFG_FILE = EXAMPLE_ROOT_DIR.joinpath("model-config.yaml")
+
+
+PT24_AVAILABLE = (
+    True
+    if packaging.version.parse(torch.__version__) > packaging.version.parse("2.4")
+    else False
+)
+
+EXPECTED_RESULTS = ["tabby", "tiger_cat", "Egyptian_cat", "lynx", "lens_cap"]
+
+
+@pytest.fixture(scope="function")
+def chdir_example(monkeypatch):
+    # Change directory to example directory
+    monkeypatch.chdir(EXAMPLE_ROOT_DIR)
+    monkeypatch.syspath_prepend(EXAMPLE_ROOT_DIR)
+    yield
+
+    # Teardown
+    monkeypatch.undo()
+
+    # Delete imported model
+    model = MODEL_FILE.split(".")[0]
+    if model in sys.modules:
+        del sys.modules[model]
+
+
+@pytest.mark.skipif(PT24_AVAILABLE == False, reason="torch version is < 2.4")
+@pytest.mark.skipif(
+    not ((torch.cuda.device_count() > 0) and torch.cuda.is_available()),
+    reason="Test to be run on GPU only",
+)
+@pytest.mark.skip(reason="Skipping till we have the next stable release of torchao")
+def test_torchao_inference(chdir_example):
+    # Download weights
+    if not os.path.isfile(EXAMPLE_ROOT_DIR.joinpath(MODEL_PTH_FILE)):
+        try_and_handle(
+            f"wget https://download.pytorch.org/models/{MODEL_PTH_FILE} -P {EXAMPLE_ROOT_DIR}"
+        )
+
+    # Handler for Image classification
+    handler = ImageClassifier()
+
+    # Context definition
+    ctx = MockContext(
+        model_pt_file=MODEL_PTH_FILE,
+        model_dir=EXAMPLE_ROOT_DIR.as_posix(),
+        model_file=MODEL_FILE,
+        model_yaml_config_file=MODEL_YAML_CFG_FILE,
+    )
+
+    torch.manual_seed(42 * 42)
+    handler.initialize(ctx)
+    handler.context = ctx
+    handler.mapping = load_label_mapping(MAPPING_DATA)
+
+    data = {}
+    with open(TEST_DATA, "rb") as image:
+        image_file = image.read()
+        byte_array_type = bytearray(image_file)
+        data["body"] = byte_array_type
+
+    result = handler.handle([data], ctx)
+
+    labels = list(result[0].keys())
+
+    # Checking sorted list as a workarfound for https://github.com/pytorch/serve/issues/3189
+    assert sorted(labels) == sorted(EXPECTED_RESULTS)

--- a/ts/torch_handler/base_handler.py
+++ b/ts/torch_handler/base_handler.py
@@ -58,6 +58,11 @@ if packaging.version.parse(torch.__version__) > packaging.version.parse("2.2.2")
 else:
     PT230_AVAILABLE = False
 
+if packaging.version.parse(torch.__version__) > packaging.version.parse("2.4.0"):
+    PT240_AVAILABLE = True
+else:
+    PT240_AVAILABLE = False
+
 try:
     import openvino.torch  # nopycln: import
 
@@ -289,7 +294,7 @@ class BaseHandler(abc.ABC):
                 logger.warning(e)
 
         # Check for torchao optimizations
-        if PT2_AVAILABLE and "ao" in pt2_value:
+        if PT240_AVAILABLE and "ao" in pt2_value:
             ao_options = pt2_value["ao"]
             if ao_options.get("enable", False) == True:
                 if "autoquant" in ao_options:

--- a/ts/torch_handler/base_handler.py
+++ b/ts/torch_handler/base_handler.py
@@ -234,7 +234,7 @@ class BaseHandler(abc.ABC):
         else:
             raise RuntimeError("No model weights could be loaded")
 
-        pt2_value = None
+        pt2_value = {}
         if hasattr(self, "model_yaml_config") and "pt2" in self.model_yaml_config:
             pt2_value = self.model_yaml_config["pt2"]
 

--- a/ts_scripts/spellcheck_conf/wordlist.txt
+++ b/ts_scripts/spellcheck_conf/wordlist.txt
@@ -1299,3 +1299,8 @@ torchaudio
 ln
 OpenAI
 openai
+Affine
+activations
+autoquant
+torchao
+dtype


### PR DESCRIPTION
## Description

This PR shows integration of `torchao` quantization with TorchServe
- Adds support for autoquant API
- Adds support for affine quantization
- Added pytest but skipping it till we have the next stable release ( to include in developer.txt)

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

```
(torchserve) ubuntu@ip-172-31-4-205:~/serve/test/pytest$ pytest -v test_example_torchao.py 
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.10.0, pytest-7.3.1, pluggy-1.5.0 -- /home/ubuntu/anaconda3/envs/torchserve/bin/python
cachedir: .pytest_cache
rootdir: /home/ubuntu/serve
plugins: cov-4.1.0, timeout-2.3.1, mock-3.14.0
collected 1 item                                                                                                                                                       

test_example_torchao.py::test_torchao_inference PASSED                                                                                                           [100%]

=========================================================================== warnings summary ===========================================================================
test/pytest/test_example_torchao.py::test_torchao_inference
  /home/ubuntu/anaconda3/envs/torchserve/lib/python3.10/site-packages/ts/torch_handler/base_handler.py:386: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
    state_dict = torch.load(model_pt_path, map_location=map_location)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================================== 1 passed, 1 warning in 15.32s =====================================================================
```

## Checklist:

- [ ] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?