### PR TITLE
Set vllm multiproc method to spawn

### DIFF
--- a/ts/torch_handler/vllm_handler.py
+++ b/ts/torch_handler/vllm_handler.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 import pathlib
 import time
 from unittest.mock import MagicMock
@@ -40,6 +41,8 @@ class VLLMHandler(BaseHandler):
         vllm_engine_config = self._get_vllm_engine_config(
             ctx.model_yaml_config.get("handler", {})
         )
+        
+        os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
         self.vllm_engine = AsyncLLMEngine.from_engine_args(vllm_engine_config)
 

--- a/ts/torch_handler/vllm_handler.py
+++ b/ts/torch_handler/vllm_handler.py
@@ -41,7 +41,7 @@ class VLLMHandler(BaseHandler):
         vllm_engine_config = self._get_vllm_engine_config(
             ctx.model_yaml_config.get("handler", {})
         )
-        
+
         os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
         self.vllm_engine = AsyncLLMEngine.from_engine_args(vllm_engine_config)


### PR DESCRIPTION
## Description
This PR changes the vllm method to create their workers from fork to spawn to avoid an issue where vllm tries to reinitialize the CUDA context


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Feature/Issue validation/testing

Please describe the Unit or Integration tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
Logs for Test A

- [ ] Test B
Logs for Test B


## Checklist:

- [X] Did you have fun?
