### PR TITLE
Add Apple system metrics support

### DIFF
--- a/frontend/server/src/main/java/org/pytorch/serve/device/utils/AppleUtil.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/device/utils/AppleUtil.java
@@ -5,10 +5,9 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.pytorch.serve.device.Accelerator;
 import org.pytorch.serve.device.AcceleratorVendor;
 import org.pytorch.serve.device.interfaces.IAcceleratorUtility;
@@ -75,15 +74,12 @@ public class AppleUtil implements IAcceleratorUtility, IJsonSmiParser {
                         .getAsJsonObject() // Gets the outer object
                         .get("SPDisplaysDataType") // Gets the "SPDisplaysDataType" element
                         .getAsJsonArray();
-        JsonObject gpuObject = displaysArray.get(0).getAsJsonObject();
-        int number_of_cores = Integer.parseInt(gpuObject.get("sppci_cores").getAsString());
 
-        // add the object `number_of_cores` times to maintain the exsisitng
-        // functionality
-        accelerators =
-                IntStream.range(0, number_of_cores)
-                        .mapToObj(i -> gpuObject)
-                        .collect(Collectors.toList());
+        JsonObject gpuObject = displaysArray.get(0).getAsJsonObject();
+
+        // Create list with only a single accelerator object as
+        // M1, M2, M3 Macs have only single integrated GPU
+        accelerators = Collections.singletonList(gpuObject);
 
         return accelerators;
     }

--- a/frontend/server/src/test/java/org/pytorch/serve/ModelServerTest.java
+++ b/frontend/server/src/test/java/org/pytorch/serve/ModelServerTest.java
@@ -1373,8 +1373,17 @@ public class ModelServerTest {
             Assert.assertTrue(++count < 5);
         }
 
