### PR TITLE
Tags in tj-actions/changed-files are compromised

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v41.0.0
+        uses: tj-actions/changed-files@d6e91a2266cdb9d62096cebf1e8546899c6aa18f # v45.0.6
         with:
           files: |
             **/*.md


### PR DESCRIPTION
The tags in tj-actions/changed-files action are compromised and are leaking GitHub secrets in repos using the compromised repo. This pins the action to a known good hash.

https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised
