### PR TITLE
Fix typo: "a asynchronous" -> "an asynchronous"

### DIFF
--- a/frontend/server/src/main/java/org/pytorch/serve/openapi/OpenApiUtils.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/openapi/OpenApiUtils.java
@@ -350,8 +350,8 @@ public final class OpenApiUtils {
             operationId = "version_unregisterModel";
         } else {
             operationDescription =
-                    "Unregister the default version of a model from TorchServe if it is the only version available."
-                            + "This is a asynchronous call by default. Caller can call listModels to confirm model is unregistered";
+                    "Unregister the default version of a model from TorchServe if it is the only version available. "
+                            + "This is an asynchronous call by default. Caller can call listModels to confirm model is unregistered.";
             operationId = "unregisterModel";
         }
         Operation operation = new Operation(operationId, operationDescription);
@@ -482,12 +482,12 @@ public final class OpenApiUtils {
         if (version) {
             operationDescription =
                     "Configure number of workers for a specified version of a model. "
-                            + "This is a asynchronous call by default. Caller need to call describeModel to check if the model workers has been changed.";
+                            + "This is an asynchronous call by default. Caller need to call describeModel to check if the model workers has been changed.";
             operationId = "version_setAutoScale";
         } else {
             operationDescription =
-                    "Configure number of workers for a default version of a model."
-                            + "This is a asynchronous call by default. Caller need to call describeModel to check if the model workers has been changed.";
+                    "Configure number of workers for a default version of a model. "
+                            + "This is an asynchronous call by default. Caller need to call describeModel to check if the model workers has been changed.";
             operationId = "setAutoScale";
         }
 

--- a/frontend/server/src/main/resources/proto/management.proto
+++ b/frontend/server/src/main/resources/proto/management.proto
@@ -111,12 +111,12 @@ service ManagementAPIsService {
     // Register a new model in TorchServe.
     rpc RegisterModel(RegisterModelRequest) returns (ManagementResponse) {}
 
-    // Configure number of workers for a default version of a model.This is a asynchronous call by default. Caller need to call describeModel to check if the model workers has been changed.
+    // Configure number of workers for a default version of a model. This is an asynchronous call by default. Caller need to call describeModel to check if the model workers has been changed.
     rpc ScaleWorker(ScaleWorkerRequest) returns (ManagementResponse) {}
 
     // Set default version of a model
     rpc SetDefault(SetDefaultRequest) returns (ManagementResponse) {}
 
-    // Unregister the default version of a model from TorchServe if it is the only version available.This is a asynchronous call by default. Caller can call listModels to confirm model is unregistered
+    // Unregister the default version of a model from TorchServe if it is the only version available. This is an asynchronous call by default. Caller can call listModels to confirm model is unregistered.
     rpc UnregisterModel(UnregisterModelRequest) returns (ManagementResponse) {}
 }

--- a/frontend/server/src/test/resources/management_open_api.json
+++ b/frontend/server/src/test/resources/management_open_api.json
@@ -666,7 +666,7 @@
         }
       },
       "put": {
-        "description": "Configure number of workers for a default version of a model.This is a asynchronous call by default. Caller need to call describeModel to check if the model workers has been changed.",
+        "description": "Configure number of workers for a default version of a model. This is an asynchronous call by default. Caller need to call describeModel to check if the model workers has been changed.",
         "operationId": "setAutoScale",
         "parameters": [
           {
@@ -877,7 +877,7 @@
         }
       },
       "delete": {
-        "description": "Unregister the default version of a model from TorchServe if it is the only version available.This is a asynchronous call by default. Caller can call listModels to confirm model is unregistered",
+        "description": "Unregister the default version of a model from TorchServe if it is the only version available. This is an asynchronous call by default. Caller can call listModels to confirm model is unregistered.",
         "operationId": "unregisterModel",
         "parameters": [
           {
@@ -1254,7 +1254,7 @@
         }
       },
       "put": {
-        "description": "Configure number of workers for a specified version of a model. This is a asynchronous call by default. Caller need to call describeModel to check if the model workers has been changed.",
+        "description": "Configure number of workers for a specified version of a model. This is an asynchronous call by default. Caller need to call describeModel to check if the model workers has been changed.",
         "operationId": "version_setAutoScale",
         "parameters": [
           {

--- a/frontend/server/src/test/resources/model_management_api.json
+++ b/frontend/server/src/test/resources/model_management_api.json
@@ -211,7 +211,7 @@
         }
       },
       "put": {
-        "description": "Configure number of workers for a default version of a model.This is a asynchronous call by default. Caller need to call describeModel to check if the model workers has been changed.",
+        "description": "Configure number of workers for a default version of a model. This is an asynchronous call by default. Caller need to call describeModel to check if the model workers has been changed.",
         "operationId": "setAutoScale",
         "parameters": [
           {
@@ -422,7 +422,7 @@
         }
       },
       "delete": {
-        "description": "Unregister the default version of a model from TorchServe if it is the only version available.This is a asynchronous call by default. Caller can call listModels to confirm model is unregistered",
+        "description": "Unregister the default version of a model from TorchServe if it is the only version available. This is an asynchronous call by default. Caller can call listModels to confirm model is unregistered.",
         "operationId": "unregisterModel",
         "parameters": [
           {
@@ -799,7 +799,7 @@
         }
       },
       "put": {
-        "description": "Configure number of workers for a specified version of a model. This is a asynchronous call by default. Caller need to call describeModel to check if the model workers has been changed.",
+        "description": "Configure number of workers for a specified version of a model. This is an asynchronous call by default. Caller need to call describeModel to check if the model workers has been changed.",
         "operationId": "version_setAutoScale",
         "parameters": [
           {


### PR DESCRIPTION
## Description

Simple typo fix in the openapi specs:
- "a asynchronous" -> "an asynchronous"
- Insert space between two sentences
- Add period at the end of some sentences

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

n/a


## Checklist:

- [x] Did you have fun?
- [ ] Have you added tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?