-        // 7 system-level metrics + 2 gpu-specific metrics
-        Assert.assertEquals(metrics.size(), 7 + 2 * configManager.getNumberOfGpu());
+        // Determine if the device is Apple or not
+        String vendor = System.getProperty("os.name");
+        if (vendor != null) {
+            if (vendor.startsWith("Mac")) {
+                // 7 system-level metrics + 2 gpu-specific metrics (per GPU) for Apple devices
+                Assert.assertEquals(metrics.size(), 7 + 2 * configManager.getNumberOfGpu());
+            } else {
+                // 7 system-level metrics + 3 gpu-specific metrics (per GPU) for non-Apple devices
+                Assert.assertEquals(metrics.size(), 7 + 3 * configManager.getNumberOfGpu());
+            }
+        }
 
         for (Metric metric : metrics) {
             String metricName = metric.getMetricName();

--- a/frontend/server/src/test/java/org/pytorch/serve/ModelServerTest.java
+++ b/frontend/server/src/test/java/org/pytorch/serve/ModelServerTest.java
@@ -1351,7 +1351,8 @@ public class ModelServerTest {
         Map<String, Map<String, String>> expectedMetrics = new HashMap<>();
         expectedMetrics.put("GPUMemoryUtilization", Map.of(UNIT, "Percent", LEVEL, HOST));
         expectedMetrics.put("GPUMemoryUsed", Map.of(UNIT, "Megabytes", LEVEL, HOST));
-        expectedMetrics.put("GPUUtilization", Map.of(UNIT, "Percent", LEVEL, HOST));
+        // torch.mps does not allow to calculate GPUUtilization, see ts/metrics/system_metrics.py
+        // expectedMetrics.put("GPUUtilization", Map.of(UNIT, "Percent", LEVEL, HOST));
         expectedMetrics.put("CPUUtilization", Map.of(UNIT, "Percent", LEVEL, HOST));
         expectedMetrics.put("MemoryUsed", Map.of(UNIT, "Megabytes", LEVEL, HOST));
         expectedMetrics.put("MemoryAvailable", Map.of(UNIT, "Megabytes", LEVEL, HOST));
@@ -1372,8 +1373,8 @@ public class ModelServerTest {
             Assert.assertTrue(++count < 5);
         }
 
-        // 7 system-level metrics + 3 gpu-specific metrics
-        Assert.assertEquals(metrics.size(), 7 + 3 * configManager.getNumberOfGpu());
+        // 7 system-level metrics + 2 gpu-specific metrics
+        Assert.assertEquals(metrics.size(), 7 + 2 * configManager.getNumberOfGpu());
 
         for (Metric metric : metrics) {
             String metricName = metric.getMetricName();

--- a/frontend/server/src/test/java/org/pytorch/serve/ModelServerTest.java
+++ b/frontend/server/src/test/java/org/pytorch/serve/ModelServerTest.java
@@ -1351,8 +1351,7 @@ public class ModelServerTest {
         Map<String, Map<String, String>> expectedMetrics = new HashMap<>();
         expectedMetrics.put("GPUMemoryUtilization", Map.of(UNIT, "Percent", LEVEL, HOST));
         expectedMetrics.put("GPUMemoryUsed", Map.of(UNIT, "Megabytes", LEVEL, HOST));
-        // torch.mps does not allow to calculate GPUUtilization, see ts/metrics/system_metrics.py
-        // expectedMetrics.put("GPUUtilization", Map.of(UNIT, "Percent", LEVEL, HOST));
+        expectedMetrics.put("GPUUtilization", Map.of(UNIT, "Percent", LEVEL, HOST));
         expectedMetrics.put("CPUUtilization", Map.of(UNIT, "Percent", LEVEL, HOST));
         expectedMetrics.put("MemoryUsed", Map.of(UNIT, "Megabytes", LEVEL, HOST));
         expectedMetrics.put("MemoryAvailable", Map.of(UNIT, "Megabytes", LEVEL, HOST));

--- a/frontend/server/src/test/java/org/pytorch/serve/device/utils/AppleUtilTest.java
+++ b/frontend/server/src/test/java/org/pytorch/serve/device/utils/AppleUtilTest.java
@@ -76,7 +76,7 @@ public class AppleUtilTest {
     public void testExtractAccelerators() {
         List<JsonObject> accelerators = appleUtil.extractAccelerators(sampleOutputJson);
 
-        assertEquals(accelerators.size(), 7);
+        assertEquals(accelerators.size(), 1);
         assertEquals(accelerators.get(0).get("sppci_model").getAsString(), "Apple M1");
     }
 
@@ -88,7 +88,7 @@ public class AppleUtilTest {
         ArrayList<Accelerator> updatedAccelerators =
                 appleUtil.smiOutputToUpdatedAccelerators(sampleOutputJson.toString(), parsedGpuIds);
 
-        assertEquals(updatedAccelerators.size(), 7);
+        assertEquals(updatedAccelerators.size(), 1);
         Accelerator accelerator = updatedAccelerators.get(0);
         assertEquals(accelerator.getAcceleratorModel(), "Apple M1");
         assertEquals(accelerator.getVendor(), AcceleratorVendor.APPLE);
@@ -112,7 +112,7 @@ public class AppleUtilTest {
         ArrayList<Accelerator> availableAccelerators =
                 spyAppleUtil.getAvailableAccelerators(availableAcceleratorIds);
 
-        assertEquals(availableAccelerators.size(), 7);
+        assertEquals(availableAccelerators.size(), 1);
         Accelerator accelerator = availableAccelerators.get(0);
         assertEquals(accelerator.getAcceleratorModel(), "Apple M1");
         assertEquals(accelerator.getVendor(), AcceleratorVendor.APPLE);

--- a/frontend/server/src/test/java/org/pytorch/serve/util/ConfigManagerTest.java
+++ b/frontend/server/src/test/java/org/pytorch/serve/util/ConfigManagerTest.java
@@ -118,7 +118,8 @@ public class ConfigManagerTest {
         String mac_arm64_cpu_only = System.getenv().getOrDefault("TS_MAC_ARM64_CPU_ONLY", "False");
         if (arch.equals("aarch64")) {
             if (mac_arm64_cpu_only.equals("True")) {
-                Assert.assertEquals(configManager.getNumberOfGpu(), 0);
+                // Mac M1 returns 1 accelerator device
+                Assert.assertEquals(configManager.getNumberOfGpu(), 1);
             } else {
                 Assert.assertTrue(configManager.getNumberOfGpu() > 0);
             }

--- a/ts/metrics/system_metrics.py
+++ b/ts/metrics/system_metrics.py
@@ -88,6 +88,20 @@ def collect_gpu_metrics(num_of_gpus):
                     amdsmi.amdsmi_shut_down()
                 except amdsmi.AmdSmiException as e:
                     logging.error("Could not shut down AMD-SMI library.")
+        elif torch.backends.mps.is_available():
+            try:
+                total_memory = torch.mps.driver_allocated_memory()
+                mem_used = torch.mps.current_allocated_memory()
+                gpu_mem_utilization = (
+                    (mem_used / total_memory * 100) if total_memory > 0 else 0
+                )
+                # Currently there is no way to calculate GPU utilization with MPS.
+                gpu_utilization = None
+            except Exception as e:
+                logging.error(f"Could not capture MPS memory metrics")
+                mem_used = 0
+                gpu_mem_utilization = 0
+                gpu_utilization = None
 
         dimension_gpu = [
             Dimension("Level", "Host"),


### PR DESCRIPTION
## Description

Backend system metrics lacks support for `torch.mps` accelerator devices. This PR will add those changes and modify frontend code to handle Apple M1 GPU as single accelerator device to fix issues with frontend tests and make Accelerator class definition to be more consistent across hardware vendors.

Fixes #3376

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Feature/Issue validation/testing

- [x] Frontend test

```
> ./frontend/gradlew -p frontend clean build

...

BUILD SUCCESSFUL
```

## Checklist:

- [x] Did you have fun?
- [x] Have you added tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?