### PR TITLE
3416 Add RBLN(Rebellions) accelerator vendor

### DIFF
--- a/docs/hardware_support/hardware_support.rst
+++ b/docs/hardware_support/hardware_support.rst
@@ -6,3 +6,4 @@
   linux_aarch64
   nvidia_mps
   Intel Extension for PyTorch <https://github.com/pytorch/serve/tree/master/examples/intel_extension_for_pytorch>
+  rbln_support

--- a/docs/hardware_support/rbln_support.md
+++ b/docs/hardware_support/rbln_support.md
@@ -1,0 +1,47 @@
+<font size="6" style="font-weight: bold;"> ⚠️ Notice: Limited Maintenance </font>
+
+This project is no longer actively maintained. While existing releases remain available, there are no planned updates, bug fixes, new features, or security patches. Users should be aware that vulnerabilities may not be addressed.
+
+# Rebellions Support
+
+RBLN (Rebellions) NPUs are fully compatible with TorchServe. Rebellions provides documentation and tutorials to help you easily get started using the RBLN NPU with TorchServe.
+
+- [Rebellions TorchServe supports document](https://docs.rbln.ai/software/model_serving/torchserve/torchserve.html)
+
+## Support Matrix
+For details on supported features and compatibility of the RBLN NPU, see the `Support Matrix` below:
+- [Support Matrix](https://docs.rbln.ai/supports/version_matrix.html)
+
+## Installation
+Please refer to the Installation Guide in the Rebellions documentation for instructions on installing the Driver and RBLN SDK.
+- [Installation Guide](https://docs.rbln.ai/getting_started/installation_guide.html)
+
+## TorchServe with RBLN NPUs
+
+To start properly, please refer to the Rebellions' TorchServe Tutorials.
+
+Tutorials are available for various models including `Image Classification (ResNet50)`, `Object Detection (YOLOv8)`, and `LLM (Llama3-8B)`.
+
+- [Tutorial - ResNet50](https://docs.rbln.ai/software/model_serving/torchserve/tutorial/resnet50.html)
+- [Tutorial - YOLOv8](https://docs.rbln.ai/software/model_serving/torchserve/tutorial/yolov8.html)
+- [Tutorial - Llama3-8B](https://docs.rbln.ai/software/model_serving/torchserve/tutorial/llama3-8B.html)
+
+## Docker
+
+Please refer to the `Docker Support` documentation.
+
+- [Docker Support](https://docs.rbln.ai/software/system_management/docker.html)
+
+## Multi Devices
+
+For monitoring NPU statistics and utilizing multiple RBLN NPUs, please refer to the `Device Management` documentation.
+
+- [Device Management](https://docs.rbln.ai/software/system_management/device_management.html)
+
+## Contact
+
+We are always interested in improving the utilization of the RBLN NPU and providing technical support.
+
+Please contact us through the following page:
+
+- [Contact Us](https://docs.rbln.ai/supports/contact_us.html)

--- a/frontend/server/src/main/java/org/pytorch/serve/device/AcceleratorVendor.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/device/AcceleratorVendor.java
@@ -5,5 +5,6 @@ public enum AcceleratorVendor {
     NVIDIA,
     INTEL,
     APPLE,
+    RBLN,
     UNKNOWN
 }

--- a/frontend/server/src/main/java/org/pytorch/serve/device/SystemInfo.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/device/SystemInfo.java
@@ -63,6 +63,8 @@ public class SystemInfo {
                 return new XpuUtil();
             case APPLE:
                 return new AppleUtil();
+            case RBLN:
+                return new RblnUtil();
             default:
                 return null;
         }
@@ -107,7 +109,9 @@ public class SystemInfo {
             return AcceleratorVendor.INTEL;
         } else if (isCommandAvailable("system_profiler")) {
             return AcceleratorVendor.APPLE;
-        } else {
+        } else if (isCommandAvailable("rbln-stat")) {
+            return AcceleratorVendor.RBLN;
+        }else {
             return AcceleratorVendor.UNKNOWN;
         }
     }

--- a/frontend/server/src/main/java/org/pytorch/serve/device/utils/RblnUtil.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/device/utils/RblnUtil.java
@@ -1,0 +1,108 @@
+package org.pytorch.serve.device.utils;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import org.pytorch.serve.device.Accelerator;
+import org.pytorch.serve.device.AcceleratorVendor;
+import org.pytorch.serve.device.interfaces.IAcceleratorUtility;
+import org.pytorch.serve.device.interfaces.IJsonSmiParser;
+
+public class RblnUtil implements IAcceleratorUtility, IJsonSmiParser {
+
+    @Override
+    public String getGpuEnvVariableName() {
+        return "RBLN_DEVICES";
+    }
+
+    @Override
+    public String[] getUtilizationSmiCommand() {
+        return new String[] {
+            "rbln-stat", "-j"
+        };
+    }
+
+    @Override
+    public ArrayList<Accelerator> getAvailableAccelerators(
+            LinkedHashSet<Integer> availableAcceleratorIds) {
+        String jsonOutput = IAcceleratorUtility.callSMI(getUtilizationSmiCommand());
+        JsonObject rootObject = JsonParser.parseString(jsonOutput).getAsJsonObject();
+        return jsonOutputToAccelerators(rootObject, availableAcceleratorIds);
+            }
+
+    @Override
+    public ArrayList<Accelerator> smiOutputToUpdatedAccelerators(
+            String smiOutput, LinkedHashSet<Integer> parsedGpuIds) {
+        JsonObject rootObject = JsonParser.parseString(smiOutput).getAsJsonObject();
+        return jsonOutputToAccelerators(rootObject, parsedGpuIds);
+            }
+
+    @Override
+    public Accelerator jsonObjectToAccelerator(JsonObject gpuObject) {
+        String model = gpuObject.get("name").getAsString();
+        if (!model.startsWith("RBLN")) {
+            return null;
+        }
+        int npuId = gpuObject.get("npu").getAsInt();
+        float npuUtil = gpuObject.get("util").getAsFloat();
+        long memoryTotal = gpuObject.getAsJsonObject("memory").get("total").getAsLong();
+        long memoryUsed = gpuObject.getAsJsonObject("memory").get("used").getAsLong();
+
+        Accelerator accelerator = new Accelerator(model, AcceleratorVendor.RBLN, npuId);
+
+        // Set additional information
+        accelerator.setUsagePercentage(npuUtil);
+        accelerator.setMemoryUtilizationPercentage((memoryUsed==0)?0f:(memoryUsed/(float)memoryTotal));
+        accelerator.setMemoryUtilizationMegabytes((int)(memoryUsed/1024/1024));
+
+        return accelerator;
+    }
+
+    @Override
+    public Integer extractAcceleratorId(JsonObject cardObject) {
+        Integer npuId = cardObject.get("npu").getAsInt();
+        return npuId;
+    }
+
+    @Override
+    public List<JsonObject> extractAccelerators(JsonElement rootObject) {
+        List<JsonObject> accelerators = new ArrayList<>();
+        JsonArray devicesArray =
+            rootObject
+            .getAsJsonObject()
+            .get("devices")
+            .getAsJsonArray();
+
+        for (JsonElement elem : devicesArray){
+            accelerators.add(elem.getAsJsonObject());
+        }
+
+        return accelerators;
+    }
+
+    public ArrayList<Accelerator> jsonOutputToAccelerators(
+            JsonObject rootObject, LinkedHashSet<Integer> parsedAcceleratorIds) {
+
+        ArrayList<Accelerator> accelerators = new ArrayList<>();
+        List<JsonObject> acceleratorObjects = extractAccelerators(rootObject);
+
+        int i=0;
+        for (JsonObject acceleratorObject : acceleratorObjects) {
+            Integer acceleratorId = extractAcceleratorId(acceleratorObject);
+            if (acceleratorId != null
+                    && (parsedAcceleratorIds.isEmpty()
+                        || parsedAcceleratorIds.contains(acceleratorId))) {
+                Accelerator accelerator = jsonObjectToAccelerator(acceleratorObject);
+                accelerators.add(accelerator);
+            }
+            i++;
+        }
+
+        return accelerators;
+    }
+}

--- a/test/pytest/test_data/rbln_compile/compile.py
+++ b/test/pytest/test_data/rbln_compile/compile.py
@@ -1,0 +1,13 @@
+import rebel
+import torch
+from torchvision.models import ResNet50_Weights, resnet50
+
+weights = ResNet50_Weights.DEFAULT
+model = resnet50(weights=weights)
+model.eval()
+
+compiled_model = rebel.compile_from_torch(
+    model,
+    [("input", [1, 3, 224, 224], torch.float32)],
+)
+compiled_model.save("resnet50.rbln")

--- a/test/pytest/test_data/rbln_compile/config.properties
+++ b/test/pytest/test_data/rbln_compile/config.properties
@@ -1,0 +1,10 @@
+default_workers_per_model:1
+
+models={\
+    "resnet50":{\
+        "1.0":{\
+            "marName": "resnet50.mar",\
+            "responseTimeout": 120\
+        }\
+    }\
+}

--- a/test/pytest/test_data/rbln_compile/rbln_handler.py
+++ b/test/pytest/test_data/rbln_compile/rbln_handler.py
@@ -1,0 +1,102 @@
+# resnet50_handler.py
+#
+
+import io
+import os
+
+import PIL.Image as Image
+import rebel  # RBLN Runtime
+import torch
+from torchvision.models import ResNet50_Weights
+
+from ts.torch_handler.base_handler import BaseHandler
+
+
+class Resnet50Handler(BaseHandler):
+    def __init__(self):
+        self._context = None
+        self.initialized = False
+        self.model = None
+        self.weights = None
+
+    def initialize(self, context):
+        """
+        Initialize model. This will be called during model loading time
+        :param context: Initial context contains model server system properties.
+        :return:
+        """
+        self._context = context
+        #  load the model, refer 'custom handler class' above for details
+        model_dir = context.system_properties.get("model_dir")
+        serialized_file = context.manifest["model"].get("serializedFile")
+        model_path = os.path.join(model_dir, serialized_file)
+        if not os.path.isfile(model_path):
+            raise RuntimeError(
+                f"[RBLN ERROR] File not found at the specified model_path({model_path})."
+            )
+
+        self.module = rebel.Runtime(model_path, tensor_type="pt")
+        self.weights = ResNet50_Weights.DEFAULT
+        self.initialized = True
+
+    def preprocess(self, data):
+        """
+        Transform raw input into model input data.
+        :param batch: list of raw requests, should match batch size
+        :return: list of preprocessed model input data
+        """
+        input_data = data[0].get("data")
+        if input_data is None:
+            input_data = data[0].get("body")
+        assert input_data is not None, print(
+            "[RBLN][ERROR] Data not found with client request."
+        )
+        if not isinstance(input_data, (bytes, bytearray)):
+            raise ValueError("[RBLN][ERROR] Preprocessed data is not binary data.")
+
+        try:
+            image = Image.open(io.BytesIO(input_data))
+        except Exception as e:
+            raise ValueError(f"[RBLN][ERROR]Invalid image data: {e}")
+        prep = self.weights.transforms()
+        batch = prep(image).unsqueeze(0)
+        preprocessed_data = batch.numpy()
+
+        return torch.from_numpy(preprocessed_data)
+
+    def inference(self, model_input):
+        """
+        Internal inference methods
+        :param model_input: transformed model input data
+        :return: list of inference output in NDArray
+        """
+
+        model_output = self.module.run(model_input)
+
+        return model_output
+
+    def postprocess(self, inference_output):
+        """
+        Return inference result.
+        :param inference_output: list of inference output
+        :return: list of predict results
+        """
+        score, class_id = torch.topk(inference_output, 1, dim=1)
+        category_name = self.weights.meta["categories"][class_id]
+        return category_name
+
+    def handle(self, data, context):
+        """
+        Invoke by TorchServe for prediction request.
+        Do pre-processing of data, prediction using model and postprocessing of prediciton output
+        :param data: Input data for prediction
+        :param context: Initial context contains model server system properties.
+        :return: prediction output
+        """
+        model_input = self.preprocess(data)
+        model_output = self.inference(model_input)
+        category_name = self.postprocess(model_output)
+
+        print("[RBLN][INFO] Top1 category: ", category_name)
+
+        return [{"result": category_name}]

--- a/test/pytest/test_rbln_serving.py
+++ b/test/pytest/test_rbln_serving.py
@@ -1,0 +1,129 @@
+import glob
+import importlib.util
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+try:
+    import rebel  # nopycln: import
+
+    RBLN_AVAILABLE = True
+except ImportError:
+    RBLN_AVAILABLE = False
+
+REQUIRED_PKG = ["torchvision", "torch"]
+
+CURR_FILE_PATH = Path(__file__).parent
+RBLN_TEST_DATA_DIR = os.path.join(CURR_FILE_PATH, "test_data", "rbln_compile")
+
+COMPILE_FILE = os.path.join(RBLN_TEST_DATA_DIR, "compile.py")
+HANDLER_FILE = os.path.join(RBLN_TEST_DATA_DIR, "rbln_handler.py")
+CONFIG_PROPERTIES = os.path.join(RBLN_TEST_DATA_DIR, "config.properties")
+SERIALIZED_FILE = os.path.join(RBLN_TEST_DATA_DIR, "resnet50.rbln")
+MODEL_STORE_DIR = os.path.join(RBLN_TEST_DATA_DIR, "model_store")
+MODEL_NAME = "resnet50"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def install_pkgs():
+    for package_name in REQUIRED_PKG:
+        if importlib.util.find_spec(package_name) is None:
+            print(f"Installing missing package: {package_name}")
+            try:
+                subprocess.check_call(
+                    [sys.executable, "-m", "pip", "install", package_name]
+                )
+            except subprocess.CalledProcessError as e:
+                pytest.fail(f"Fail to install package {package_name}")
+            print(f"Installing missing package: {package_name} - Installed.")
+
+
+def ensure_package(import_name, package_name):
+    if importlib.util.find_spec(import_name) is None:
+        print(f"Fail to find RBLN package : {package_name}")
+        return False
+    return True
+
+
+@pytest.mark.skipif(RBLN_AVAILABLE == False, reason='"rebel-compiler" is not installed')
+class TestTorchRbln:
+    def teardown_class(self):
+        subprocess.run("torchserve --stop", shell=True, check=True)
+        time.sleep(10)
+
+    def test_rbln_sdk_packages(self):
+        assert ensure_package("rebel", "rebel-compiler") == True
+
+    def test_archive_model_artifact(self):
+        assert len(glob.glob(COMPILE_FILE)) == 1
+        assert len(glob.glob(HANDLER_FILE)) == 1
+        assert len(glob.glob(CONFIG_PROPERTIES)) == 1
+
+        subprocess.run(
+            f"cd {RBLN_TEST_DATA_DIR} && python3 {COMPILE_FILE}", shell=True, check=True
+        )
+        subprocess.run(f"mkdir -p {MODEL_STORE_DIR}", shell=True, check=True)
+
+        assert len(glob.glob(SERIALIZED_FILE)) == 1
+
+        subprocess.run(
+            f"torch-model-archiver --model-name {MODEL_NAME} --version 1.0 --handler {HANDLER_FILE} --serialized-file {SERIALIZED_FILE} --export-path {MODEL_STORE_DIR} -f",
+            shell=True,
+            check=True,
+        )
+        assert len(glob.glob(os.path.join(MODEL_STORE_DIR, f"{MODEL_NAME}.mar"))) == 1
+
+    def test_start_torchserve(self):
+        subprocess.run(
+            f"torchserve --start --ncs --models {MODEL_NAME}.mar --model-store {MODEL_STORE_DIR} --ts-config {CONFIG_PROPERTIES} --disable-token-auth",
+            shell=True,
+            check=True,
+        )
+        time.sleep(10)
+        assert len(glob.glob("logs/access_log.log")) == 1
+        assert len(glob.glob("logs/model_log.log")) == 1
+        assert len(glob.glob("logs/ts_log.log")) == 1
+
+    def test_server_status(self):
+        result = subprocess.run(
+            "curl http://localhost:8080/ping",
+            shell=True,
+            capture_output=True,
+            check=True,
+        )
+        expected_server_status_str = '{"status": "Healthy"}'
+        expected_server_status = json.loads(expected_server_status_str)
+        assert json.loads(result.stdout) == expected_server_status
+
+    def test_registered_model(self):
+        result = subprocess.run(
+            "curl http://localhost:8081/models",
+            shell=True,
+            capture_output=True,
+            check=True,
+        )
+        expected_registered_model_str = (
+            '{"models": [{"modelName": "resnet50", "modelUrl": "resnet50.mar"}]}'
+        )
+        expected_registered_model = json.loads(expected_registered_model_str)
+        assert json.loads(result.stdout) == expected_registered_model
+
+    def test_serve_inference(self):
+        if not Path(f"{RBLN_TEST_DATA_DIR}/tabby.jpg").exists():
+            subprocess.run(
+                f"cd {RBLN_TEST_DATA_DIR} && wget https://rbln-public.s3.ap-northeast-2.amazonaws.com/images/tabby.jpg",
+                shell=True,
+            )
+        result = subprocess.run(
+            f'cd {RBLN_TEST_DATA_DIR} && curl -X POST "http://127.0.0.1:8080/predictions/resnet50" -H "Content-Type: application/octet-stream" --data-binary @./tabby.jpg',
+            shell=True,
+            capture_output=True,
+            check=True,
+        )
+        expected_result_str = '{"result":"tabby"}'
+        expected_result = json.loads(expected_result_str)
+        assert json.loads(result.stdout) == expected_result


### PR DESCRIPTION
This PR relates to #3416 

## Description


Although Rebellions provides a guide on how to utilize TorchServe with the RBLN NPU through its official website(https://docs.rbln.ai/), the current implementation of TorchServe does not recognize the RBLN NPU as a valid accelerator vendor. As a result, even when gpu_id is configured in environments using the RBLN NPU, the specified device cannot be properly utilized.

We propose adding RBLN NPU as a recognized accelerator vendor in TorchServe, along with an official user guide. This addition will enable seamless integration and usage of TorchServe in environments equipped with Rebellions NPUs.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x]  This change requires a documentation update

## Documentation
Added the `Rebellions Support` page, which includes a description and examples of how to utilize the RBLN NPU with TorchServe.
<img width="981" alt="image" src="https://github.com/user-attachments/assets/f94fe153-8e02-4269-9715-24acd4d739df" />

## Feature/Issue validation/testing

Added a new vendor type for `RBLN`, the NPU manufacturer Rebellions.
Documentation and PyTest for new added feature are added.

- [x] Backend Test with RBLN NPU
```bash
$ python3 -m pytest ts/tests/unit_tests ts/torch_handler/unit_tests
============================================================= 113 passed, 30 warnings in 18.72s ==============================================================
$ cd workflow-archiver && python3 -m pytest workflow_archiver/tests/unit_tests workflow_archiver/tests/integ_tests
===================================================================== 20 passed in 0.34s =====================================================================
$ cd model-archiver && python3 -m pytest model_archiver/tests/unit_tests model_archiver/tests/integ_tests
===================================================================== 33 passed in 0.33s =====================================================================
```

- [x] PyTest for added feature
```
$ pytest ./test/pytest/test_rbln_serving.py
collected 6 items

test/pytest/test_rbln_serving.py ......                                                                                                                            [100%]

=========================================================================== 6 passed in 35.11s ===========================================================================
```


## Checklist:

- [x] Did you have fun?
- [x] Have you added tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?